### PR TITLE
fix(lint): clear repo lint blockers

### DIFF
--- a/notebooks/feat_01_ingest_validation.ipynb
+++ b/notebooks/feat_01_ingest_validation.ipynb
@@ -99,7 +99,7 @@
     "print(f\"Archive shape: {df_archive.shape}\")\n",
     "print(f\"Time range:    {df_archive.index.min()} to {df_archive.index.max()}\")\n",
     "print(f\"Null count:    {df_archive.isnull().sum().sum()}\")\n",
-    "print(f\"\\nDescriptive statistics:\")\n",
+    "print(\"\\nDescriptive statistics:\")\n",
     "df_archive.describe()"
    ]
   },

--- a/src/foehncast/feature_pipeline/engineer.py
+++ b/src/foehncast/feature_pipeline/engineer.py
@@ -39,9 +39,7 @@ def gust_factor(df: pd.DataFrame) -> pd.Series:
     )
 
 
-def shore_alignment(
-    df: pd.DataFrame, shore_orientation_deg: float
-) -> pd.Series:
+def shore_alignment(df: pd.DataFrame, shore_orientation_deg: float) -> pd.Series:
     """Cosine similarity of wind direction to ideal shore orientation.
 
     Cross-shore flow (perpendicular) scores highest (1.0).
@@ -58,9 +56,7 @@ def shore_alignment(
     return np.cos(angle_diff)
 
 
-def engineer_features(
-    df: pd.DataFrame, shore_orientation_deg: float
-) -> pd.DataFrame:
+def engineer_features(df: pd.DataFrame, shore_orientation_deg: float) -> pd.DataFrame:
     """Add all engineered features to a spot forecast DataFrame.
 
     Args:

--- a/tests/test_engineer.py
+++ b/tests/test_engineer.py
@@ -1,6 +1,5 @@
 """Tests for feature engineering functions."""
 
-import numpy as np
 import pandas as pd
 import pytest
 
@@ -48,9 +47,7 @@ class TestGustFactor:
         pd.testing.assert_series_equal(result, expected)
 
     def test_zero_wind_returns_nan(self):
-        df = pd.DataFrame(
-            {"wind_gusts_10m": [5.0], "wind_speed_10m": [0.0]}
-        )
+        df = pd.DataFrame({"wind_gusts_10m": [5.0], "wind_speed_10m": [0.0]})
         result = gust_factor(df)
         assert result.isna().all()
 


### PR DESCRIPTION
What changed:
- remove the redundant f-string prefix in the ingest validation notebook
- remove the unused numpy import from the engineer tests

Why:
- clear the current Ruff failures that block pull-request CI on merge refs

Verification:
- uv run ruff check notebooks/feat_01_ingest_validation.ipynb tests/test_engineer.py
- uv run pytest tests/test_engineer.py -q

Closes:
- #40