### PR TITLE
feat(compose): scaffold modular local stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,6 +4,11 @@ GCP_LOCATION=europe-west1
 GCP_BUCKET_NAME=foehncast-data
 GOOGLE_APPLICATION_CREDENTIALS=keys/service-account.json
 
+# Local object storage
+MINIO_ADMIN=minioadmin
+MINIO_SECRET=minioadmin123
+MINIO_ENDPOINT=http://objectstore:9000
+
 # MLflow
 MLFLOW_TRACKING_URI=http://localhost:5000
 

--- a/containers/development_env/Dockerfile
+++ b/containers/development_env/Dockerfile
@@ -1,0 +1,20 @@
+FROM python:3.12-slim
+
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1 \
+    UV_LINK_MODE=copy \
+    UV_PROJECT_ENVIRONMENT=/workspace/.venv
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git tini \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /uvx /usr/local/bin/
+
+RUN useradd --create-home --shell /bin/bash appuser
+
+WORKDIR /workspace
+USER appuser
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["bash", "-lc", "uv sync && tail -f /dev/null"]

--- a/containers/development_env/docker-compose.yml
+++ b/containers/development_env/docker-compose.yml
@@ -1,0 +1,15 @@
+services:
+  development_env:
+    container_name: development_env
+    build: .
+    working_dir: /workspace
+    environment:
+      - FSSPEC_S3_KEY=${MINIO_ADMIN}
+      - FSSPEC_S3_SECRET=${MINIO_SECRET}
+      - FSSPEC_S3_ENDPOINT_URL=${MINIO_ENDPOINT}
+      - GIT_PYTHON_REFRESH=quiet
+    volumes:
+      - ../../:/workspace
+    networks:
+      - development
+      - production

--- a/containers/objectstore/docker-compose.yml
+++ b/containers/objectstore/docker-compose.yml
@@ -1,0 +1,20 @@
+services:
+  objectstore:
+    container_name: objectstore
+    image: minio/minio
+    command: server --address "0.0.0.0:9000" --console-address "0.0.0.0:9001" /data
+    hostname: objectstore
+    ports:
+      - 127.0.0.1:9000:9000
+      - 127.0.0.1:9001:9001
+    environment:
+      - MINIO_ROOT_USER=${MINIO_ADMIN}
+      - MINIO_ROOT_PASSWORD=${MINIO_SECRET}
+    volumes:
+      - objectstore_data:/data
+    networks:
+      - development
+      - production
+
+volumes:
+  objectstore_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,7 @@
+include:
+  - docker_includes/networks.yml
+  - containers/development_env/docker-compose.yml
+  - containers/objectstore/docker-compose.yml
+#  - containers/mlflow/docker-compose.yml
+#  - containers/app/docker-compose.yml
+#  - containers/monitoring/docker-compose.yml

--- a/docker_includes/networks.yml
+++ b/docker_includes/networks.yml
@@ -1,0 +1,5 @@
+networks:
+  development:
+    name: development
+  production:
+    name: production


### PR DESCRIPTION
What changed:
- add a root docker-compose.yml include entrypoint for FoehnCast
- add shared development and production networks
- add a reusable development container based on Python 3.12 and uv
- add a MinIO object storage service and extend the environment template with local object-store settings

Why:
- establish the first local-first container slice so services and pipelines can be validated locally before adding more infrastructure

Verification:
- docker compose --env-file .env.example -f docker-compose.yml config

Closes:
- #42