### PR TITLE
feat(compose): add MLflow service and GCP auth helper

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,16 +1,18 @@
 # GCP
+# Use gcloud ADC locally and GitHub OIDC in CI/CD. Do not commit service account keys.
 GCP_PROJECT_ID=your-gcp-project
-GCP_LOCATION=europe-west1
+GCP_LOCATION=europe-west6
 GCP_BUCKET_NAME=foehncast-data
-GOOGLE_APPLICATION_CREDENTIALS=keys/service-account.json
 
-# Local object storage
-MINIO_ADMIN=minioadmin
-MINIO_SECRET=minioadmin123
-MINIO_ENDPOINT=http://objectstore:9000
+# Local object storage (MinIO, S3-compatible)
+OBJECTSTORE_ACCESS_KEY=minioadmin
+OBJECTSTORE_SECRET_KEY=minioadmin123
+OBJECTSTORE_ENDPOINT=http://objectstore:9000
+OBJECTSTORE_BUCKET=artifacts
 
 # MLflow
-MLFLOW_TRACKING_URI=http://localhost:5000
+# Host tools use localhost; the development container uses http://model-registry:5001.
+MLFLOW_TRACKING_URI=http://localhost:5001
 
 # Airflow
 AIRFLOW_HOME=./airflow

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,13 @@ on:
     branches: [ main ]
 
 jobs:
+  compose:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: docker compose --env-file .env.example -f docker-compose.yml config
+      - run: docker compose --env-file .env.example -f docker-compose.yml build model-registry
+
   lint:
     runs-on: ubuntu-latest
     steps:

--- a/containers/development_env/docker-compose.yml
+++ b/containers/development_env/docker-compose.yml
@@ -3,10 +3,15 @@ services:
     container_name: development_env
     build: .
     working_dir: /workspace
+    depends_on:
+      - objectstore
+      - model-registry
     environment:
-      - FSSPEC_S3_KEY=${MINIO_ADMIN}
-      - FSSPEC_S3_SECRET=${MINIO_SECRET}
-      - FSSPEC_S3_ENDPOINT_URL=${MINIO_ENDPOINT}
+      - FSSPEC_S3_KEY=${OBJECTSTORE_ACCESS_KEY}
+      - FSSPEC_S3_SECRET=${OBJECTSTORE_SECRET_KEY}
+      - FSSPEC_S3_ENDPOINT_URL=${OBJECTSTORE_ENDPOINT}
+      # Use the Compose service name inside the Docker network.
+      - MLFLOW_TRACKING_URI=http://model-registry:5001
       - GIT_PYTHON_REFRESH=quiet
     volumes:
       - ../../:/workspace

--- a/containers/mlflow/Dockerfile
+++ b/containers/mlflow/Dockerfile
@@ -1,0 +1,3 @@
+FROM ghcr.io/mlflow/mlflow:v3.7.0
+
+RUN pip install --no-cache-dir boto3

--- a/containers/mlflow/docker-compose.yml
+++ b/containers/mlflow/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  model-registry:
+    container_name: model-registry
+    build: .
+    image: foehncast-mlflow:local
+    command: mlflow server --host 0.0.0.0 --port 5001 --artifacts-destination s3://${OBJECTSTORE_BUCKET} --backend-store-uri sqlite:///metadata/metadata.sqlite --disable-security-middleware
+    hostname: model-registry
+    ports:
+      - 127.0.0.1:5001:5001
+    depends_on:
+      - objectstore
+    environment:
+      # MLflow uses boto3 for S3-compatible artifact stores, even when the repo targets GCP.
+      - AWS_ACCESS_KEY_ID=${OBJECTSTORE_ACCESS_KEY}
+      - AWS_SECRET_ACCESS_KEY=${OBJECTSTORE_SECRET_KEY}
+      - MLFLOW_S3_ENDPOINT_URL=${OBJECTSTORE_ENDPOINT}
+    volumes:
+      - mlflow_metadata:/metadata
+    networks:
+      - development
+      - production
+
+volumes:
+  mlflow_metadata:

--- a/containers/objectstore/docker-compose.yml
+++ b/containers/objectstore/docker-compose.yml
@@ -8,8 +8,8 @@ services:
       - 127.0.0.1:9000:9000
       - 127.0.0.1:9001:9001
     environment:
-      - MINIO_ROOT_USER=${MINIO_ADMIN}
-      - MINIO_ROOT_PASSWORD=${MINIO_SECRET}
+      - MINIO_ROOT_USER=${OBJECTSTORE_ACCESS_KEY}
+      - MINIO_ROOT_PASSWORD=${OBJECTSTORE_SECRET_KEY}
     volumes:
       - objectstore_data:/data
     networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,6 @@ include:
   - docker_includes/networks.yml
   - containers/development_env/docker-compose.yml
   - containers/objectstore/docker-compose.yml
-#  - containers/mlflow/docker-compose.yml
+  - containers/mlflow/docker-compose.yml
 #  - containers/app/docker-compose.yml
 #  - containers/monitoring/docker-compose.yml

--- a/scripts/gcp-auth.sh
+++ b/scripts/gcp-auth.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${1:-$ROOT_DIR/.env}"
+
+if ! command -v gcloud >/dev/null 2>&1; then
+  echo "gcloud is required but not installed." >&2
+  exit 1
+fi
+
+if [[ -f "$ENV_FILE" ]]; then
+  set -a
+  # shellcheck disable=SC1090
+  source "$ENV_FILE"
+  set +a
+fi
+
+: "${GCP_PROJECT_ID:?Set GCP_PROJECT_ID in .env or the environment.}"
+: "${GCP_LOCATION:?Set GCP_LOCATION in .env or the environment.}"
+
+gcloud config set project "$GCP_PROJECT_ID"
+
+if ! gcloud auth list --filter=status:ACTIVE --format='value(account)' | grep -q .; then
+  gcloud auth login
+fi
+
+if ! gcloud auth application-default print-access-token >/dev/null 2>&1; then
+  gcloud auth application-default login
+fi
+
+gcloud auth configure-docker "${GCP_LOCATION}-docker.pkg.dev"
+
+echo "Configured gcloud CLI, ADC, and Artifact Registry auth for ${GCP_PROJECT_ID} in ${GCP_LOCATION}."
+echo "Use GitHub OIDC for CI/CD and avoid storing service account keys in this repository."


### PR DESCRIPTION
## Summary
- add a dedicated MLflow service module under containers/mlflow
- switch repo-facing storage settings to neutral object storage names while keeping the boto3-specific variables internal to MLflow
- add a local gcloud auth helper that uses ADC and configures Artifact Registry without long-lived tokens
- validate Compose config and the MLflow image build in CI

Closes #44