### PR TITLE
feat(terraform): scaffold GCP baseline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,24 @@ on:
 jobs:
   compose:
     runs-on: ubuntu-latest
+    env:
+      OBJECTSTORE_ACCESS_KEY: minioadmin
+      OBJECTSTORE_SECRET_KEY: minioadmin123
+      OBJECTSTORE_ENDPOINT: http://objectstore:9000
+      OBJECTSTORE_BUCKET: artifacts
     steps:
       - uses: actions/checkout@v4
-      - run: docker compose --env-file .env.example -f docker-compose.yml config
-      - run: docker compose --env-file .env.example -f docker-compose.yml build model-registry
+      - run: docker compose -f docker-compose.yml config
+      - run: docker compose -f docker-compose.yml build model-registry
+
+  terraform:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: hashicorp/setup-terraform@v3
+      - run: terraform -chdir=terraform init -backend=false
+      - run: terraform -chdir=terraform fmt -check
+      - run: terraform -chdir=terraform validate
 
   lint:
     runs-on: ubuntu-latest

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ keys/
 # Terraform
 terraform/.terraform/
 terraform/*.tfstate*
-terraform/.terraform.lock.hcl
+terraform/terraform.tfvars
 
 # MLflow
 mlruns/

--- a/config.yaml
+++ b/config.yaml
@@ -110,6 +110,8 @@ gcp:
   artifact_registry: "foehncast-docker"
   cloud_run_service: "foehncast-serve"
   cloud_run_region: "europe-west6"
+  github_oidc_pool: "github-actions"
+  github_oidc_provider: "github-oidc"
 
 # Model training settings
 model:

--- a/terraform/.terraform.lock.hcl
+++ b/terraform/.terraform.lock.hcl
@@ -1,0 +1,22 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "6.50.0"
+  constraints = "~> 6.32"
+  hashes = [
+    "h1:79CwMTsp3Ud1nOl5hFS5mxQHyT0fGVye7pqpU0PPlHI=",
+    "zh:1f3513fcfcbf7ca53d667a168c5067a4dd91a4d4cccd19743e248ff31065503c",
+    "zh:3da7db8fc2c51a77dd958ea8baaa05c29cd7f829bd8941c26e2ea9cb3aadc1e5",
+    "zh:3e09ac3f6ca8111cbb659d38c251771829f4347ab159a12db195e211c76068bb",
+    "zh:7bb9e41c568df15ccf1a8946037355eefb4dfb4e35e3b190808bb7c4abae547d",
+    "zh:81e5d78bdec7778e6d67b5c3544777505db40a826b6eb5abe9b86d4ba396866b",
+    "zh:8d309d020fb321525883f5c4ea864df3d5942b6087f6656d6d8b3a1377f340fc",
+    "zh:93e112559655ab95a523193158f4a4ac0f2bfed7eeaa712010b85ebb551d5071",
+    "zh:d3efe589ffd625b300cef5917c4629513f77e3a7b111c9df65075f76a46a63c7",
+    "zh:d4a4d672bbef756a870d8f32b35925f8ce2ef4f6bbd5b71a3cb764f1b6c85421",
+    "zh:e13a86bca299ba8a118e80d5f84fbdd708fe600ecdceea1a13d4919c068379fe",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fec30c095647b583a246c39d557704947195a1b7d41f81e369ba377d997faef6",
+  ]
+}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,0 +1,31 @@
+# Terraform Baseline
+
+This directory manages the first GCP infrastructure baseline for FoehnCast:
+
+- required Google APIs
+- Artifact Registry for container images
+- a GCS bucket for artifacts
+- a GitHub Actions deployer service account
+- a Cloud Run runtime service account
+- GitHub OIDC trust via Workload Identity Federation
+
+## Local Use
+
+1. Bootstrap your local GCP session:
+   `./scripts/gcp-auth.sh`
+2. Copy `terraform/terraform.tfvars.example` to `terraform/terraform.tfvars`.
+3. Fill in the project-specific values.
+4. Run:
+   `cd terraform && terraform init && terraform fmt -check && terraform validate`
+
+## Bootstrap Notes
+
+- Terraform manages project services after authentication, but the project still needs a usable GCP project and billing enabled.
+- Commit `terraform/.terraform.lock.hcl` so provider resolution stays reproducible across local runs and CI.
+
+## CI/CD Guidance
+
+- Prefer GitHub OIDC with `google-github-actions/auth`.
+- Do not store service account keys in repository secrets.
+- Restrict the OIDC provider to this repository and the `main` branch.
+- Grant the deployer service account only the roles needed for build and deploy.

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,132 @@
+locals {
+  github_repository_path = "${var.github_owner}/${var.github_repository}"
+
+  required_services = toset([
+    "artifactregistry.googleapis.com",
+    "iam.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "run.googleapis.com",
+    "sts.googleapis.com",
+  ])
+}
+
+resource "google_project_service" "required" {
+  for_each = local.required_services
+
+  project = var.project_id
+  service = each.value
+
+  disable_on_destroy = false
+}
+
+resource "google_artifact_registry_repository" "containers" {
+  provider = google
+
+  location      = var.region
+  repository_id = var.artifact_registry_repository_id
+  description   = "Docker images for the FoehnCast services"
+  format        = "DOCKER"
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_storage_bucket" "artifacts" {
+  name                        = var.artifact_bucket_name
+  location                    = var.region
+  uniform_bucket_level_access = true
+  force_destroy               = false
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    condition {
+      age = 30
+    }
+
+    action {
+      type = "Delete"
+    }
+  }
+}
+
+resource "google_service_account" "github_deployer" {
+  account_id   = "github-actions-deployer"
+  display_name = "GitHub Actions deployer"
+}
+
+resource "google_service_account" "cloud_run_runtime" {
+  account_id   = "foehncast-cloud-run"
+  display_name = "FoehnCast Cloud Run runtime"
+}
+
+resource "google_project_iam_member" "github_artifact_registry_writer" {
+  project = var.project_id
+  role    = "roles/artifactregistry.writer"
+  member  = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
+resource "google_project_iam_member" "github_cloud_run_admin" {
+  project = var.project_id
+  role    = "roles/run.admin"
+  member  = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
+resource "google_project_iam_member" "github_service_account_user" {
+  project = var.project_id
+  role    = "roles/iam.serviceAccountUser"
+  member  = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
+resource "google_storage_bucket_iam_member" "github_bucket_admin" {
+  bucket = google_storage_bucket.artifacts.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "cloud_run_reader" {
+  location   = google_artifact_registry_repository.containers.location
+  repository = google_artifact_registry_repository.containers.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
+}
+
+resource "google_storage_bucket_iam_member" "cloud_run_bucket_reader" {
+  bucket = google_storage_bucket.artifacts.name
+  role   = "roles/storage.objectViewer"
+  member = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
+}
+
+resource "google_iam_workload_identity_pool" "github" {
+  workload_identity_pool_id = var.github_oidc_pool_id
+  display_name              = "GitHub Actions"
+  description               = "OIDC trust for GitHub Actions deployments"
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_iam_workload_identity_pool_provider" "github" {
+  workload_identity_pool_id          = google_iam_workload_identity_pool.github.workload_identity_pool_id
+  workload_identity_pool_provider_id = var.github_oidc_provider_id
+  display_name                       = "GitHub OIDC"
+
+  attribute_mapping = {
+    "google.subject"       = "assertion.sub"
+    "attribute.actor"      = "assertion.actor"
+    "attribute.repository" = "assertion.repository"
+    "attribute.ref"        = "assertion.ref"
+  }
+
+  attribute_condition = "assertion.repository == '${local.github_repository_path}' && assertion.ref == 'refs/heads/main'"
+
+  oidc {
+    issuer_uri = "https://token.actions.githubusercontent.com"
+  }
+}
+
+resource "google_service_account_iam_member" "github_workload_identity_user" {
+  service_account_id = google_service_account.github_deployer.name
+  role               = "roles/iam.workloadIdentityUser"
+  member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.github.name}/attribute.repository/${local.github_repository_path}"
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,24 @@
+output "artifact_registry_repository" {
+  description = "Artifact Registry repository path for container images."
+  value       = google_artifact_registry_repository.containers.id
+}
+
+output "artifact_bucket_name" {
+  description = "GCS bucket managed by Terraform for artifacts."
+  value       = google_storage_bucket.artifacts.name
+}
+
+output "github_deployer_service_account" {
+  description = "Service account used by GitHub Actions via Workload Identity Federation."
+  value       = google_service_account.github_deployer.email
+}
+
+output "github_workload_identity_provider" {
+  description = "Full provider name for GitHub OIDC authentication."
+  value       = google_iam_workload_identity_pool_provider.github.name
+}
+
+output "cloud_run_runtime_service_account" {
+  description = "Service account intended for Cloud Run runtime execution."
+  value       = google_service_account.cloud_run_runtime.email
+}

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,0 +1,15 @@
+terraform {
+  required_version = ">= 1.8.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 6.32"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.region
+}

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -1,0 +1,8 @@
+project_id                     = "your-gcp-project"
+region                         = "europe-west6"
+artifact_registry_repository_id = "foehncast-docker"
+artifact_bucket_name           = "foehncast-artifacts-your-gcp-project"
+github_owner                   = "javihslu"
+github_repository              = "foehncast"
+github_oidc_pool_id            = "github-actions"
+github_oidc_provider_id        = "github-oidc"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,45 @@
+variable "project_id" {
+  description = "GCP project ID for FoehnCast resources."
+  type        = string
+}
+
+variable "region" {
+  description = "Primary GCP region for deployed resources."
+  type        = string
+  default     = "europe-west6"
+}
+
+variable "artifact_registry_repository_id" {
+  description = "Artifact Registry repository name for container images."
+  type        = string
+  default     = "foehncast-docker"
+}
+
+variable "artifact_bucket_name" {
+  description = "GCS bucket for artifacts and Terraform-managed storage assets."
+  type        = string
+}
+
+variable "github_owner" {
+  description = "GitHub organization or user that owns the repository."
+  type        = string
+  default     = "javihslu"
+}
+
+variable "github_repository" {
+  description = "GitHub repository name."
+  type        = string
+  default     = "foehncast"
+}
+
+variable "github_oidc_pool_id" {
+  description = "Workload Identity Pool ID used by GitHub Actions."
+  type        = string
+  default     = "github-actions"
+}
+
+variable "github_oidc_provider_id" {
+  description = "Workload Identity Provider ID used by GitHub Actions."
+  type        = string
+  default     = "github-oidc"
+}


### PR DESCRIPTION
## Summary
- add a Terraform baseline for GCP APIs, Artifact Registry, a storage bucket, service accounts, and GitHub OIDC trust
- add a local gcloud auth helper for ADC and Artifact Registry setup
- validate Terraform in CI and commit the provider lockfile for reproducibility

Closes #46