### PR TITLE
feat(validate): add data validation checks

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -117,6 +117,50 @@ gcp:
   github_oidc_pool: "github-actions"
   github_oidc_provider: "github-oidc"
 
+# Validation settings
+validation:
+  required_columns:
+    - wind_speed_10m
+    - wind_speed_80m
+    - wind_speed_120m
+    - wind_direction_10m
+    - wind_direction_80m
+    - wind_gusts_10m
+    - temperature_2m
+    - precipitation
+    - relative_humidity_2m
+    - cloud_cover
+    - pressure_msl
+    - cape
+    - lifted_index
+  completeness:
+    max_null_pct: 0.1
+  ranges:
+    wind_speed_10m:
+      min: 0
+      max: 80
+    wind_speed_80m:
+      min: 0
+      max: 80
+    wind_speed_120m:
+      min: 0
+      max: 80
+    wind_gusts_10m:
+      min: 0
+      max: 120
+    wind_direction_10m:
+      min: 0
+      max: 360
+    wind_direction_80m:
+      min: 0
+      max: 360
+    temperature_2m:
+      min: -40
+      max: 50
+    relative_humidity_2m:
+      min: 0
+      max: 100
+
 # Model training settings
 model:
   algorithm: "random_forest"

--- a/src/foehncast/config.py
+++ b/src/foehncast/config.py
@@ -52,6 +52,11 @@ def get_storage_config() -> dict[str, Any]:
     return load_config()["storage"]
 
 
+def get_validation_config() -> dict[str, Any]:
+    """Return the validation settings."""
+    return load_config()["validation"]
+
+
 def get_mlflow_config() -> dict[str, Any]:
     """Return the MLflow settings."""
     return load_config()["mlflow"]

--- a/src/foehncast/feature_pipeline/validate.py
+++ b/src/foehncast/feature_pipeline/validate.py
@@ -1,1 +1,104 @@
 """Data quality checks on ingested data."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pandas as pd
+
+from foehncast.config import get_validation_config
+
+
+@dataclass
+class ValidationResult:
+    """Structured validation outcome for one spot dataset."""
+
+    spot_id: str
+    schema_valid: bool
+    completeness_valid: bool
+    range_valid: bool
+    missing_columns: list[str]
+    null_fractions: dict[str, float]
+    range_violations: pd.DataFrame
+
+    @property
+    def is_valid(self) -> bool:
+        return self.schema_valid and self.completeness_valid and self.range_valid
+
+
+def _missing_columns(df: pd.DataFrame, expected_columns: list[str]) -> list[str]:
+    return [column for column in expected_columns if column not in df.columns]
+
+
+def _null_fractions(df: pd.DataFrame) -> dict[str, float]:
+    if df.empty:
+        return {column: 0.0 for column in df.columns}
+    return df.isna().mean().to_dict()
+
+
+def validate_schema(df: pd.DataFrame, expected_columns: list[str]) -> bool:
+    """Check that all expected columns are present."""
+    return not _missing_columns(df, expected_columns)
+
+
+def validate_ranges(
+    df: pd.DataFrame, range_config: dict[str, dict[str, float]]
+) -> pd.DataFrame:
+    """Return all values that fall outside the configured numeric bounds."""
+    violations: list[dict[str, Any]] = []
+
+    for column, bounds in range_config.items():
+        if column not in df.columns:
+            continue
+
+        series = df[column]
+        lower = bounds.get("min")
+        upper = bounds.get("max")
+        mask = pd.Series(False, index=series.index)
+
+        if lower is not None:
+            mask |= series < lower
+        if upper is not None:
+            mask |= series > upper
+
+        for index, value in series[mask].items():
+            violations.append(
+                {
+                    "column": column,
+                    "index": index,
+                    "value": value,
+                    "min": lower,
+                    "max": upper,
+                }
+            )
+
+    return pd.DataFrame(violations, columns=["column", "index", "value", "min", "max"])
+
+
+def validate_completeness(df: pd.DataFrame, max_null_pct: float = 0.1) -> bool:
+    """Check that no column exceeds the configured null threshold."""
+    return all(
+        null_fraction <= max_null_pct for null_fraction in _null_fractions(df).values()
+    )
+
+
+def run_validation(df: pd.DataFrame, spot_id: str) -> ValidationResult:
+    """Run schema, completeness, and range validation for one spot dataset."""
+    validation_config = get_validation_config()
+    expected_columns = validation_config["required_columns"]
+    missing_columns = _missing_columns(df, expected_columns)
+    null_fractions = _null_fractions(df)
+    range_violations = validate_ranges(df, validation_config["ranges"])
+
+    return ValidationResult(
+        spot_id=spot_id,
+        schema_valid=not missing_columns,
+        completeness_valid=validate_completeness(
+            df, validation_config["completeness"]["max_null_pct"]
+        ),
+        range_valid=range_violations.empty,
+        missing_columns=missing_columns,
+        null_fractions=null_fractions,
+        range_violations=range_violations,
+    )

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -1,0 +1,122 @@
+"""Tests for feature-pipeline data validation."""
+
+from __future__ import annotations
+
+import pandas as pd
+
+from foehncast.feature_pipeline.validate import (
+    ValidationResult,
+    run_validation,
+    validate_completeness,
+    validate_ranges,
+    validate_schema,
+)
+
+
+def _sample_raw_features() -> pd.DataFrame:
+    return pd.DataFrame(
+        {
+            "wind_speed_10m": [12.0, 18.0],
+            "wind_speed_80m": [15.0, 20.0],
+            "wind_speed_120m": [18.0, 22.0],
+            "wind_direction_10m": [220.0, 235.0],
+            "wind_direction_80m": [225.0, 240.0],
+            "wind_gusts_10m": [18.0, 24.0],
+            "temperature_2m": [12.0, 14.0],
+            "precipitation": [0.0, 0.2],
+            "relative_humidity_2m": [55.0, 60.0],
+            "cloud_cover": [25.0, 40.0],
+            "pressure_msl": [1013.0, 1012.0],
+            "cape": [50.0, 75.0],
+            "lifted_index": [-1.0, -2.0],
+        },
+        index=pd.Index(["row-1", "row-2"], name="time"),
+    )
+
+
+def test_validate_schema_returns_true_when_all_columns_are_present() -> None:
+    df = _sample_raw_features()
+
+    assert validate_schema(df, ["wind_speed_10m", "temperature_2m"])
+
+
+def test_validate_schema_returns_false_when_columns_are_missing() -> None:
+    df = _sample_raw_features().drop(columns=["temperature_2m"])
+
+    assert not validate_schema(df, ["wind_speed_10m", "temperature_2m"])
+
+
+def test_validate_ranges_returns_violation_rows() -> None:
+    df = _sample_raw_features()
+    df.loc["row-2", "wind_direction_10m"] = 400.0
+    df.loc["row-1", "temperature_2m"] = -45.0
+
+    violations = validate_ranges(
+        df,
+        {
+            "wind_direction_10m": {"min": 0, "max": 360},
+            "temperature_2m": {"min": -40, "max": 50},
+        },
+    )
+
+    assert list(violations["column"]) == ["wind_direction_10m", "temperature_2m"]
+    assert list(violations["index"]) == ["row-2", "row-1"]
+
+
+def test_validate_completeness_fails_when_column_exceeds_null_threshold() -> None:
+    df = _sample_raw_features()
+    df["temperature_2m"] = [None, 14.0]
+
+    assert not validate_completeness(df, max_null_pct=0.4)
+
+
+def test_run_validation_returns_valid_result_for_clean_dataset(monkeypatch) -> None:
+    df = _sample_raw_features()
+    monkeypatch.setattr(
+        "foehncast.feature_pipeline.validate.get_validation_config",
+        lambda: {
+            "required_columns": list(df.columns),
+            "completeness": {"max_null_pct": 0.1},
+            "ranges": {
+                "wind_speed_10m": {"min": 0, "max": 80},
+                "wind_gusts_10m": {"min": 0, "max": 120},
+                "wind_direction_10m": {"min": 0, "max": 360},
+                "temperature_2m": {"min": -40, "max": 50},
+                "relative_humidity_2m": {"min": 0, "max": 100},
+            },
+        },
+    )
+
+    result = run_validation(df, spot_id="silvaplana")
+
+    assert isinstance(result, ValidationResult)
+    assert result.spot_id == "silvaplana"
+    assert result.is_valid
+    assert result.range_violations.empty
+    assert result.missing_columns == []
+
+
+def test_run_validation_collects_missing_columns_and_range_violations(
+    monkeypatch,
+) -> None:
+    df = _sample_raw_features().drop(columns=["cloud_cover"])
+    df.loc["row-2", "relative_humidity_2m"] = 120.0
+    monkeypatch.setattr(
+        "foehncast.feature_pipeline.validate.get_validation_config",
+        lambda: {
+            "required_columns": [*list(_sample_raw_features().columns)],
+            "completeness": {"max_null_pct": 0.1},
+            "ranges": {
+                "relative_humidity_2m": {"min": 0, "max": 100},
+            },
+        },
+    )
+
+    result = run_validation(df, spot_id="urnersee")
+
+    assert not result.is_valid
+    assert not result.schema_valid
+    assert result.completeness_valid
+    assert not result.range_valid
+    assert result.missing_columns == ["cloud_cover"]
+    assert list(result.range_violations["column"]) == ["relative_humidity_2m"]


### PR DESCRIPTION
What changed:
- implement schema, completeness, and numeric range validation for the feature pipeline
- add a structured ValidationResult with missing columns, null fractions, and range violations
- add config-driven validation settings and focused tests for the validation module

Why:
- complete the validation step in the feature pipeline before training and serving layers build on it
- keep the validation rules explicit and reusable through central configuration

Verification:
- uv run ruff check src/foehncast/config.py src/foehncast/feature_pipeline/validate.py tests/test_validate.py
- uv run pytest tests/test_validate.py -q

Closes: #6