### PR TITLE
feat(evaluate): add model evaluation pipeline

### DIFF
--- a/src/foehncast/training_pipeline/evaluate.py
+++ b/src/foehncast/training_pipeline/evaluate.py
@@ -1,1 +1,91 @@
 """Model evaluation metrics and reporting."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import mlflow
+import pandas as pd
+from sklearn.metrics import mean_absolute_error, mean_squared_error, r2_score
+
+from foehncast.config import get_mlflow_config
+
+
+def _rounded_predictions(predictions: Any, target_true: pd.Series) -> pd.Series:
+    lower = int(target_true.min())
+    upper = int(target_true.max())
+    rounded = pd.Series(predictions, index=target_true.index).round().clip(lower, upper)
+    return rounded.astype(int)
+
+
+def _class_accuracy_metrics(
+    target_true: pd.Series, predictions: Any
+) -> dict[str, float]:
+    rounded_predictions = _rounded_predictions(predictions, target_true)
+    metrics = {
+        "overall_class_accuracy": float((rounded_predictions == target_true).mean())
+    }
+
+    for label in sorted(target_true.astype(int).unique()):
+        mask = target_true == label
+        metrics[f"class_accuracy_{label}"] = float(
+            (rounded_predictions[mask] == target_true[mask]).mean()
+        )
+
+    return metrics
+
+
+def evaluate_model(
+    model: Any, features_test: pd.DataFrame, target_test: pd.Series
+) -> dict[str, float]:
+    """Compute regression and class-bucket metrics for a trained model."""
+    predictions = model.predict(features_test)
+    metrics = {
+        "mae": float(mean_absolute_error(target_test, predictions)),
+        "rmse": float(mean_squared_error(target_test, predictions) ** 0.5),
+        "r2": float(r2_score(target_test, predictions)),
+    }
+    metrics.update(_class_accuracy_metrics(target_test, predictions))
+
+    active_run = getattr(mlflow, "active_run", lambda: None)()
+    if active_run is not None:
+        mlflow.log_metrics(metrics)
+
+    return metrics
+
+
+def generate_evaluation_report(metrics: dict[str, float], output_path: str) -> str:
+    """Write a markdown evaluation report and return its path."""
+    report_path = Path(output_path)
+    report_path.parent.mkdir(parents=True, exist_ok=True)
+
+    lines = ["# Evaluation Report", "", "| Metric | Value |", "| --- | ---: |"]
+    for name, value in metrics.items():
+        lines.append(f"| {name} | {value:.4f} |")
+    report_path.write_text("\n".join(lines) + "\n")
+
+    active_run = getattr(mlflow, "active_run", lambda: None)()
+    if active_run is not None:
+        mlflow.log_artifact(str(report_path), artifact_path="evaluation")
+
+    return str(report_path)
+
+
+def compare_models(run_ids: list[str]) -> pd.DataFrame:
+    """Compare MLflow runs by collecting their logged metrics into a dataframe."""
+    mlflow_config = get_mlflow_config()
+    mlflow.set_tracking_uri(mlflow_config["tracking_uri"])
+    client = mlflow.MlflowClient()
+    rows: list[dict[str, Any]] = []
+
+    for run_id in run_ids:
+        run = client.get_run(run_id)
+        row: dict[str, Any] = {
+            "run_id": run_id,
+            "algorithm": run.data.params.get("algorithm"),
+        }
+        row.update(run.data.metrics)
+        rows.append(row)
+
+    return pd.DataFrame(rows)

--- a/tests/test_evaluate.py
+++ b/tests/test_evaluate.py
@@ -1,0 +1,135 @@
+"""Tests for model evaluation helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+
+from foehncast.training_pipeline import evaluate
+
+
+class ConstantModel:
+    def __init__(self, predictions: list[float]) -> None:
+        self._predictions = predictions
+
+    def predict(self, features_test: pd.DataFrame) -> list[float]:
+        return self._predictions
+
+
+def test_evaluate_model_returns_regression_and_class_metrics() -> None:
+    features_test = pd.DataFrame({"wind_speed_10m": [10.0, 20.0, 30.0]})
+    target_test = pd.Series([1, 3, 4])
+    model = ConstantModel([1.2, 2.8, 3.6])
+
+    metrics = evaluate.evaluate_model(model, features_test, target_test)
+
+    assert set(metrics) >= {
+        "mae",
+        "rmse",
+        "r2",
+        "overall_class_accuracy",
+        "class_accuracy_1",
+        "class_accuracy_3",
+        "class_accuracy_4",
+    }
+    assert metrics["overall_class_accuracy"] == 1.0
+
+
+def test_evaluate_model_logs_metrics_when_mlflow_run_is_active(monkeypatch) -> None:
+    logged: dict[str, dict[str, float]] = {}
+
+    class FakeMlflow:
+        def active_run(self) -> object:
+            return object()
+
+        def log_metrics(self, metrics: dict[str, float]) -> None:
+            logged["metrics"] = metrics
+
+    monkeypatch.setattr(evaluate, "mlflow", FakeMlflow())
+
+    features_test = pd.DataFrame({"wind_speed_10m": [10.0, 20.0]})
+    target_test = pd.Series([1, 2])
+    model = ConstantModel([1.0, 2.0])
+
+    metrics = evaluate.evaluate_model(model, features_test, target_test)
+
+    assert logged["metrics"] == metrics
+
+
+def test_generate_evaluation_report_writes_markdown(tmp_path: Path) -> None:
+    metrics = {"mae": 0.5, "rmse": 0.75, "r2": 0.8}
+
+    report_path = evaluate.generate_evaluation_report(
+        metrics, str(tmp_path / "reports" / "evaluation.md")
+    )
+
+    content = Path(report_path).read_text()
+    assert "# Evaluation Report" in content
+    assert "| mae | 0.5000 |" in content
+    assert Path(report_path).exists()
+
+
+def test_generate_evaluation_report_logs_artifact_when_mlflow_run_is_active(
+    monkeypatch, tmp_path: Path
+) -> None:
+    logged: dict[str, tuple[str, str | None]] = {}
+
+    class FakeMlflow:
+        def active_run(self) -> object:
+            return object()
+
+        def log_artifact(self, path: str, artifact_path: str | None = None) -> None:
+            logged["artifact"] = (path, artifact_path)
+
+    monkeypatch.setattr(evaluate, "mlflow", FakeMlflow())
+
+    report_path = evaluate.generate_evaluation_report(
+        {"mae": 0.5}, str(tmp_path / "evaluation.md")
+    )
+
+    assert logged["artifact"] == (report_path, "evaluation")
+
+
+def test_compare_models_returns_metrics_dataframe(monkeypatch) -> None:
+    run_lookup = {
+        "run-1": SimpleNamespace(
+            data=SimpleNamespace(
+                params={"algorithm": "random_forest"},
+                metrics={"mae": 0.4, "rmse": 0.6, "r2": 0.8},
+            )
+        ),
+        "run-2": SimpleNamespace(
+            data=SimpleNamespace(
+                params={"algorithm": "gradient_boosting"},
+                metrics={"mae": 0.5, "rmse": 0.7, "r2": 0.7},
+            )
+        ),
+    }
+    logged: dict[str, str] = {}
+
+    class FakeClient:
+        def get_run(self, run_id: str):
+            return run_lookup[run_id]
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
+
+    monkeypatch.setattr(evaluate, "mlflow", FakeMlflow())
+    monkeypatch.setattr(
+        evaluate,
+        "get_mlflow_config",
+        lambda: {"tracking_uri": "http://localhost:5001"},
+    )
+
+    result = evaluate.compare_models(["run-1", "run-2"])
+
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert list(result["run_id"]) == ["run-1", "run-2"]
+    assert list(result["algorithm"]) == ["random_forest", "gradient_boosting"]
+    assert list(result["mae"]) == [0.4, 0.5]


### PR DESCRIPTION
What changed:
- implement evaluation metrics for trained models, including MAE, RMSE, R2, and class-bucket accuracy
- add markdown report generation and MLflow artifact logging for evaluation outputs
- add MLflow run comparison support and focused tests for evaluation helpers

Why:
- complete the model-evaluation slice that follows training in the backend chain
- make evaluation results explicit and ready for MLflow-backed review workflows

Verification:
- uv run ruff check src/foehncast/training_pipeline/evaluate.py tests/test_evaluate.py
- uv run pytest tests/test_evaluate.py -q

Closes: #10