### PR TITLE
feat(register): add MLflow model registry helpers

### DIFF
--- a/src/foehncast/training_pipeline/register.py
+++ b/src/foehncast/training_pipeline/register.py
@@ -1,1 +1,62 @@
-"""Register model in MLflow registry."""
+"""Register and load models from the MLflow registry."""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, Any
+
+import mlflow
+
+from foehncast.config import get_mlflow_config
+
+if TYPE_CHECKING:
+    from mlflow.entities.model_registry import ModelVersion
+
+
+def _tracking_uri(mlflow_config: dict[str, Any]) -> str:
+    return os.getenv("MLFLOW_TRACKING_URI", mlflow_config["tracking_uri"])
+
+
+def _resolved_model_name(model_name: str | None, mlflow_config: dict[str, Any]) -> str:
+    return model_name or mlflow_config["model_name"]
+
+
+def _registry_alias(stage: str, mlflow_config: dict[str, Any]) -> str:
+    normalized_stage = stage.strip().lower()
+    if normalized_stage == "production":
+        return mlflow_config.get("champion_alias", "champion")
+
+    return normalized_stage
+
+
+def register_model(run_id: str, model_name: str | None = None) -> "ModelVersion":
+    """Register the trained model artifact from a run and return its version."""
+    mlflow_config = get_mlflow_config()
+    resolved_model_name = _resolved_model_name(model_name, mlflow_config)
+    mlflow.set_tracking_uri(_tracking_uri(mlflow_config))
+    return mlflow.register_model(f"runs:/{run_id}/model", resolved_model_name)
+
+
+def promote_model(
+    model_name: str | None, version: str | int, stage: str = "Production"
+) -> None:
+    """Promote a registered model version by assigning the configured alias."""
+    mlflow_config = get_mlflow_config()
+    resolved_model_name = _resolved_model_name(model_name, mlflow_config)
+    mlflow.set_tracking_uri(_tracking_uri(mlflow_config))
+
+    client = mlflow.MlflowClient()
+    client.set_registered_model_alias(
+        resolved_model_name,
+        _registry_alias(stage, mlflow_config),
+        str(version),
+    )
+
+
+def get_production_model(model_name: str | None = None) -> Any:
+    """Load the currently deployed production model from the registry."""
+    mlflow_config = get_mlflow_config()
+    resolved_model_name = _resolved_model_name(model_name, mlflow_config)
+    alias = _registry_alias("Production", mlflow_config)
+    mlflow.set_tracking_uri(_tracking_uri(mlflow_config))
+    return mlflow.pyfunc.load_model(f"models:/{resolved_model_name}@{alias}")

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -1,0 +1,123 @@
+"""Tests for the MLflow model registry helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from foehncast.training_pipeline import register
+
+
+@pytest.fixture()
+def mlflow_config() -> dict[str, str]:
+    return {
+        "tracking_uri": "http://localhost:5001",
+        "model_name": "foehncast-quality",
+        "champion_alias": "champion",
+    }
+
+
+def test_register_model_registers_run_artifact(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, object] = {}
+    expected_version = SimpleNamespace(name="foehncast-quality", version="3")
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def register_model(self, model_uri: str, model_name: str) -> object:
+            logged["registration"] = (model_uri, model_name)
+            return expected_version
+
+    monkeypatch.setattr(register, "mlflow", FakeMlflow())
+    monkeypatch.setattr(register, "get_mlflow_config", lambda: mlflow_config)
+
+    model_version = register.register_model("run-123")
+
+    assert model_version is expected_version
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["registration"] == (
+        "runs:/run-123/model",
+        "foehncast-quality",
+    )
+
+
+def test_register_model_allows_model_name_override(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, tuple[str, str]] = {}
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            return None
+
+        def register_model(self, model_uri: str, model_name: str) -> object:
+            logged["registration"] = (model_uri, model_name)
+            return object()
+
+    monkeypatch.setattr(register, "mlflow", FakeMlflow())
+    monkeypatch.setattr(register, "get_mlflow_config", lambda: mlflow_config)
+
+    register.register_model("run-456", model_name="foehncast-experiment")
+
+    assert logged["registration"] == (
+        "runs:/run-456/model",
+        "foehncast-experiment",
+    )
+
+
+def test_promote_model_assigns_champion_alias_for_production(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, object] = {}
+
+    class FakeClient:
+        def set_registered_model_alias(
+            self, model_name: str, alias: str, version: str
+        ) -> None:
+            logged["alias"] = (model_name, alias, version)
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
+
+    monkeypatch.setattr(register, "mlflow", FakeMlflow())
+    monkeypatch.setattr(register, "get_mlflow_config", lambda: mlflow_config)
+
+    register.promote_model(None, 7)
+
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["alias"] == ("foehncast-quality", "champion", "7")
+
+
+def test_get_production_model_loads_model_from_champion_alias(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, str] = {}
+    expected_model = object()
+
+    class FakePyfunc:
+        def load_model(self, model_uri: str) -> object:
+            logged["model_uri"] = model_uri
+            return expected_model
+
+    class FakeMlflow:
+        pyfunc = FakePyfunc()
+
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+    monkeypatch.setattr(register, "mlflow", FakeMlflow())
+    monkeypatch.setattr(register, "get_mlflow_config", lambda: mlflow_config)
+
+    model = register.get_production_model()
+
+    assert model is expected_model
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["model_uri"] == "models:/foehncast-quality@champion"


### PR DESCRIPTION
What changed:
- implement MLflow model registration from training run artifacts
- add alias-based promotion helpers and champion-model loading from the registry
- add focused tests for registration, alias promotion, and production-model loading

Why:
- complete the model-registry slice that follows training and evaluation in the backend chain
- make the deployed model version explicit through the MLflow registry alias flow

Verification:
- uv run ruff check src/foehncast/training_pipeline/register.py tests/test_register.py
- uv run pytest tests/test_train.py tests/test_evaluate.py tests/test_register.py -q

Closes: #11