### PR TITLE
feat(serve): add FastAPI prediction endpoints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.1.0"
 description = "Personalized kiteboarding forecast system with FTI pipeline"
 requires-python = ">=3.12"
 dependencies = [
+    "fastapi>=0.115",
     "matplotlib>=3.8",
     "mlflow>=3.0",
     "pandas>=2.0",
@@ -16,10 +17,12 @@ dependencies = [
     "requests>=2.31",
     "scikit-learn>=1.5",
     "s3fs>=2024.0",
+    "uvicorn>=0.30",
 ]
 
 [dependency-groups]
 dev = [
+    "httpx>=0.27",
     "ruff>=0.1.0",
     "pytest>=7.0.0",
     "pytest-mock>=3.0",

--- a/src/foehncast/config.py
+++ b/src/foehncast/config.py
@@ -62,6 +62,11 @@ def get_mlflow_config() -> dict[str, Any]:
     return load_config()["mlflow"]
 
 
+def get_inference_config() -> dict[str, Any]:
+    """Return the inference settings."""
+    return load_config()["inference"]
+
+
 def get_monitoring_config() -> dict[str, Any]:
     """Return the monitoring settings."""
     return load_config()["monitoring"]

--- a/src/foehncast/inference_pipeline/predict.py
+++ b/src/foehncast/inference_pipeline/predict.py
@@ -1,1 +1,118 @@
-"""Prediction logic (load model, compute quality index)."""
+"""Prediction logic for live spot forecasts."""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+import mlflow
+import pandas as pd
+
+from foehncast.config import (
+    get_inference_config,
+    get_mlflow_config,
+    get_model_config,
+    get_spots,
+)
+from foehncast.feature_pipeline.engineer import engineer_features
+from foehncast.feature_pipeline.ingest import fetch_forecast
+from foehncast.training_pipeline.register import get_production_model
+
+
+def _tracking_uri(mlflow_config: dict[str, Any]) -> str:
+    return os.getenv("MLFLOW_TRACKING_URI", mlflow_config["tracking_uri"])
+
+
+def _spot_lookup() -> dict[str, dict[str, Any]]:
+    return {spot["id"]: spot for spot in get_spots()}
+
+
+def _resolve_spots(spot_ids: list[str] | None) -> list[dict[str, Any]]:
+    spot_lookup = _spot_lookup()
+    if spot_ids is None:
+        return list(spot_lookup.values())
+
+    missing_spots = sorted(set(spot_ids) - set(spot_lookup))
+    if missing_spots:
+        missing = ", ".join(missing_spots)
+        raise KeyError(f"Unknown spot requested: {missing}")
+
+    return [spot_lookup[spot_id] for spot_id in spot_ids]
+
+
+def list_available_spots() -> list[dict[str, Any]]:
+    """Return the configured spots available for inference."""
+    return [spot.copy() for spot in get_spots()]
+
+
+def get_serving_model_version(model_name: str | None = None) -> str:
+    """Return the MLflow registry version currently assigned to the serving alias."""
+    mlflow_config = get_mlflow_config()
+    resolved_model_name = model_name or mlflow_config["model_name"]
+    alias = mlflow_config.get("champion_alias", "champion")
+
+    mlflow.set_tracking_uri(_tracking_uri(mlflow_config))
+    client = mlflow.MlflowClient()
+    model_version = client.get_model_version_by_alias(resolved_model_name, alias)
+    return str(model_version.version)
+
+
+def _prepare_feature_frame(
+    forecast_df: pd.DataFrame, spot: dict[str, Any], feature_columns: list[str]
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    engineered_df = engineer_features(forecast_df, spot["shore_orientation_deg"])
+    feature_frame = engineered_df[feature_columns].copy().ffill().bfill().fillna(0.0)
+    return engineered_df, feature_frame
+
+
+def predict_spots(spot_ids: list[str] | None = None) -> dict[str, Any]:
+    """Fetch forecasts for the requested spots and return model predictions."""
+    requested_spots = _resolve_spots(spot_ids)
+    model = get_production_model()
+    model_config = get_model_config()
+    inference_config = get_inference_config()
+    feature_columns = model_config["features"]
+    max_horizon_hours = inference_config["max_horizon_hours"]
+    predictions: list[dict[str, Any]] = []
+
+    for spot in requested_spots:
+        forecast_df = fetch_forecast(spot["lat"], spot["lon"])
+        forecast_df = forecast_df.head(max_horizon_hours)
+        if forecast_df.empty:
+            predictions.append(
+                {
+                    "spot_id": spot["id"],
+                    "spot_name": spot["name"],
+                    "forecast": [],
+                }
+            )
+            continue
+
+        engineered_df, feature_frame = _prepare_feature_frame(
+            forecast_df, spot, feature_columns
+        )
+        model_predictions = model.predict(feature_frame)
+        forecast_rows = []
+
+        for timestamp, quality_index in zip(
+            engineered_df.index, model_predictions, strict=False
+        ):
+            forecast_rows.append(
+                {
+                    "time": timestamp.isoformat(),
+                    "quality_index": float(quality_index),
+                }
+            )
+
+        predictions.append(
+            {
+                "spot_id": spot["id"],
+                "spot_name": spot["name"],
+                "forecast": forecast_rows,
+            }
+        )
+
+    return {
+        "model_version": get_serving_model_version(),
+        "predictions": predictions,
+    }

--- a/src/foehncast/inference_pipeline/serve.py
+++ b/src/foehncast/inference_pipeline/serve.py
@@ -1,1 +1,49 @@
 """FastAPI prediction endpoint."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from foehncast.inference_pipeline.predict import (
+    get_serving_model_version,
+    list_available_spots,
+    predict_spots,
+)
+
+
+class PredictionRequest(BaseModel):
+    spot_ids: list[str] | None = None
+
+
+def create_app() -> FastAPI:
+    """Build the serving application for health and inference endpoints."""
+    app = FastAPI(title="FoehnCast API", version="0.1.0")
+
+    @app.get("/health")
+    def health() -> dict[str, str]:
+        try:
+            return {
+                "status": "healthy",
+                "model_version": get_serving_model_version(),
+            }
+        except Exception as exc:
+            raise HTTPException(status_code=503, detail=str(exc)) from exc
+
+    @app.get("/spots")
+    def spots() -> list[dict[str, Any]]:
+        return list_available_spots()
+
+    @app.post("/predict")
+    def predict(request: PredictionRequest) -> dict[str, Any]:
+        try:
+            return predict_spots(request.spot_ids)
+        except KeyError as exc:
+            raise HTTPException(status_code=404, detail=str(exc)) from exc
+
+    return app
+
+
+app = create_app()

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -1,1 +1,167 @@
-"""Tests for prediction and ranking logic."""
+"""Tests for prediction helpers and serving endpoints."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from foehncast.inference_pipeline import predict, serve
+
+
+@pytest.fixture()
+def model_config() -> dict[str, object]:
+    return {
+        "features": [
+            "wind_speed_10m",
+            "wind_gusts_10m",
+            "wind_direction_10m",
+            "wind_steadiness",
+            "gust_factor",
+            "shore_alignment",
+        ]
+    }
+
+
+@pytest.fixture()
+def spot() -> dict[str, object]:
+    return {
+        "id": "silvaplana",
+        "name": "Silvaplana",
+        "lat": 46.45,
+        "lon": 9.79,
+        "shore_orientation_deg": 225,
+    }
+
+
+@pytest.fixture()
+def forecast_df() -> pd.DataFrame:
+    index = pd.date_range("2025-01-01T00:00:00", periods=3, freq="h")
+    return pd.DataFrame(
+        {
+            "wind_speed_10m": [14.0, 16.0, 18.0],
+            "wind_gusts_10m": [18.0, 20.0, 22.0],
+            "wind_direction_10m": [210.0, 220.0, 230.0],
+        },
+        index=index,
+    )
+
+
+def test_get_serving_model_version_reads_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: dict[str, object] = {}
+
+    class FakeClient:
+        def get_model_version_by_alias(self, model_name: str, alias: str) -> object:
+            logged["lookup"] = (model_name, alias)
+            return SimpleNamespace(version="5")
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
+
+    monkeypatch.setattr(predict, "mlflow", FakeMlflow())
+    monkeypatch.setattr(
+        predict,
+        "get_mlflow_config",
+        lambda: {
+            "tracking_uri": "http://localhost:5001",
+            "model_name": "foehncast-quality",
+            "champion_alias": "champion",
+        },
+    )
+
+    model_version = predict.get_serving_model_version()
+
+    assert model_version == "5"
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["lookup"] == ("foehncast-quality", "champion")
+
+
+def test_predict_spots_returns_forecasts_for_requested_spots(
+    monkeypatch: pytest.MonkeyPatch,
+    model_config: dict[str, object],
+    spot: dict[str, object],
+    forecast_df: pd.DataFrame,
+) -> None:
+    class FakeModel:
+        def predict(self, features_df: pd.DataFrame) -> list[float]:
+            assert list(features_df.columns) == model_config["features"]
+            return [2.1, 3.2]
+
+    monkeypatch.setattr(predict, "get_production_model", lambda: FakeModel())
+    monkeypatch.setattr(predict, "get_model_config", lambda: model_config)
+    monkeypatch.setattr(
+        predict, "get_inference_config", lambda: {"max_horizon_hours": 2}
+    )
+    monkeypatch.setattr(predict, "get_spots", lambda: [spot])
+    monkeypatch.setattr(predict, "fetch_forecast", lambda lat, lon: forecast_df)
+    monkeypatch.setattr(predict, "get_serving_model_version", lambda: "7")
+
+    result = predict.predict_spots(["silvaplana"])
+
+    assert result["model_version"] == "7"
+    assert len(result["predictions"]) == 1
+    assert result["predictions"][0]["spot_id"] == "silvaplana"
+    assert result["predictions"][0]["spot_name"] == "Silvaplana"
+    assert len(result["predictions"][0]["forecast"]) == 2
+    assert result["predictions"][0]["forecast"][0]["quality_index"] == 2.1
+
+
+def test_predict_spots_rejects_unknown_spots(
+    monkeypatch: pytest.MonkeyPatch, spot: dict[str, object]
+) -> None:
+    monkeypatch.setattr(predict, "get_spots", lambda: [spot])
+
+    with pytest.raises(KeyError, match="Unknown spot requested"):
+        predict.predict_spots(["unknown-spot"])
+
+
+def test_health_endpoint_reports_model_version(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(serve, "get_serving_model_version", lambda: "9")
+    client = TestClient(serve.app)
+
+    response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json() == {"status": "healthy", "model_version": "9"}
+
+
+def test_spots_endpoint_lists_available_spots(
+    monkeypatch: pytest.MonkeyPatch, spot: dict[str, object]
+) -> None:
+    monkeypatch.setattr(serve, "list_available_spots", lambda: [spot])
+    client = TestClient(serve.app)
+
+    response = client.get("/spots")
+
+    assert response.status_code == 200
+    assert response.json() == [spot]
+
+
+def test_predict_endpoint_returns_prediction_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {
+        "model_version": "11",
+        "predictions": [
+            {
+                "spot_id": "silvaplana",
+                "spot_name": "Silvaplana",
+                "forecast": [{"time": "2025-01-01T00:00:00", "quality_index": 2.4}],
+            }
+        ],
+    }
+    monkeypatch.setattr(serve, "predict_spots", lambda spot_ids: payload)
+    client = TestClient(serve.app)
+
+    response = client.post("/predict", json={"spot_ids": ["silvaplana"]})
+
+    assert response.status_code == 200
+    assert response.json() == payload

--- a/uv.lock
+++ b/uv.lock
@@ -719,6 +719,7 @@ name = "foehncast"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "fastapi" },
     { name = "matplotlib" },
     { name = "mlflow" },
     { name = "pandas" },
@@ -727,10 +728,12 @@ dependencies = [
     { name = "requests" },
     { name = "s3fs" },
     { name = "scikit-learn" },
+    { name = "uvicorn" },
 ]
 
 [package.dev-dependencies]
 dev = [
+    { name = "httpx" },
     { name = "ipykernel" },
     { name = "pytest" },
     { name = "pytest-mock" },
@@ -743,6 +746,7 @@ docs = [
 
 [package.metadata]
 requires-dist = [
+    { name = "fastapi", specifier = ">=0.115" },
     { name = "matplotlib", specifier = ">=3.8" },
     { name = "mlflow", specifier = ">=3.0" },
     { name = "pandas", specifier = ">=2.0" },
@@ -751,10 +755,12 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31" },
     { name = "s3fs", specifier = ">=2024.0" },
     { name = "scikit-learn", specifier = ">=1.5" },
+    { name = "uvicorn", specifier = ">=0.30" },
 ]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "httpx", specifier = ">=0.27" },
     { name = "ipykernel", specifier = ">=6.0" },
     { name = "pytest", specifier = ">=7.0.0" },
     { name = "pytest-mock", specifier = ">=3.0" },
@@ -1047,6 +1053,34 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
What changed:
- implement MLflow-registry-backed spot prediction helpers with live forecast fetching and engineered feature preparation
- add FastAPI /health, /spots, and /predict endpoints for serving model-backed forecasts
- add serving dependencies, inference config access, and focused API plus inference tests

Why:
- complete the serving slice that exposes the trained and registered model through the course FastAPI deployment pattern
- report the active serving model version through the health and prediction responses

Verification:
- uv run ruff check src/foehncast/config.py src/foehncast/inference_pipeline/predict.py src/foehncast/inference_pipeline/serve.py tests/test_predict.py
- uv run pytest tests -q

Closes: #14