### PR TITLE
feat(rank): add spot ranking helpers

### DIFF
--- a/src/foehncast/inference_pipeline/rank.py
+++ b/src/foehncast/inference_pipeline/rank.py
@@ -1,1 +1,121 @@
 """Rank spots by quality index, proximity, and duration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from foehncast.config import get_inference_config, get_spots
+from foehncast.spots.distance import get_drive_minutes_to_spot
+
+_RIDEABLE_QUALITY_THRESHOLD = 2.0
+_MIN_DRIVE_HOURS = 0.25
+
+
+@dataclass(slots=True)
+class RankedSpot:
+    spot_id: str
+    spot_name: str
+    quality_index: float
+    drive_minutes: float
+    session_hours: float
+    ride_drive_ratio: float
+    score: float
+
+
+def compute_ride_drive_ratio(
+    quality: float, drive_minutes: float, session_hours: float
+) -> float:
+    """Estimate ride value per drive-hour for a ranked spot."""
+    if quality <= 0 or session_hours <= 0:
+        return 0.0
+
+    drive_hours = max(drive_minutes / 60.0, _MIN_DRIVE_HOURS)
+    return float((quality * session_hours) / drive_hours)
+
+
+def _normalize(values: list[float]) -> list[float]:
+    if not values:
+        return []
+
+    min_value = min(values)
+    max_value = max(values)
+    if min_value == max_value:
+        return [1.0 if max_value > 0 else 0.0 for _ in values]
+
+    return [(value - min_value) / (max_value - min_value) for value in values]
+
+
+def _session_hours(forecast: list[dict[str, Any]]) -> float:
+    return float(
+        sum(
+            1
+            for hour in forecast
+            if hour["quality_index"] >= _RIDEABLE_QUALITY_THRESHOLD
+        )
+    )
+
+
+def rank_spots(
+    predictions: dict[str, Any], rider_config: dict[str, Any]
+) -> list[RankedSpot]:
+    """Rank predicted spot forecasts using quality, duration, and drive-time ROI."""
+    ranking_weights = get_inference_config()["ranking_weights"]
+    spots_by_id = {spot["id"]: spot for spot in get_spots()}
+    candidate_rows: list[dict[str, Any]] = []
+
+    for prediction in predictions.get("predictions", []):
+        spot = spots_by_id[prediction["spot_id"]]
+        forecast = prediction.get("forecast", [])
+        quality_index = max(
+            (float(hour["quality_index"]) for hour in forecast),
+            default=0.0,
+        )
+        session_hours = _session_hours(forecast)
+        drive_minutes = get_drive_minutes_to_spot(spot, rider_config)
+        ride_drive_ratio = compute_ride_drive_ratio(
+            quality=quality_index,
+            drive_minutes=drive_minutes,
+            session_hours=session_hours,
+        )
+        candidate_rows.append(
+            {
+                "spot_id": prediction["spot_id"],
+                "spot_name": prediction["spot_name"],
+                "quality_index": quality_index,
+                "drive_minutes": drive_minutes,
+                "session_hours": session_hours,
+                "ride_drive_ratio": ride_drive_ratio,
+            }
+        )
+
+    quality_scores = _normalize([row["quality_index"] for row in candidate_rows])
+    ratio_scores = _normalize([row["ride_drive_ratio"] for row in candidate_rows])
+    duration_scores = _normalize([row["session_hours"] for row in candidate_rows])
+    ranked_spots: list[RankedSpot] = []
+
+    for row, quality_score, ratio_score, duration_score in zip(
+        candidate_rows,
+        quality_scores,
+        ratio_scores,
+        duration_scores,
+        strict=False,
+    ):
+        composite_score = (
+            ranking_weights["quality_index"] * quality_score
+            + ranking_weights["ride_drive_ratio"] * ratio_score
+            + ranking_weights["duration_forecast"] * duration_score
+        )
+        ranked_spots.append(
+            RankedSpot(
+                spot_id=row["spot_id"],
+                spot_name=row["spot_name"],
+                quality_index=row["quality_index"],
+                drive_minutes=row["drive_minutes"],
+                session_hours=row["session_hours"],
+                ride_drive_ratio=row["ride_drive_ratio"],
+                score=float(composite_score),
+            )
+        )
+
+    return sorted(ranked_spots, key=lambda spot: spot.score, reverse=True)

--- a/src/foehncast/spots/distance.py
+++ b/src/foehncast/spots/distance.py
@@ -1,1 +1,42 @@
 """OSRM distance and drive time calculations from rider location."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import requests
+
+from foehncast.config import get_api_config
+
+_TIMEOUT = 30
+
+
+def get_drive_minutes(
+    origin_lat: float,
+    origin_lon: float,
+    destination_lat: float,
+    destination_lon: float,
+) -> float:
+    """Return the OSRM drive time in minutes between two coordinates."""
+    base_url = get_api_config()["osrm"]["base_url"].rstrip("/")
+    url = f"{base_url}/{origin_lon},{origin_lat};{destination_lon},{destination_lat}"
+    response = requests.get(url, params={"overview": "false"}, timeout=_TIMEOUT)
+    response.raise_for_status()
+
+    routes = response.json().get("routes", [])
+    if not routes:
+        raise ValueError("OSRM did not return a route")
+
+    return float(routes[0]["duration"]) / 60.0
+
+
+def get_drive_minutes_to_spot(
+    spot: dict[str, Any], rider_config: dict[str, Any]
+) -> float:
+    """Return the OSRM drive time in minutes from the rider's home to a spot."""
+    return get_drive_minutes(
+        origin_lat=rider_config["home_lat"],
+        origin_lon=rider_config["home_lon"],
+        destination_lat=spot["lat"],
+        destination_lon=spot["lon"],
+    )

--- a/tests/test_rank.py
+++ b/tests/test_rank.py
@@ -1,0 +1,168 @@
+"""Tests for ranking and drive-time helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from foehncast.inference_pipeline import rank
+from foehncast.spots import distance
+
+
+def test_get_drive_minutes_calls_osrm_route(monkeypatch: pytest.MonkeyPatch) -> None:
+    logged: dict[str, Any] = {}
+
+    class FakeResponse:
+        def raise_for_status(self) -> None:
+            return None
+
+        def json(self) -> dict[str, Any]:
+            return {"routes": [{"duration": 5400.0}]}
+
+    def fake_get(url: str, params: dict[str, str], timeout: int) -> FakeResponse:
+        logged["url"] = url
+        logged["params"] = params
+        logged["timeout"] = timeout
+        return FakeResponse()
+
+    monkeypatch.setattr(
+        distance,
+        "get_api_config",
+        lambda: {"osrm": {"base_url": "https://router.example/route/v1/driving"}},
+    )
+    monkeypatch.setattr(distance.requests, "get", fake_get)
+
+    drive_minutes = distance.get_drive_minutes(47.02, 8.65, 46.45, 9.79)
+
+    assert drive_minutes == 90.0
+    assert (
+        logged["url"] == "https://router.example/route/v1/driving/8.65,47.02;9.79,46.45"
+    )
+    assert logged["params"] == {"overview": "false"}
+    assert logged["timeout"] == 30
+
+
+def test_compute_ride_drive_ratio_returns_zero_for_non_rideable_sessions() -> None:
+    assert (
+        rank.compute_ride_drive_ratio(
+            quality=0.0, drive_minutes=45.0, session_hours=2.0
+        )
+        == 0.0
+    )
+    assert (
+        rank.compute_ride_drive_ratio(
+            quality=3.0, drive_minutes=45.0, session_hours=0.0
+        )
+        == 0.0
+    )
+
+
+def test_rank_spots_orders_by_weighted_score(monkeypatch: pytest.MonkeyPatch) -> None:
+    predictions = {
+        "predictions": [
+            {
+                "spot_id": "near-strong",
+                "spot_name": "Near Strong",
+                "forecast": [
+                    {"time": "2025-01-01T00:00:00", "quality_index": 3.8},
+                    {"time": "2025-01-01T01:00:00", "quality_index": 3.4},
+                    {"time": "2025-01-01T02:00:00", "quality_index": 2.8},
+                    {"time": "2025-01-01T03:00:00", "quality_index": 2.4},
+                ],
+            },
+            {
+                "spot_id": "far-peak",
+                "spot_name": "Far Peak",
+                "forecast": [
+                    {"time": "2025-01-01T00:00:00", "quality_index": 4.0},
+                    {"time": "2025-01-01T01:00:00", "quality_index": 2.3},
+                ],
+            },
+            {
+                "spot_id": "weak-local",
+                "spot_name": "Weak Local",
+                "forecast": [
+                    {"time": "2025-01-01T00:00:00", "quality_index": 1.4},
+                ],
+            },
+        ]
+    }
+    spots = [
+        {"id": "near-strong", "name": "Near Strong", "lat": 0.0, "lon": 0.0},
+        {"id": "far-peak", "name": "Far Peak", "lat": 0.0, "lon": 0.0},
+        {"id": "weak-local", "name": "Weak Local", "lat": 0.0, "lon": 0.0},
+    ]
+    drive_minutes = {
+        "near-strong": 30.0,
+        "far-peak": 180.0,
+        "weak-local": 20.0,
+    }
+
+    monkeypatch.setattr(
+        rank,
+        "get_inference_config",
+        lambda: {
+            "ranking_weights": {
+                "quality_index": 0.6,
+                "ride_drive_ratio": 0.3,
+                "duration_forecast": 0.1,
+            }
+        },
+    )
+    monkeypatch.setattr(rank, "get_spots", lambda: spots)
+    monkeypatch.setattr(
+        rank,
+        "get_drive_minutes_to_spot",
+        lambda spot, rider_config: drive_minutes[spot["id"]],
+    )
+
+    ranked_spots = rank.rank_spots(
+        predictions,
+        rider_config={"home_lat": 47.02, "home_lon": 8.65},
+    )
+
+    assert [spot.spot_id for spot in ranked_spots] == [
+        "near-strong",
+        "far-peak",
+        "weak-local",
+    ]
+    assert ranked_spots[0].session_hours == 4.0
+    assert ranked_spots[0].drive_minutes == 30.0
+    assert ranked_spots[0].score > ranked_spots[1].score > ranked_spots[2].score
+
+
+def test_rank_spots_handles_empty_forecasts(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        rank,
+        "get_inference_config",
+        lambda: {
+            "ranking_weights": {
+                "quality_index": 0.6,
+                "ride_drive_ratio": 0.3,
+                "duration_forecast": 0.1,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        rank,
+        "get_spots",
+        lambda: [{"id": "silvaplana", "name": "Silvaplana", "lat": 0.0, "lon": 0.0}],
+    )
+    monkeypatch.setattr(
+        rank, "get_drive_minutes_to_spot", lambda spot, rider_config: 45.0
+    )
+
+    ranked_spots = rank.rank_spots(
+        {
+            "predictions": [
+                {"spot_id": "silvaplana", "spot_name": "Silvaplana", "forecast": []}
+            ]
+        },
+        rider_config={"home_lat": 47.02, "home_lon": 8.65},
+    )
+
+    assert len(ranked_spots) == 1
+    assert ranked_spots[0].quality_index == 0.0
+    assert ranked_spots[0].session_hours == 0.0
+    assert ranked_spots[0].ride_drive_ratio == 0.0


### PR DESCRIPTION
What changed:
- implement OSRM drive-time helpers for spot travel estimates from the rider home location
- add weighted spot ranking with quality, ride-drive ratio, and forecasted session duration
- add focused tests for drive-time lookup, ride-drive ratio, and ranking order

Why:
- complete the spot-ranking slice that builds on the prediction service for the MS3 demo flow
- rank predicted sessions using the inference weights defined in config.yaml

Verification:
- uv run ruff check src/foehncast/spots/distance.py src/foehncast/inference_pipeline/rank.py tests/test_rank.py
- uv run pytest tests -q

Closes: #15