### PR TITLE
feat(airflow): add local orchestration stack

### DIFF
--- a/containers/airflow/Dockerfile
+++ b/containers/airflow/Dockerfile
@@ -1,0 +1,21 @@
+FROM apache/airflow:2.10.5-python3.12
+
+USER root
+
+COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /uvx /usr/local/bin/
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends git tini \
+    && rm -rf /var/lib/apt/lists/*
+
+USER airflow
+WORKDIR /workspace
+
+ENV PYTHONUNBUFFERED=1 \
+    UV_LINK_MODE=copy \
+    AIRFLOW_HOME=/workspace/airflow \
+    AIRFLOW__CORE__DAGS_FOLDER=/workspace/dags \
+    PYTHONPATH=/workspace/src
+
+ENTRYPOINT ["/usr/bin/tini", "--"]
+CMD ["bash", "-lc", "cd /workspace && uv pip install --system -e . && airflow standalone"]

--- a/containers/airflow/docker-compose.yml
+++ b/containers/airflow/docker-compose.yml
@@ -1,0 +1,28 @@
+services:
+  airflow:
+    container_name: airflow
+    build:
+      context: ../..
+      dockerfile: containers/airflow/Dockerfile
+    image: foehncast-airflow:local
+    working_dir: /workspace
+    command: bash -lc "cd /workspace && uv pip install --system -e . && airflow standalone"
+    ports:
+      - 127.0.0.1:8080:8080
+    depends_on:
+      - objectstore
+      - model-registry
+    environment:
+      - AIRFLOW_HOME=${AIRFLOW_HOME}
+      - AIRFLOW__CORE__LOAD_EXAMPLES=${AIRFLOW__CORE__LOAD_EXAMPLES}
+      - AIRFLOW__CORE__DAGS_FOLDER=/workspace/dags
+      - AIRFLOW__DATABASE__SQL_ALCHEMY_CONN=sqlite:////workspace/airflow/airflow.db
+      - MLFLOW_TRACKING_URI=http://model-registry:5001
+      - OBJECTSTORE_ACCESS_KEY=${OBJECTSTORE_ACCESS_KEY}
+      - OBJECTSTORE_SECRET_KEY=${OBJECTSTORE_SECRET_KEY}
+      - OBJECTSTORE_ENDPOINT=http://objectstore:9000
+      - PYTHONPATH=/workspace/src
+    volumes:
+      - ../../:/workspace
+    networks:
+      - development

--- a/dags/feature_dag.py
+++ b/dags/feature_dag.py
@@ -1,1 +1,26 @@
-"""Airflow DAG: ingest -> engineer -> store."""
+"""Airflow DAG for the local feature pipeline."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+try:
+    from airflow import DAG
+    from airflow.operators.python import PythonOperator
+except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
+    dag = None
+else:
+    from foehncast.orchestration import run_feature_pipeline
+
+    with DAG(
+        dag_id="feature_pipeline",
+        description="Fetch forecasts, engineer features, validate them, and store them.",
+        start_date=datetime(2024, 1, 1),
+        schedule=None,
+        catchup=False,
+        tags=["foehncast", "feature"],
+    ) as dag:
+        PythonOperator(
+            task_id="run_feature_pipeline",
+            python_callable=run_feature_pipeline,
+        )

--- a/dags/training_dag.py
+++ b/dags/training_dag.py
@@ -1,1 +1,41 @@
-"""Airflow DAG: label -> train -> evaluate -> register."""
+"""Airflow DAG for local model training, evaluation, and registration."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+try:
+    from airflow import DAG
+    from airflow.operators.python import PythonOperator
+except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
+    dag = None
+else:
+    from foehncast.orchestration import evaluate_training_run, register_training_run
+    from foehncast.training_pipeline.train import run_training_pipeline
+
+    with DAG(
+        dag_id="training_pipeline",
+        description="Train the model, log evaluation outputs, and register the new version.",
+        start_date=datetime(2024, 1, 1),
+        schedule=None,
+        catchup=False,
+        tags=["foehncast", "training"],
+    ) as dag:
+        train_model = PythonOperator(
+            task_id="train_model",
+            python_callable=run_training_pipeline,
+        )
+
+        evaluate_model_task = PythonOperator(
+            task_id="evaluate_model",
+            python_callable=evaluate_training_run,
+            op_args=[train_model.output],
+        )
+
+        register_model_task = PythonOperator(
+            task_id="register_model",
+            python_callable=register_training_run,
+            op_args=[train_model.output],
+        )
+
+        train_model >> evaluate_model_task >> register_model_task

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,7 @@
 include:
   - docker_includes/networks.yml
   - containers/development_env/docker-compose.yml
+  - containers/airflow/docker-compose.yml
   - containers/objectstore/docker-compose.yml
   - containers/mlflow/docker-compose.yml
 #  - containers/app/docker-compose.yml

--- a/src/foehncast/orchestration.py
+++ b/src/foehncast/orchestration.py
@@ -1,0 +1,74 @@
+"""High-level orchestration helpers for local Airflow DAGs."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import mlflow
+import pandas as pd
+
+from foehncast.config import get_mlflow_config, get_spots
+from foehncast.feature_pipeline.engineer import engineer_features
+from foehncast.feature_pipeline.ingest import fetch_all_spots
+from foehncast.feature_pipeline.store import write_features
+from foehncast.feature_pipeline.validate import run_validation
+from foehncast.training_pipeline.evaluate import (
+    evaluate_model,
+    generate_evaluation_report,
+)
+from foehncast.training_pipeline.register import promote_model, register_model
+from foehncast.training_pipeline.train import load_training_data
+
+_ROOT = Path(__file__).resolve().parent.parent.parent
+
+
+def _tracking_uri() -> str:
+    mlflow_config = get_mlflow_config()
+    return os.getenv("MLFLOW_TRACKING_URI", mlflow_config["tracking_uri"])
+
+
+def run_feature_pipeline(dataset: str = "train") -> list[str]:
+    """Fetch, engineer, validate, and store features for all configured spots."""
+    forecasts_by_spot = fetch_all_spots()
+    stored_spots: list[str] = []
+
+    for spot in get_spots():
+        spot_id = spot["id"]
+        forecast_df = forecasts_by_spot.get(spot_id, pd.DataFrame())
+        if forecast_df.empty:
+            continue
+
+        feature_df = engineer_features(forecast_df, spot["shore_orientation_deg"])
+        validation = run_validation(feature_df, spot_id)
+        if not validation.is_valid:
+            raise ValueError(f"Feature validation failed for spot '{spot_id}'")
+
+        write_features(feature_df, spot_id=spot_id, dataset=dataset)
+        stored_spots.append(spot_id)
+
+    if not stored_spots:
+        raise ValueError("No feature data was generated for any configured spot")
+
+    return stored_spots
+
+
+def evaluate_training_run(run_id: str, dataset: str = "train") -> str:
+    """Resume a training run, log evaluation metrics, and return the report path."""
+    mlflow.set_tracking_uri(_tracking_uri())
+    features_df, target_series = load_training_data(dataset=dataset)
+    model = mlflow.pyfunc.load_model(f"runs:/{run_id}/model")
+
+    report_dir = _ROOT / "airflow" / "reports"
+    report_path = report_dir / f"evaluation-{run_id}.md"
+
+    with mlflow.start_run(run_id=run_id):
+        metrics = evaluate_model(model, features_df, target_series)
+        return generate_evaluation_report(metrics, str(report_path))
+
+
+def register_training_run(run_id: str, stage: str = "Production") -> str:
+    """Register and promote a training run's model, returning the new version."""
+    model_version = register_model(run_id)
+    promote_model(None, model_version.version, stage=stage)
+    return str(model_version.version)

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -1,0 +1,173 @@
+"""Tests for Airflow orchestration helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from foehncast import orchestration
+
+
+def test_run_feature_pipeline_fetches_validated_features(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    feature_df = pd.DataFrame(
+        {
+            "wind_speed_10m": [14.0],
+            "wind_gusts_10m": [18.0],
+            "wind_direction_10m": [220.0],
+        }
+    )
+    stored: list[tuple[str, str]] = []
+
+    monkeypatch.setattr(
+        orchestration,
+        "get_spots",
+        lambda: [
+            {
+                "id": "silvaplana",
+                "shore_orientation_deg": 225,
+            }
+        ],
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "fetch_all_spots",
+        lambda: {"silvaplana": feature_df},
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "engineer_features",
+        lambda df, shore_orientation_deg: df.assign(gust_factor=1.2),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "run_validation",
+        lambda df, spot_id: SimpleNamespace(is_valid=True),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "write_features",
+        lambda df, spot_id, dataset: stored.append((spot_id, dataset)),
+    )
+
+    stored_spots = orchestration.run_feature_pipeline()
+
+    assert stored_spots == ["silvaplana"]
+    assert stored == [("silvaplana", "train")]
+
+
+def test_run_feature_pipeline_raises_on_validation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        orchestration,
+        "get_spots",
+        lambda: [{"id": "silvaplana", "shore_orientation_deg": 225}],
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "fetch_all_spots",
+        lambda: {"silvaplana": pd.DataFrame({"wind_speed_10m": [14.0]})},
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "engineer_features",
+        lambda df, shore_orientation_deg: df,
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "run_validation",
+        lambda df, spot_id: SimpleNamespace(is_valid=False),
+    )
+
+    with pytest.raises(ValueError, match="Feature validation failed"):
+        orchestration.run_feature_pipeline()
+
+
+def test_evaluate_training_run_logs_to_existing_mlflow_run(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    logged: dict[str, object] = {}
+
+    class FakeRun:
+        def __enter__(self) -> FakeRun:
+            logged["entered"] = True
+            return self
+
+        def __exit__(self, exc_type, exc, exc_tb) -> None:
+            return None
+
+    class FakePyfunc:
+        def load_model(self, model_uri: str) -> object:
+            logged["model_uri"] = model_uri
+            return object()
+
+    class FakeMlflow:
+        pyfunc = FakePyfunc()
+
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def start_run(self, run_id: str) -> FakeRun:
+            logged["run_id"] = run_id
+            return FakeRun()
+
+    monkeypatch.setattr(orchestration, "mlflow", FakeMlflow())
+    monkeypatch.setattr(
+        orchestration,
+        "get_mlflow_config",
+        lambda: {"tracking_uri": "http://localhost:5001"},
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "load_training_data",
+        lambda dataset="train": (
+            pd.DataFrame({"wind_speed_10m": [10.0]}),
+            pd.Series([3]),
+        ),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "evaluate_model",
+        lambda model, features_df, target_series: {"mae": 0.5},
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "generate_evaluation_report",
+        lambda metrics, output_path: str(tmp_path / "evaluation.md"),
+    )
+
+    report_path = orchestration.evaluate_training_run("run-123")
+
+    assert report_path == str(tmp_path / "evaluation.md")
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["model_uri"] == "runs:/run-123/model"
+    assert logged["run_id"] == "run-123"
+
+
+def test_register_training_run_registers_and_promotes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        orchestration,
+        "register_model",
+        lambda run_id: SimpleNamespace(version="7"),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "promote_model",
+        lambda model_name, version, stage="Production": logged.update(
+            {"promotion": (model_name, version, stage)}
+        ),
+    )
+
+    version = orchestration.register_training_run("run-456")
+
+    assert version == "7"
+    assert logged["promotion"] == (None, "7", "Production")


### PR DESCRIPTION
What changed:
- add a local Airflow service to the Compose stack for end-to-end orchestration testing
- turn the feature and training DAG stubs into runnable Airflow DAGs
- add orchestration helpers that reuse the existing project modules for feature generation, evaluation, and model registration
- add focused tests for the new orchestration helper layer

Why:
- enable local end-to-end stack testing before MS3 polishing, narrative cleanup, and site refinement
- keep orchestration thin and aligned with the existing feature and training modules instead of duplicating pipeline logic

Verification:
- uv run ruff check src/foehncast/orchestration.py dags/feature_dag.py dags/training_dag.py tests/test_orchestration.py
- uv run pytest tests -q
- docker compose --env-file .env.example config --services

Closes: #57