### PR TITLE
fix(training-pipeline): align label thresholds with km/h features

### DIFF
--- a/src/foehncast/training_pipeline/label.py
+++ b/src/foehncast/training_pipeline/label.py
@@ -15,6 +15,7 @@ _REQUIRED_COLUMNS = {
     "gust_factor",
     "shore_alignment",
 }
+_KMH_PER_KNOT = 1.852
 
 
 def _require_columns(features_df: pd.DataFrame) -> None:
@@ -32,9 +33,14 @@ def _minimum_rideable_wind(
     return float(minimum_cfg["default_min_kts"])
 
 
+def _kmh_to_kts(value: float) -> float:
+    return float(value) / _KMH_PER_KNOT
+
+
 def _is_perfect_storm(row: pd.Series, perfect_cfg: dict[str, Any]) -> bool:
+    wind_speed_10m_kts = _kmh_to_kts(row["wind_speed_10m"])
     return (
-        perfect_cfg["min_kts"] <= row["wind_speed_10m"] <= perfect_cfg["max_kts"]
+        perfect_cfg["min_kts"] <= wind_speed_10m_kts <= perfect_cfg["max_kts"]
         and row["gust_factor"] <= perfect_cfg["max_gust_factor"]
         and row["shore_alignment"] >= perfect_cfg["min_shore_alignment"]
         and row["wind_steadiness"] <= perfect_cfg["max_wind_steadiness"]
@@ -44,13 +50,14 @@ def _is_perfect_storm(row: pd.Series, perfect_cfg: dict[str, Any]) -> bool:
 def _base_quality(
     wind_speed_10m: float, minimum_wind: float, bands_cfg: dict[str, Any]
 ) -> int:
-    if wind_speed_10m < minimum_wind:
+    wind_speed_10m_kts = _kmh_to_kts(wind_speed_10m)
+    if wind_speed_10m_kts < minimum_wind:
         return 1
-    if wind_speed_10m < bands_cfg["marginal"]["max_kts"]:
+    if wind_speed_10m_kts < bands_cfg["marginal"]["max_kts"]:
         return 2
-    if wind_speed_10m < bands_cfg["good_enough"]["max_kts"]:
+    if wind_speed_10m_kts < bands_cfg["good_enough"]["max_kts"]:
         return 3
-    if wind_speed_10m <= bands_cfg["fun_day"]["max_kts"]:
+    if wind_speed_10m_kts <= bands_cfg["fun_day"]["max_kts"]:
         return 4
     return 3
 
@@ -59,9 +66,11 @@ def _score_row(
     row: pd.Series, labeling_cfg: dict[str, Any], minimum_wind: float
 ) -> int:
     dangerous_cfg = labeling_cfg["dangerous"]
+    wind_speed_10m_kts = _kmh_to_kts(row["wind_speed_10m"])
+    wind_gusts_10m_kts = _kmh_to_kts(row["wind_gusts_10m"])
     if (
-        row["wind_speed_10m"] > dangerous_cfg["max_wind_speed_10m_kts"]
-        or row["wind_gusts_10m"] > dangerous_cfg["max_wind_gusts_10m_kts"]
+        wind_speed_10m_kts > dangerous_cfg["max_wind_speed_10m_kts"]
+        or wind_gusts_10m_kts > dangerous_cfg["max_wind_gusts_10m_kts"]
     ):
         return 0
 

--- a/tests/test_label.py
+++ b/tests/test_label.py
@@ -5,14 +5,30 @@ import pytest
 
 from foehncast.training_pipeline.label import compute_quality_index, label_dataset
 
+_KMH_PER_KNOT = 1.852
+
 
 @pytest.fixture()
 def labeled_features_df() -> pd.DataFrame:
     """Feature rows that should hit each quality bucket."""
     return pd.DataFrame(
         {
-            "wind_speed_10m": [45.0, 10.0, 16.0, 19.0, 26.0, 20.0],
-            "wind_gusts_10m": [46.0, 12.0, 18.0, 21.0, 28.0, 22.0],
+            "wind_speed_10m": [
+                45.0 * _KMH_PER_KNOT,
+                10.0 * _KMH_PER_KNOT,
+                16.0 * _KMH_PER_KNOT,
+                19.0 * _KMH_PER_KNOT,
+                26.0 * _KMH_PER_KNOT,
+                20.0 * _KMH_PER_KNOT,
+            ],
+            "wind_gusts_10m": [
+                46.0 * _KMH_PER_KNOT,
+                12.0 * _KMH_PER_KNOT,
+                18.0 * _KMH_PER_KNOT,
+                21.0 * _KMH_PER_KNOT,
+                28.0 * _KMH_PER_KNOT,
+                22.0 * _KMH_PER_KNOT,
+            ],
             "wind_steadiness": [0.10, 0.30, 0.25, 0.22, 0.18, 0.15],
             "gust_factor": [1.02, 1.20, 1.12, 1.10, 1.08, 1.10],
             "shore_alignment": [0.90, 0.10, 0.20, 0.30, 0.60, 0.85],
@@ -31,8 +47,8 @@ class TestComputeQualityIndex:
     def test_light_rider_uses_lower_minimum_wind_threshold(self):
         features_df = pd.DataFrame(
             {
-                "wind_speed_10m": [13.0],
-                "wind_gusts_10m": [15.0],
+                "wind_speed_10m": [13.0 * _KMH_PER_KNOT],
+                "wind_gusts_10m": [15.0 * _KMH_PER_KNOT],
                 "wind_steadiness": [0.25],
                 "gust_factor": [1.15],
                 "shore_alignment": [0.20],


### PR DESCRIPTION
What changed:
- Convert synthetic label scoring to compare wind speed and gust values in knots before evaluating dangerous, minimum-wind, and perfect-storm thresholds.
- Update label tests so the input values are explicit km/h feature values with stable bucket expectations.

Why:
- The curated feature pipeline stores wind values in km/h while the labeling thresholds are configured in knots.
- This keeps the training labels aligned with the current feature data contract.

Verification:
- /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/python -m pytest tests/test_label.py tests/test_train.py

Closes: #66
