### PR TITLE
chore(terraform): add guarded remote destroy path

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -17,6 +17,12 @@ on:
         options:
           - plan
           - apply
+          - destroy
+      destroy_confirmation:
+        description: For destroy only, type the resolved GCP project id to confirm
+          remote teardown
+        required: false
+        type: string
       project_id:
         description: GCP project id
         required: false
@@ -218,6 +224,8 @@ jobs:
             bigquery_feature_table_id='forecast_features'
           fi
 
+          terraform_command="${{ inputs.command }}"
+          destroy_confirmation="${{ inputs.destroy_confirmation }}"
           provision_cloud_run_service="${{ inputs.provision_cloud_run_service }}"
           mlflow_tracking_uri="${{ inputs.mlflow_tracking_uri }}"
           provision_online_compose_host="${{ inputs.provision_online_compose_host }}"
@@ -229,6 +237,8 @@ jobs:
           github_repository="${{ github.event.repository.name }}"
 
           {
+            echo "TF_COMMAND=${terraform_command}"
+            echo "TF_DESTROY_CONFIRMATION=${destroy_confirmation}"
             echo "TF_VAR_project_id=${project_id}"
             echo "TF_VAR_region=${region}"
             echo "TF_VAR_artifact_bucket_name=${artifact_bucket_name}"
@@ -249,10 +259,35 @@ jobs:
             echo "TF_STATE_PREFIX=${state_prefix}"
           } >> "$GITHUB_ENV"
 
-      - name: Ensure Terraform state bucket exists
+      - name: Validate destroy confirmation
+        if: ${{ inputs.command == 'destroy' }}
         run: |
           set -euo pipefail
-          if ! gcloud storage buckets describe "gs://${TF_STATE_BUCKET}" --project "${TF_VAR_project_id}" >/dev/null 2>&1; then
+
+          if [[ -z "$TF_DESTROY_CONFIRMATION" ]]; then
+            echo "Set destroy_confirmation to the resolved GCP project id before running remote destroy." >&2
+            exit 1
+          fi
+
+          if [[ "$TF_DESTROY_CONFIRMATION" != "$TF_VAR_project_id" ]]; then
+            echo "destroy_confirmation must exactly match the resolved GCP project id (${TF_VAR_project_id})." >&2
+            exit 1
+          fi
+
+      - name: Ensure Terraform state backend is ready
+        run: |
+          set -euo pipefail
+
+          if gcloud storage buckets describe "gs://${TF_STATE_BUCKET}" --project "${TF_VAR_project_id}" >/dev/null 2>&1; then
+            exit 0
+          fi
+
+          if [[ "$TF_COMMAND" == 'destroy' ]]; then
+            echo "Remote state bucket gs://${TF_STATE_BUCKET} was not found. Remote destroy needs the existing backend state." >&2
+            exit 1
+          fi
+
+          if [[ "$TF_COMMAND" == 'plan' || "$TF_COMMAND" == 'apply' ]]; then
             gcloud storage buckets create "gs://${TF_STATE_BUCKET}" \
               --project "${TF_VAR_project_id}" \
               --location "${TF_VAR_region}" \
@@ -266,10 +301,17 @@ jobs:
             -backend-config="prefix=${TF_STATE_PREFIX}"
 
       - name: Terraform plan
-        run: terraform -chdir=terraform plan -out=tfplan
+        run: |
+          set -euo pipefail
 
-      - name: Terraform apply
-        if: ${{ inputs.command == 'apply' }}
+          if [[ "$TF_COMMAND" == 'destroy' ]]; then
+            terraform -chdir=terraform plan -destroy -out=tfplan
+          else
+            terraform -chdir=terraform plan -out=tfplan
+          fi
+
+      - name: Terraform apply chosen plan
+        if: ${{ inputs.command == 'apply' || inputs.command == 'destroy' }}
         run: terraform -chdir=terraform apply -auto-approve tfplan
 
       - name: Sync repository variables
@@ -302,4 +344,18 @@ jobs:
             echo "- Airflow URL: $(render_output online_compose_airflow_url host-local-by-default)"
             echo "- MLflow URL: $(render_output online_compose_mlflow_url host-local-by-default)"
             echo "- Cloud Run URL: $(terraform -chdir=terraform output -raw cloud_run_service_url 2>/dev/null || echo not-provisioned)"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Summarize destroy
+        if: ${{ inputs.command == 'destroy' }}
+        run: |
+          set -euo pipefail
+
+          {
+            echo "## Terraform destroy"
+            echo
+            echo "- Project: ${TF_VAR_project_id}"
+            echo "- State bucket: gs://${TF_STATE_BUCKET}"
+            echo "- Terraform-managed resources in the remote backend were targeted for destroy."
+            echo "- GitHub repository variables and the state bucket remain for deliberate follow-up cleanup."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/teardown-gcp.sh
+++ b/scripts/teardown-gcp.sh
@@ -167,6 +167,7 @@ fi
 if [[ "$PLAN_ONLY" == "true" ]]; then
   if [[ "$HAS_LOCAL_TERRAFORM_STATE" == "false" ]]; then
     echo "No local Terraform state was found in ${ROOT_DIR}/terraform. Nothing to preview in this working copy."
+    echo "If this environment was provisioned through the remote Terraform backend, use the GitHub Actions Terraform workflow with command=destroy instead."
   else
     require_command terraform
     require_file "$TFVARS_FILE" "Terraform variables file not found: $TFVARS_FILE. Reuse the file created for provisioning so destroy targets the same settings."
@@ -200,6 +201,7 @@ fi
 
 if [[ "$HAS_LOCAL_TERRAFORM_STATE" == "false" && "$CLEAR_GITHUB_ACTIONS" != "true" && "$DELETE_STATE_BUCKET" != "true" && "$DELETE_PROJECT" != "true" ]]; then
   echo "No local Terraform state was found in ${ROOT_DIR}/terraform. Nothing to destroy in this working copy."
+  echo "If the environment was created from the remote backend, run the GitHub Actions Terraform workflow with command=destroy and the matching destroy_confirmation value."
   exit 0
 fi
 
@@ -224,6 +226,7 @@ if [[ "$HAS_LOCAL_TERRAFORM_STATE" == "true" ]]; then
   TERRAFORM_DESTROYED=true
 else
   echo "No local Terraform state was found in ${ROOT_DIR}/terraform. Skipping Terraform destroy path."
+  echo "Use the remote GitHub Actions Terraform workflow if the active environment is managed through the remote backend."
 fi
 
 if [[ "$CLEAR_GITHUB_ACTIONS" == "true" ]]; then

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -100,6 +100,10 @@ Review the destroy preview, then rerun `./scripts/teardown-gcp.sh` without `--pl
 
 This teardown utility is intended for the local bootstrap-and-test path. It destroys Terraform-managed resources from the local state in your working copy.
 
+For environments managed through the remote backend, use the manual GitHub Actions Terraform workflow with `command=destroy`. The remote path uses the same OIDC-authenticated backend as remote apply and requires `destroy_confirmation` to exactly match the resolved GCP project id before it will continue.
+
+Remote destroy intentionally stops at Terraform-managed resources tracked in the remote backend. GitHub repository variables, the Terraform state bucket, and optional project deletion remain deliberate follow-up cleanup steps.
+
 ## GitHub Delivery Inputs
 
 The repository uses two delivery workflows:
@@ -139,7 +143,9 @@ When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow
 
 ## GitHub Actions Terraform Path
 
-Use `.github/workflows/terraform.yml` to run validate, plan, or apply from GitHub Actions without requiring local Terraform. The manual workflow bootstraps the GCS backend bucket if needed, runs Terraform against that backend, and can sync the GitHub repository variables after a successful apply.
+Use `.github/workflows/terraform.yml` to run validate, plan, apply, or destroy from GitHub Actions without requiring local Terraform. The manual workflow bootstraps the GCS backend bucket if needed for remote plan or apply, runs Terraform against that backend, and can sync the GitHub repository variables after a successful apply.
+
+For `command=destroy`, the workflow does not create a missing backend bucket. Instead it fails fast unless the remote state backend already exists, and it requires `destroy_confirmation` to match the resolved GCP project id. That keeps remote teardown explicit and tied to the same state that created the environment.
 
 Authentication options:
 


### PR DESCRIPTION
What changed:
- added a guarded `destroy` path to the GitHub Actions Terraform workflow
- required an explicit `destroy_confirmation` value that must match the resolved GCP project id
- documented when to use remote destroy versus the local teardown helper
- pointed the local teardown helper at the remote workflow when no local Terraform state is present

Why:
- remove the contributor-laptop dependency for cloud teardown when the environment is managed through the remote backend
- keep the remote infrastructure lifecycle symmetric with the existing remote plan and apply path

Verification:
- `python3 - <<'PY' ... yaml.safe_load(Path('.github/workflows/terraform.yml').read_text()) ... PY`
- `bash -n scripts/teardown-gcp.sh`
- `mkdocs build -f docs/mkdocs.yml --strict`

Closes: #75
