### PR TITLE
docs: split onboarding and prefer Cloud Shell for cloud bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,10 +39,10 @@ docs-build:  ## Build the documentation site
 docs-serve:  ## Serve the documentation site locally
 	cd $(ROOT_DIR) && uv sync --group docs && uv run mkdocs serve -f docs/mkdocs.yml
 
-bootstrap-local:  ## Rebuild and validate the local stack from scratch
+bootstrap-local:  ## Rebuild and validate the GCP-free local evaluator stack from scratch
 	cd $(ROOT_DIR) && ./scripts/bootstrap-local.sh
 
-bootstrap-gcp:  ## Run the interactive GCP bootstrap
+bootstrap-gcp:  ## Run the cloud-operator GCP bootstrap (prefer Cloud Shell)
 	cd $(ROOT_DIR) && ./scripts/bootstrap-gcp.sh
 
 compose-up:  ## Start the local compose stack

--- a/README.md
+++ b/README.md
@@ -58,13 +58,15 @@ flowchart TB
 | CI/CD path | Working | GitHub Actions publishes runtime images and can drive Terraform remotely |
 | Local reproducibility | Working | `./scripts/bootstrap-local.sh` builds the local stack from a clean state and validates it |
 
-## Local Quick Start
+## Local Evaluator Quick Start
 
-This is the default path for a fresh machine.
+This is the default path for a fresh machine, and it is intentionally GCP-free.
 
 1. Install Docker.
 2. Clone the repository.
 3. Run `./scripts/bootstrap-local.sh`.
+
+You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 
 `make` is optional in this repository. The committed `Makefile` only provides shortcut targets for the same `uv`, Docker Compose, and helper-script commands documented here. Contributors who do not use `make` can run the underlying commands directly, and Windows users may prefer WSL for the shell-based shortcuts.
 
@@ -100,11 +102,19 @@ curl -fsS -X POST http://127.0.0.1:8000/rank \
   -d '{"spot_ids":["silvaplana","urnersee"]}'
 ```
 
-## Personal GCP Quick Start
+## Cloud Operator Quick Start
 
-Use this when a collaborator wants a private FoehnCast environment in their own GCP project.
+Use this only when you want to provision a hosted FoehnCast environment in a GCP project you control. This is a separate operator path from the default local evaluator setup.
 
-Install:
+Preferred environment:
+
+1. Open Google Cloud Shell.
+2. Clone the repository there.
+3. Run `./scripts/bootstrap-gcp.sh`.
+
+This keeps `gcloud`, Terraform, project creation, billing linkage, and Terraform state handling in an admin shell instead of on the evaluator machine.
+
+Alternative local admin shell:
 
 - Google Cloud CLI (`gcloud`)
 - Terraform
@@ -117,6 +127,8 @@ Run:
 ```
 
 The interactive setup signs you into GCP, lets you pick or create a project, confirms region and storage defaults, optionally provisions Cloud Run, and can align GitHub Actions variables for your own fork. During setup it writes `.env` and `terraform/terraform.tfvars`, then refreshes them from Terraform outputs after apply.
+
+After the first bootstrap, prefer the remote Terraform workflow for day-2 plan, apply, destroy, and cleanup operations.
 
 Useful variants:
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -50,6 +50,8 @@ flowchart LR
 
 For the shortest evaluator path, run `./scripts/bootstrap-local.sh` from the repo root. It builds the local stack, seeds the feature and training DAGs, and checks the API health endpoint.
 
+This path is intentionally GCP-free. You do not need `gcloud`, Terraform, GitHub Actions variables, or Cloud Shell to run it.
+
 The default local path keeps feature data on local files, starts Airflow and MLflow without a login, and resets local Docker volumes for a clean run each time.
 Optional S3-compatible settings can be injected through the environment for experiments, but they are not part of the default local stack.
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -22,6 +22,8 @@ Public GHCR images are convenience artifacts for reuse. They do not provide shar
 
 The repository keeps local evaluation and maintainer-managed automation separate, so forks can reuse the same deployment shape with their own approvals and cloud accounts.
 
+Default onboarding follows that same split: use `./scripts/bootstrap-local.sh` for a GCP-free local evaluator path, and use `./scripts/bootstrap-gcp.sh` only for cloud operator bootstrap, preferably from Google Cloud Shell.
+
 ## What Works
 
 | Area | Current state | What it means |

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -21,6 +21,24 @@ INTERACTIVE=true
 
 usage() {
   echo "Usage: $0 [--env-file path] [--tfvars-file path] [--plan-only] [--auto-approve] [--configure-github-actions] [--repo owner/repo] [--non-interactive]" >&2
+  echo "Use ./scripts/bootstrap-local.sh for the default local evaluator path." >&2
+  echo "Prefer running this cloud bootstrap from Google Cloud Shell when possible." >&2
+}
+
+in_cloud_shell() {
+  [[ -n "${CLOUD_SHELL:-}" || -n "${DEVSHELL_PROJECT_ID:-}" ]]
+}
+
+print_bootstrap_context() {
+  echo "Cloud bootstrap provisions a hosted GCP environment."
+  echo "For the default local evaluator path, use ./scripts/bootstrap-local.sh instead."
+
+  if in_cloud_shell; then
+    echo "Execution context: Google Cloud Shell (preferred for first-time cloud bootstrap)."
+  else
+    echo "Execution context: local admin shell."
+    echo "Tip: run this script from Google Cloud Shell if you want to avoid installing gcloud and Terraform on your local machine."
+  fi
 }
 
 require_file() {
@@ -507,6 +525,8 @@ if [[ -n "$TARGET_REPO" ]]; then
   CONFIGURE_GITHUB=true
 fi
 
+print_bootstrap_context
+
 require_command gcloud
 require_command terraform
 
@@ -573,9 +593,12 @@ fi
 
 echo "Bootstrap complete for ${GCP_PROJECT_ID}."
 echo "The interactive path can create or reuse a project and link billing when your gcloud account has permission to do so."
+echo "For local evaluation, keep using ./scripts/bootstrap-local.sh."
 
 if [[ "$CONFIGURE_GITHUB" == "true" && "$PLAN_ONLY" != "true" ]]; then
   echo "GitHub Actions variables were synchronized for repo-driven deployment automation."
+  echo "Prefer the remote GitHub Actions Terraform workflow for day-2 plan, apply, destroy, and cleanup."
 else
   echo "GitHub Actions were not changed. That is fine for personal one-off environments."
+  echo "When you later configure GitHub OIDC variables, prefer the remote GitHub Actions Terraform workflow for day-2 plan, apply, destroy, and cleanup."
 fi

--- a/scripts/cli-common.sh
+++ b/scripts/cli-common.sh
@@ -12,12 +12,14 @@ install_hint() {
       ;;
     gcloud)
       echo "Install Google Cloud CLI first. On macOS with Homebrew: brew install --cask google-cloud-sdk" >&2
+      echo "Alternative: run the cloud bootstrap from Google Cloud Shell instead of installing it locally." >&2
       ;;
     gh)
       echo "Install GitHub CLI first. On macOS with Homebrew: brew install gh" >&2
       ;;
     terraform)
       echo "Install Terraform first. On macOS with Homebrew: brew tap hashicorp/tap && brew install hashicorp/tap/terraform" >&2
+      echo "Alternative: run the cloud bootstrap from Google Cloud Shell instead of installing it locally." >&2
       ;;
     uv)
       echo "Install uv first. On macOS with Homebrew: brew install uv" >&2

--- a/scripts/gcp-auth.sh
+++ b/scripts/gcp-auth.sh
@@ -21,6 +21,11 @@ ensure_gcloud_auth
 
 gcloud auth configure-docker "${GCP_LOCATION}-docker.pkg.dev"
 
-echo "Configured gcloud CLI, ADC, and Artifact Registry auth for ${GCP_PROJECT_ID} in ${GCP_LOCATION}."
+if [[ -n "${CLOUD_SHELL:-}" || -n "${DEVSHELL_PROJECT_ID:-}" ]]; then
+	echo "Configured Cloud Shell gcloud, ADC, and Artifact Registry auth for ${GCP_PROJECT_ID} in ${GCP_LOCATION}."
+else
+	echo "Configured local gcloud, ADC, and Artifact Registry auth for ${GCP_PROJECT_ID} in ${GCP_LOCATION}."
+	echo "Prefer Google Cloud Shell for first-time cloud bootstrap. Use this local helper when Docker services need GCP access."
+fi
 echo "For local BigQuery-backed containers, run Docker Compose with -f docker-compose.yml -f docker-compose.gcp.yml so ADC is mounted into the Linux services."
 echo "Use GitHub OIDC for CI/CD and avoid storing service account keys in this repository."

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -161,9 +161,11 @@ The recommended remote retirement sequence is:
 Authentication options:
 
 - remote workflow path: GitHub OIDC variables already exist from a previous apply
-- initial bootstrap path: run `./scripts/bootstrap-gcp.sh` locally, then `./scripts/configure-github-actions.sh` before using the remote workflow
+- initial bootstrap path: run `./scripts/bootstrap-gcp.sh` in Google Cloud Shell or another admin shell, then `./scripts/configure-github-actions.sh` before using the remote workflow
 
 Remote Terraform is OIDC-only. Missing repository variables should fail fast instead of falling back to a separate secret-based auth path.
+
+After the first bootstrap has created the workload identity provider, deployer service account, and repository variables, prefer the remote workflow for day-2 plan, apply, destroy, and cleanup work.
 
 ## Shared Repo vs Personal Deployments
 
@@ -180,7 +182,7 @@ State-changing upstream jobs should also use protected GitHub environments:
 
 For a personal deployment:
 
-- run `./scripts/bootstrap-gcp.sh` locally, or
+- run `./scripts/bootstrap-gcp.sh` in Google Cloud Shell or another admin shell, or
 - fork the repository and configure the same GitHub Actions variables and secrets in that fork
 
 That keeps billing, package ownership, and cloud credentials aligned with the person or team operating the environment. Compute, storage, and network costs stay with that operator.
@@ -191,9 +193,13 @@ That keeps billing, package ownership, and cloud credentials aligned with the pe
 2. Use this file when you need the Terraform-specific deployment inputs and teardown steps.
 3. Use `docs/site/system/cloud-mapping.md` when you want the higher-level architecture explanation.
 
-## Interactive Setup
+## Cloud Operator Bootstrap
 
-Run this on a fresh clone if you want the browser-authenticated local bootstrap:
+Use this only for the initial hosted-environment bootstrap, or when you intentionally need direct admin access to the cloud project.
+
+Preferred environment: Google Cloud Shell. That keeps the admin toolchain off the default evaluator machine and matches the intended operator path.
+
+Run this in Cloud Shell or another admin shell:
 
 `./scripts/bootstrap-gcp.sh`
 
@@ -217,7 +223,7 @@ Examples:
 
 The script writes `.env` and `terraform/terraform.tfvars` during setup.
 
-After Terraform apply, the script refreshes `.env` with the managed project ID, bucket, BigQuery dataset and table, and Cloud Run service name. Authentication itself stays in local `gcloud` application default credentials, while Terraform creates the runtime service accounts for Cloud Run and GitHub delivery.
+After Terraform apply, the script refreshes `.env` with the managed project ID, bucket, BigQuery dataset and table, and Cloud Run service name. Authentication itself stays in the active `gcloud` application default credentials for the admin shell you used, while Terraform creates the runtime service accounts for Cloud Run and GitHub delivery.
 
 To restart from scratch:
 
@@ -228,6 +234,8 @@ If you already know all values and want a rerun without prompts:
 `./scripts/bootstrap-gcp.sh --non-interactive`
 
 ## Local BigQuery Use
+
+This section is separate from the default local evaluator path and from the Cloud Shell bootstrap path. Use it only when your local Docker services need direct BigQuery access.
 
 1. Bootstrap your local GCP session:
    `./scripts/gcp-auth.sh`


### PR DESCRIPTION
## Summary
- split the public onboarding story between the GCP-free local evaluator path and the cloud operator bootstrap path
- make Cloud Shell the preferred execution environment for first-time `bootstrap-gcp.sh` runs
- update helper messaging so local users are redirected toward `bootstrap-local.sh` and day-2 cloud changes toward the remote Terraform workflow

## Testing
- `bash -n scripts/bootstrap-gcp.sh scripts/gcp-auth.sh scripts/cli-common.sh`
- `/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/python -m mkdocs build -f docs/mkdocs.yml --strict`

Closes #79
