### PR TITLE
chore(terraform): add remote workflow helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,9 @@
-.PHONY: help install install-docs install-feast lock lint format test test-feature check docs-build docs-serve bootstrap-local bootstrap-gcp compose-up compose-down compose-ps compose-logs dev-build dev-rebuild dev-shell notebook-server notebook-stop feast-prepare
+.PHONY: help install install-docs install-feast lock lint format test test-feature check docs-build docs-serve bootstrap-local bootstrap-gcp terraform-remote compose-up compose-down compose-ps compose-logs dev-build dev-rebuild dev-shell notebook-server notebook-stop feast-prepare
 
 ROOT_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DATASET ?= train
 JUPYTER_TOKEN ?= foehncast-local
+TF_REMOTE_ARGS ?= plan
 
 help:  ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-24s %s\n", $$1, $$2}'
@@ -44,6 +45,9 @@ bootstrap-local:  ## Rebuild and validate the GCP-free local evaluator stack fro
 
 bootstrap-gcp:  ## Run the cloud-operator GCP bootstrap (prefer Cloud Shell)
 	cd $(ROOT_DIR) && ./scripts/bootstrap-gcp.sh
+
+terraform-remote:  ## Trigger the remote Terraform workflow with TF_REMOTE_ARGS='<command> [flags]'
+	cd $(ROOT_DIR) && ./scripts/terraform-remote.sh $(TF_REMOTE_ARGS)
 
 compose-up:  ## Start the local compose stack
 	cd $(ROOT_DIR) && docker compose up -d

--- a/README.md
+++ b/README.md
@@ -130,6 +130,13 @@ The interactive setup signs you into GCP, lets you pick or create a project, con
 
 After the first bootstrap, prefer the remote Terraform workflow for day-2 plan, apply, destroy, and cleanup operations.
 
+Common remote operator commands:
+
+- Review the current remote plan: `./scripts/terraform-remote.sh plan`
+- Apply the current remote configuration: `./scripts/terraform-remote.sh apply`
+- Retire a remote environment: `./scripts/terraform-remote.sh destroy`
+- Follow destroy with post-destroy cleanup: `./scripts/terraform-remote.sh cleanup --cleanup-delete-state-bucket --cleanup-clear-github-actions`
+
 Useful variants:
 
 - Restart from scratch: `rm -f .env terraform/terraform.tfvars && ./scripts/bootstrap-gcp.sh`
@@ -143,7 +150,7 @@ Useful variants:
 Use the online compose-host path when you want Airflow, MLflow, and the API running together in the cloud.
 
 1. Publish the runtime images with the `Publish Runtime Images` workflow, or let the host build once from the repo if the images are not published yet.
-2. Run the `Terraform` workflow with `apply` and set `provision_online_compose_host=true`.
+2. Run `./scripts/terraform-remote.sh apply --input provision_online_compose_host=true`, or trigger the `Terraform` workflow manually with the same input.
 3. Provide at least:
    - `project_id`
    - `artifact_bucket_name`
@@ -165,7 +172,9 @@ Cloud Run stays available as an inference-only path for the app service.
 - Provide `mlflow_tracking_uri` so the service can reach the registry.
 - Publish the app image through the Artifact Registry plus Cloud Run workflow path.
 
-When you finish a disposable cloud test, run `./scripts/teardown-gcp.sh --plan-only` first to preview the destroy, then rerun without `--plan-only` when you are ready to remove the Terraform-managed resources created from your local `.env` and `terraform/terraform.tfvars`. In a fresh clone with no local Terraform state, the helper skips the Terraform destroy path cleanly. `--clear-github-actions`, `--delete-state-bucket`, and `--delete-project` still work as explicit cleanup actions when you request them. `--delete-project` is intended for disposable smoke environments where you also want the bootstrap-created GCP project queued for deletion, and it prompts for the exact project id unless you also pass `--auto-approve`.
+When you finish a disposable cloud test created from the local bootstrap path, run `./scripts/teardown-gcp.sh --plan-only` first to preview the destroy, then rerun without `--plan-only` when you are ready to remove the Terraform-managed resources created from your local `.env` and `terraform/terraform.tfvars`. In a fresh clone with no local Terraform state, the helper skips the Terraform destroy path cleanly. `--clear-github-actions`, `--delete-state-bucket`, and `--delete-project` still work as explicit cleanup actions when you request them. `--delete-project` is intended for disposable smoke environments where you also want the bootstrap-created GCP project queued for deletion, and it prompts for the exact project id unless you also pass `--auto-approve`.
+
+For environments managed through the remote backend, use `./scripts/terraform-remote.sh destroy` and then `./scripts/terraform-remote.sh cleanup --cleanup-delete-state-bucket --cleanup-clear-github-actions` instead of local Terraform.
 
 ## Deployment Ownership
 
@@ -182,7 +191,7 @@ When you finish a disposable cloud test, run `./scripts/teardown-gcp.sh --plan-o
 - `.github/workflows/terraform.yml`: runs Terraform validate on changes and supports manual remote plan or apply with a GCS backend.
 - `.github/workflows/publish-app-image.yml`: keeps the optional Artifact Registry plus Cloud Run path for the inference API.
 
-`./scripts/configure-github-actions.sh` syncs the GCP deploy variables plus the Terraform state bucket defaults back into the repository. When Cloud Run is not provisioned yet, it leaves `GCP_CLOUD_RUN_SERVICE` unset so the guarded workflow stays skipped without carrying stale values.
+`./scripts/configure-github-actions.sh` syncs the GCP deploy variables plus the Terraform state bucket defaults back into the repository. When Cloud Run is not provisioned yet, it leaves `GCP_CLOUD_RUN_SERVICE` unset so the guarded workflow stays skipped without carrying stale values. After that initial sync, use `./scripts/terraform-remote.sh` for common remote Terraform commands instead of keeping local Terraform in the loop.
 
 ## Optional Feast
 

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -598,7 +598,9 @@ echo "For local evaluation, keep using ./scripts/bootstrap-local.sh."
 if [[ "$CONFIGURE_GITHUB" == "true" && "$PLAN_ONLY" != "true" ]]; then
   echo "GitHub Actions variables were synchronized for repo-driven deployment automation."
   echo "Prefer the remote GitHub Actions Terraform workflow for day-2 plan, apply, destroy, and cleanup."
+  echo "Common remote command: ./scripts/terraform-remote.sh plan"
 else
   echo "GitHub Actions were not changed. That is fine for personal one-off environments."
   echo "When you later configure GitHub OIDC variables, prefer the remote GitHub Actions Terraform workflow for day-2 plan, apply, destroy, and cleanup."
+  echo "After syncing GitHub Actions variables, use ./scripts/terraform-remote.sh for common remote Terraform commands."
 fi

--- a/scripts/configure-github-actions.sh
+++ b/scripts/configure-github-actions.sh
@@ -148,3 +148,4 @@ else
 fi
 
 echo "GitHub Actions variables are configured for ${REPOSITORY_PATH}."
+echo "Use ./scripts/terraform-remote.sh for common remote Terraform plan, apply, destroy, and cleanup commands."

--- a/scripts/teardown-gcp.sh
+++ b/scripts/teardown-gcp.sh
@@ -167,7 +167,7 @@ fi
 if [[ "$PLAN_ONLY" == "true" ]]; then
   if [[ "$HAS_LOCAL_TERRAFORM_STATE" == "false" ]]; then
     echo "No local Terraform state was found in ${ROOT_DIR}/terraform. Nothing to preview in this working copy."
-    echo "If this environment was provisioned through the remote Terraform backend, use the GitHub Actions Terraform workflow with command=destroy instead."
+    echo "If this environment was provisioned through the remote Terraform backend, use ./scripts/terraform-remote.sh destroy instead."
   else
     require_command terraform
     require_file "$TFVARS_FILE" "Terraform variables file not found: $TFVARS_FILE. Reuse the file created for provisioning so destroy targets the same settings."
@@ -201,7 +201,7 @@ fi
 
 if [[ "$HAS_LOCAL_TERRAFORM_STATE" == "false" && "$CLEAR_GITHUB_ACTIONS" != "true" && "$DELETE_STATE_BUCKET" != "true" && "$DELETE_PROJECT" != "true" ]]; then
   echo "No local Terraform state was found in ${ROOT_DIR}/terraform. Nothing to destroy in this working copy."
-  echo "If the environment was created from the remote backend, run the GitHub Actions Terraform workflow with command=destroy and the matching destroy_confirmation value."
+  echo "If the environment was created from the remote backend, run ./scripts/terraform-remote.sh destroy."
   exit 0
 fi
 
@@ -226,7 +226,7 @@ if [[ "$HAS_LOCAL_TERRAFORM_STATE" == "true" ]]; then
   TERRAFORM_DESTROYED=true
 else
   echo "No local Terraform state was found in ${ROOT_DIR}/terraform. Skipping Terraform destroy path."
-  echo "Use the remote GitHub Actions Terraform workflow if the active environment is managed through the remote backend."
+  echo "Use ./scripts/terraform-remote.sh when the active environment is managed through the remote backend."
 fi
 
 if [[ "$CLEAR_GITHUB_ACTIONS" == "true" ]]; then

--- a/scripts/terraform-remote.sh
+++ b/scripts/terraform-remote.sh
@@ -1,0 +1,276 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE="${ROOT_DIR}/.env"
+WORKFLOW_FILE="terraform.yml"
+TARGET_REPO=""
+REF=""
+COMMAND=""
+PROJECT_ID=""
+REGION=""
+DRY_RUN=false
+CLEANUP_CLEAR_GITHUB_ACTIONS=false
+CLEANUP_DELETE_STATE_BUCKET=false
+EXTRA_INPUTS=()
+
+# shellcheck disable=SC1091
+source "${ROOT_DIR}/scripts/cli-common.sh"
+# shellcheck disable=SC1091
+source "${ROOT_DIR}/scripts/github-common.sh"
+# shellcheck disable=SC1091
+source "${ROOT_DIR}/scripts/gcp-common.sh"
+
+usage() {
+  echo "Usage: $0 <plan|apply|destroy|cleanup> [--repo owner/repo] [--ref branch] [--env-file path] [--project-id id] [--region region] [--input key=value] [--cleanup-clear-github-actions] [--cleanup-delete-state-bucket] [--dry-run]" >&2
+}
+
+normalize_bool() {
+  local value="$1"
+
+  case "$value" in
+    true|false)
+      printf '%s\n' "$value"
+      ;;
+    *)
+      echo "Boolean value must be true or false, got: ${value}" >&2
+      exit 1
+      ;;
+  esac
+}
+
+repo_variable_value() {
+  local repository_path="$1"
+  local variable_name="$2"
+  local value
+
+  value="$(gh variable list --repo "$repository_path" --json name,value --jq ".[] | select(.name == \"${variable_name}\").value" 2>/dev/null || true)"
+  if [[ "$value" == "null" ]]; then
+    value=""
+  fi
+
+  printf '%s\n' "$value"
+}
+
+record_input() {
+  local input="$1"
+  local key value
+
+  if [[ "$input" != *=* ]]; then
+    echo "--input expects key=value, got: ${input}" >&2
+    exit 1
+  fi
+
+  key="${input%%=*}"
+  value="${input#*=}"
+
+  case "$key" in
+    command|destroy_confirmation|cleanup_confirmation)
+      echo "${key} is managed by this helper. Use the positional command and flags instead." >&2
+      exit 1
+      ;;
+    project_id)
+      PROJECT_ID="$value"
+      ;;
+    region)
+      REGION="$value"
+      ;;
+    cleanup_clear_github_actions)
+      CLEANUP_CLEAR_GITHUB_ACTIONS="$(normalize_bool "$value")"
+      ;;
+    cleanup_delete_state_bucket)
+      CLEANUP_DELETE_STATE_BUCKET="$(normalize_bool "$value")"
+      ;;
+    *)
+      EXTRA_INPUTS+=("$input")
+      ;;
+  esac
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    plan|apply|destroy|cleanup)
+      if [[ -n "$COMMAND" ]]; then
+        usage
+        exit 1
+      fi
+      COMMAND="$1"
+      ;;
+    --repo)
+      shift
+      TARGET_REPO="${1:-}"
+      if [[ -z "$TARGET_REPO" ]]; then
+        usage
+        exit 1
+      fi
+      ;;
+    --ref)
+      shift
+      REF="${1:-}"
+      if [[ -z "$REF" ]]; then
+        usage
+        exit 1
+      fi
+      ;;
+    --env-file)
+      shift
+      ENV_FILE="${1:-}"
+      if [[ -z "$ENV_FILE" ]]; then
+        usage
+        exit 1
+      fi
+      ;;
+    --project-id)
+      shift
+      PROJECT_ID="${1:-}"
+      if [[ -z "$PROJECT_ID" ]]; then
+        usage
+        exit 1
+      fi
+      ;;
+    --region)
+      shift
+      REGION="${1:-}"
+      if [[ -z "$REGION" ]]; then
+        usage
+        exit 1
+      fi
+      ;;
+    --input)
+      shift
+      if [[ -z "${1:-}" ]]; then
+        usage
+        exit 1
+      fi
+      record_input "$1"
+      ;;
+    --cleanup-clear-github-actions)
+      CLEANUP_CLEAR_GITHUB_ACTIONS=true
+      ;;
+    --cleanup-delete-state-bucket)
+      CLEANUP_DELETE_STATE_BUCKET=true
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+
+  shift
+done
+
+if [[ -z "$COMMAND" ]]; then
+  usage
+  exit 1
+fi
+
+if [[ "$COMMAND" != "cleanup" && ( "$CLEANUP_CLEAR_GITHUB_ACTIONS" == "true" || "$CLEANUP_DELETE_STATE_BUCKET" == "true" ) ]]; then
+  echo "Cleanup flags can only be used with the cleanup command." >&2
+  exit 1
+fi
+
+require_command gh
+
+if ! gh auth status >/dev/null 2>&1; then
+  echo "gh is installed but not authenticated. Run 'gh auth login' first." >&2
+  exit 1
+fi
+
+load_env_file "$ENV_FILE"
+
+REPOSITORY_PATH="$TARGET_REPO"
+if [[ -z "$REPOSITORY_PATH" ]]; then
+  REPOSITORY_PATH="$(require_repo_from_remote "$ROOT_DIR")"
+fi
+
+if [[ -z "$PROJECT_ID" ]]; then
+  PROJECT_ID="$(repo_variable_value "$REPOSITORY_PATH" GCP_PROJECT_ID)"
+fi
+if [[ -z "$PROJECT_ID" ]]; then
+  PROJECT_ID="${GCP_PROJECT_ID:-}"
+fi
+
+if [[ -z "$REGION" ]]; then
+  REGION="$(repo_variable_value "$REPOSITORY_PATH" GCP_LOCATION)"
+fi
+if [[ -z "$REGION" ]]; then
+  REGION="${GCP_LOCATION:-}"
+fi
+
+if [[ "$COMMAND" == "destroy" || "$COMMAND" == "cleanup" ]]; then
+  if [[ -z "$PROJECT_ID" ]]; then
+    echo "Resolve the GCP project id first with --project-id, repository variable GCP_PROJECT_ID, or .env before running ${COMMAND}." >&2
+    exit 1
+  fi
+fi
+
+if [[ "$COMMAND" == "cleanup" && "$CLEANUP_CLEAR_GITHUB_ACTIONS" != "true" && "$CLEANUP_DELETE_STATE_BUCKET" != "true" ]]; then
+  echo "Cleanup requires at least one action: --cleanup-clear-github-actions or --cleanup-delete-state-bucket." >&2
+  exit 1
+fi
+
+run_args=(gh workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY_PATH")
+if [[ -n "$REF" ]]; then
+  run_args+=(--ref "$REF")
+fi
+
+if [[ -n "$COMMAND" ]]; then
+  run_args+=( -f "command=${COMMAND}" )
+fi
+
+if [[ -n "$PROJECT_ID" ]]; then
+  run_args+=( -f "project_id=${PROJECT_ID}" )
+fi
+
+if [[ -n "$REGION" ]]; then
+  run_args+=( -f "region=${REGION}" )
+fi
+
+if [[ "$COMMAND" == "destroy" ]]; then
+  run_args+=( -f "destroy_confirmation=${PROJECT_ID}" )
+fi
+
+if [[ "$COMMAND" == "cleanup" ]]; then
+  run_args+=( -f "cleanup_confirmation=${PROJECT_ID}" )
+  run_args+=( -f "cleanup_clear_github_actions=${CLEANUP_CLEAR_GITHUB_ACTIONS}" )
+  run_args+=( -f "cleanup_delete_state_bucket=${CLEANUP_DELETE_STATE_BUCKET}" )
+fi
+
+for input in "${EXTRA_INPUTS[@]}"; do
+  run_args+=( -f "$input" )
+done
+
+echo "Triggering remote Terraform workflow on ${REPOSITORY_PATH}"
+echo "- command: ${COMMAND}"
+if [[ -n "$REF" ]]; then
+  echo "- ref: ${REF}"
+fi
+if [[ -n "$PROJECT_ID" ]]; then
+  echo "- project_id: ${PROJECT_ID}"
+else
+  echo "- project_id: deferred to repository variables or explicit workflow inputs"
+fi
+if [[ -n "$REGION" ]]; then
+  echo "- region: ${REGION}"
+fi
+if [[ "$COMMAND" == "cleanup" ]]; then
+  echo "- cleanup_clear_github_actions: ${CLEANUP_CLEAR_GITHUB_ACTIONS}"
+  echo "- cleanup_delete_state_bucket: ${CLEANUP_DELETE_STATE_BUCKET}"
+fi
+
+if [[ "$DRY_RUN" == "true" ]]; then
+  printf 'Dry run: '
+  printf '%q ' "${run_args[@]}"
+  printf '\n'
+  exit 0
+fi
+
+"${run_args[@]}"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -128,6 +128,8 @@ The easiest way to set them is:
 2. apply Terraform
 3. run `./scripts/configure-github-actions.sh`
 
+After that first sync, use `./scripts/terraform-remote.sh` for common remote Terraform plan, apply, destroy, and cleanup commands.
+
 The helper script reads the Terraform outputs, sets the required GitHub Actions variables on the repository remote, and leaves `GCP_CLOUD_RUN_SERVICE` unset until the Cloud Run service has actually been provisioned. It also writes the Terraform state bucket defaults used by the GitHub Actions Terraform workflow.
 
 Recommended mappings from Terraform-managed values:
@@ -144,6 +146,15 @@ When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow
 ## GitHub Actions Terraform Path
 
 Use `.github/workflows/terraform.yml` to run validate, plan, apply, destroy, or cleanup from GitHub Actions without requiring local Terraform. The manual workflow bootstraps the GCS backend bucket if needed for remote plan or apply, runs Terraform against that backend, and can sync the GitHub repository variables after a successful apply.
+
+For the common operator path, trigger that workflow with `./scripts/terraform-remote.sh` instead of opening the Actions UI manually.
+
+Examples:
+
+- `./scripts/terraform-remote.sh plan`
+- `./scripts/terraform-remote.sh apply`
+- `./scripts/terraform-remote.sh destroy`
+- `./scripts/terraform-remote.sh cleanup --cleanup-delete-state-bucket --cleanup-clear-github-actions`
 
 For `command=destroy`, the workflow does not create a missing backend bucket. Instead it fails fast unless the remote state backend already exists, and it requires `destroy_confirmation` to match the resolved GCP project id. That keeps remote teardown explicit and tied to the same state that created the environment.
 
@@ -165,7 +176,7 @@ Authentication options:
 
 Remote Terraform is OIDC-only. Missing repository variables should fail fast instead of falling back to a separate secret-based auth path.
 
-After the first bootstrap has created the workload identity provider, deployer service account, and repository variables, prefer the remote workflow for day-2 plan, apply, destroy, and cleanup work.
+After the first bootstrap has created the workload identity provider, deployer service account, and repository variables, prefer the remote workflow for day-2 plan, apply, destroy, and cleanup work through `./scripts/terraform-remote.sh` or the manual GitHub Actions UI.
 
 ## Shared Repo vs Personal Deployments
 


### PR DESCRIPTION
## Summary
- add a `gh`-based helper to trigger the remote Terraform workflow for common day-2 operator commands
- update bootstrap, GitHub-variable sync, teardown, and public docs to point operators at the helper instead of local Terraform for remote-backed environments
- add a Makefile shortcut for the new helper path

## Testing
- `bash -n scripts/bootstrap-gcp.sh scripts/configure-github-actions.sh scripts/teardown-gcp.sh scripts/terraform-remote.sh`
- `./scripts/terraform-remote.sh plan --repo javihslu/foehncast --dry-run`
- `./scripts/terraform-remote.sh destroy --repo javihslu/foehncast --project-id foehncast-demo --dry-run`
- `./scripts/terraform-remote.sh cleanup --repo javihslu/foehncast --project-id foehncast-demo --cleanup-delete-state-bucket --cleanup-clear-github-actions --dry-run`
- `/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/python -m mkdocs build -f docs/mkdocs.yml --strict`

Closes #81
