### PR TITLE
chore(terraform): add bootstrap-only setup path

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ The interactive setup signs you into GCP, lets you pick or create a project, con
 
 After the first bootstrap, prefer the remote Terraform workflow for day-2 plan, apply, destroy, and cleanup operations.
 
+If you want the smallest first-time local step, run `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions --repo <owner/repo>`. That path creates only the remote-control-plane prerequisites, stores that bootstrap state in the remote backend, and leaves the broader platform apply for `./scripts/terraform-remote.sh apply`.
+
 Common remote operator commands:
 
 - Review the current remote plan: `./scripts/terraform-remote.sh plan`
@@ -140,6 +142,7 @@ Common remote operator commands:
 Useful variants:
 
 - Restart from scratch: `rm -f .env terraform/terraform.tfvars && ./scripts/bootstrap-gcp.sh`
+- Bootstrap only the remote-control-plane prerequisites: `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions --repo <owner/repo>`
 - Skip prompts when you already know the values: `./scripts/bootstrap-gcp.sh --non-interactive`
 - Configure fork automation during bootstrap: `./scripts/bootstrap-gcp.sh --configure-github-actions --repo <your-github-user>/foehncast`
 

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -17,10 +17,11 @@ CONFIGURE_GITHUB=false
 TARGET_REPO=""
 PLAN_ONLY=false
 AUTO_APPROVE=false
+BOOTSTRAP_ONLY=false
 INTERACTIVE=true
 
 usage() {
-  echo "Usage: $0 [--env-file path] [--tfvars-file path] [--plan-only] [--auto-approve] [--configure-github-actions] [--repo owner/repo] [--non-interactive]" >&2
+  echo "Usage: $0 [--env-file path] [--tfvars-file path] [--plan-only] [--auto-approve] [--bootstrap-only] [--configure-github-actions] [--repo owner/repo] [--non-interactive]" >&2
   echo "Use ./scripts/bootstrap-local.sh for the default local evaluator path." >&2
   echo "Prefer running this cloud bootstrap from Google Cloud Shell when possible." >&2
 }
@@ -32,6 +33,10 @@ in_cloud_shell() {
 print_bootstrap_context() {
   echo "Cloud bootstrap provisions a hosted GCP environment."
   echo "For the default local evaluator path, use ./scripts/bootstrap-local.sh instead."
+
+  if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+    echo "Mode: bootstrap-only. This prepares the remote Terraform control plane and leaves the broader platform apply for the remote workflow."
+  fi
 
   if in_cloud_shell; then
     echo "Execution context: Google Cloud Shell (preferred for first-time cloud bootstrap)."
@@ -147,6 +152,43 @@ read_tfvars_value() {
     replace_or_append_line "$TFVARS_FILE" "^[[:space:]]*${key}[[:space:]]*=" "${key} = ${value}"
   }
 
+  terraform_remote_state_bucket() {
+    printf '%s\n' "${GCP_PROJECT_ID}-foehncast-tfstate"
+  }
+
+  terraform_remote_state_prefix() {
+    printf '%s\n' "terraform/state"
+  }
+
+  ensure_remote_state_bucket() {
+    local state_bucket
+
+    state_bucket="$(terraform_remote_state_bucket)"
+
+    if gcloud storage buckets describe "gs://${state_bucket}" --project "$GCP_PROJECT_ID" >/dev/null 2>&1; then
+      return
+    fi
+
+    echo "Creating remote Terraform state bucket gs://${state_bucket}..."
+    gcloud storage buckets create "gs://${state_bucket}" \
+      --project "$GCP_PROJECT_ID" \
+      --location "$GCP_LOCATION" \
+      --uniform-bucket-level-access
+  }
+
+  bootstrap_target_args() {
+    printf '%s\n' \
+      "-target=google_project_service.required" \
+      "-target=google_service_account.github_deployer" \
+      "-target=google_project_iam_member.github_project_admin" \
+      "-target=google_project_iam_member.github_artifact_registry_writer" \
+      "-target=google_project_iam_member.github_cloud_run_admin" \
+      "-target=google_project_iam_member.github_service_account_user" \
+      "-target=google_iam_workload_identity_pool.github" \
+      "-target=google_iam_workload_identity_pool_provider.github" \
+      "-target=google_service_account_iam_member.github_workload_identity_user"
+  }
+
   sync_env_from_terraform_outputs() {
     local cloud_run_service
 
@@ -179,6 +221,20 @@ read_tfvars_value() {
     if [[ -n "$FOEHNCAST_TF_CLOUD_RUN_SERVICE" ]]; then
       echo "Cloud Run service: ${FOEHNCAST_TF_CLOUD_RUN_SERVICE}"
     fi
+  }
+
+  print_bootstrap_only_summary() {
+    local state_bucket state_prefix
+
+    load_terraform_platform_state "${ROOT_DIR}/terraform"
+    state_bucket="$(terraform_remote_state_bucket)"
+    state_prefix="$(terraform_remote_state_prefix)"
+
+    echo "Bootstrap-only remote state bucket: gs://${state_bucket}"
+    echo "Bootstrap-only remote state prefix: ${state_prefix}"
+    echo "GitHub deployer service account: ${FOEHNCAST_TF_SERVICE_ACCOUNT_EMAIL}"
+    echo "GitHub workload identity provider: ${FOEHNCAST_TF_WORKLOAD_IDENTITY_PROVIDER}"
+    echo "Next step: run ./scripts/terraform-remote.sh apply to provision the broader platform through the remote backend."
   }
 
   prompt_with_default() {
@@ -441,7 +497,13 @@ read_tfvars_value() {
     fi
 
     if [[ "$CONFIGURE_GITHUB" != "true" && "$INTERACTIVE" == "true" ]]; then
-      if prompt_yes_no "Configure GitHub Actions variables for shared or fork-based redeploys after bootstrap?" n; then
+      local github_default_answer="n"
+
+      if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+        github_default_answer="y"
+      fi
+
+      if prompt_yes_no "Configure GitHub Actions variables for shared or fork-based redeploys after bootstrap?" "$github_default_answer"; then
         CONFIGURE_GITHUB=true
       fi
     fi
@@ -505,6 +567,9 @@ while [[ $# -gt 0 ]]; do
     --auto-approve)
       AUTO_APPROVE=true
       ;;
+    --bootstrap-only)
+      BOOTSTRAP_ONLY=true
+      ;;
     --non-interactive)
       INTERACTIVE=false
       ;;
@@ -553,7 +618,17 @@ echo "Checking access to GCP project ${GCP_PROJECT_ID}..."
 gcloud projects describe "$GCP_PROJECT_ID" >/dev/null
 
 echo "Initializing Terraform..."
-terraform -chdir="${ROOT_DIR}/terraform" init
+terraform_init_args=(init -reconfigure)
+
+if [[ "$BOOTSTRAP_ONLY" == "true" && "$PLAN_ONLY" != "true" ]]; then
+  ensure_remote_state_bucket
+  terraform_init_args+=(
+    -backend-config="bucket=$(terraform_remote_state_bucket)"
+    -backend-config="prefix=$(terraform_remote_state_prefix)"
+  )
+fi
+
+terraform -chdir="${ROOT_DIR}/terraform" "${terraform_init_args[@]}"
 
 echo "Formatting generated Terraform variable files..."
 terraform fmt "$TFVARS_FILE" >/dev/null
@@ -562,22 +637,45 @@ echo "Checking Terraform formatting and validation..."
 terraform -chdir="${ROOT_DIR}/terraform" fmt -check
 terraform -chdir="${ROOT_DIR}/terraform" validate
 
+target_args=()
+if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+  while IFS= read -r target_arg; do
+    target_args+=("$target_arg")
+  done < <(bootstrap_target_args)
+fi
+
 if [[ "$PLAN_ONLY" == "true" ]]; then
-  echo "Running Terraform plan..."
-  terraform -chdir="${ROOT_DIR}/terraform" plan -var-file="$TFVARS_FILE"
+  if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+    echo "Running bootstrap-only Terraform plan..."
+  else
+    echo "Running Terraform plan..."
+  fi
+
+  terraform -chdir="${ROOT_DIR}/terraform" plan -var-file="$TFVARS_FILE" "${target_args[@]}"
 else
   apply_args=(apply -var-file="$TFVARS_FILE")
+
+  apply_args+=("${target_args[@]}")
 
   if [[ "$AUTO_APPROVE" == "true" ]]; then
     apply_args+=( -auto-approve )
   fi
 
-  echo "Running Terraform apply..."
+  if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+    echo "Running bootstrap-only Terraform apply against the remote backend..."
+  else
+    echo "Running Terraform apply..."
+  fi
+
   terraform -chdir="${ROOT_DIR}/terraform" "${apply_args[@]}"
 
-  echo "Syncing local cloud identifiers into .env..."
-  sync_env_from_terraform_outputs
-  print_auth_summary
+  if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+    print_bootstrap_only_summary
+  else
+    echo "Syncing local cloud identifiers into .env..."
+    sync_env_from_terraform_outputs
+    print_auth_summary
+  fi
 fi
 
 if [[ "$CONFIGURE_GITHUB" == "true" && "$PLAN_ONLY" != "true" ]]; then
@@ -591,16 +689,30 @@ if [[ "$CONFIGURE_GITHUB" == "true" && "$PLAN_ONLY" != "true" ]]; then
   "${ROOT_DIR}/scripts/configure-github-actions.sh" "${github_args[@]}"
 fi
 
-echo "Bootstrap complete for ${GCP_PROJECT_ID}."
-echo "The interactive path can create or reuse a project and link billing when your gcloud account has permission to do so."
+if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+  echo "Bootstrap-only setup complete for ${GCP_PROJECT_ID}."
+  echo "The initial bootstrap resources now live in the same remote backend used by the GitHub Actions Terraform workflow."
+else
+  echo "Bootstrap complete for ${GCP_PROJECT_ID}."
+  echo "The interactive path can create or reuse a project and link billing when your gcloud account has permission to do so."
+fi
+
 echo "For local evaluation, keep using ./scripts/bootstrap-local.sh."
 
 if [[ "$CONFIGURE_GITHUB" == "true" && "$PLAN_ONLY" != "true" ]]; then
   echo "GitHub Actions variables were synchronized for repo-driven deployment automation."
-  echo "Prefer the remote GitHub Actions Terraform workflow for day-2 plan, apply, destroy, and cleanup."
-  echo "Common remote command: ./scripts/terraform-remote.sh plan"
+  if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+    echo "Run ./scripts/terraform-remote.sh apply to provision the broader platform through the remote backend."
+  else
+    echo "Prefer the remote GitHub Actions Terraform workflow for day-2 plan, apply, destroy, and cleanup."
+    echo "Common remote command: ./scripts/terraform-remote.sh plan"
+  fi
 else
   echo "GitHub Actions were not changed. That is fine for personal one-off environments."
-  echo "When you later configure GitHub OIDC variables, prefer the remote GitHub Actions Terraform workflow for day-2 plan, apply, destroy, and cleanup."
-  echo "After syncing GitHub Actions variables, use ./scripts/terraform-remote.sh for common remote Terraform commands."
+  if [[ "$BOOTSTRAP_ONLY" == "true" ]]; then
+    echo "Sync GitHub Actions variables before handing off to ./scripts/terraform-remote.sh apply."
+  else
+    echo "When you later configure GitHub OIDC variables, prefer the remote GitHub Actions Terraform workflow for day-2 plan, apply, destroy, and cleanup."
+    echo "After syncing GitHub Actions variables, use ./scripts/terraform-remote.sh for common remote Terraform commands."
+  fi
 fi

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -130,6 +130,8 @@ The easiest way to set them is:
 
 After that first sync, use `./scripts/terraform-remote.sh` for common remote Terraform plan, apply, destroy, and cleanup commands.
 
+If you want the smallest local-first setup, run `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions --repo <owner/repo>`. That path creates only the GitHub OIDC bootstrap resources locally, stores that state in the same remote backend used by the GitHub Actions Terraform workflow, and leaves the broader platform apply for the remote workflow.
+
 The helper script reads the Terraform outputs, sets the required GitHub Actions variables on the repository remote, and leaves `GCP_CLOUD_RUN_SERVICE` unset until the Cloud Run service has actually been provisioned. It also writes the Terraform state bucket defaults used by the GitHub Actions Terraform workflow.
 
 Recommended mappings from Terraform-managed values:
@@ -178,6 +180,8 @@ Remote Terraform is OIDC-only. Missing repository variables should fail fast ins
 
 After the first bootstrap has created the workload identity provider, deployer service account, and repository variables, prefer the remote workflow for day-2 plan, apply, destroy, and cleanup work through `./scripts/terraform-remote.sh` or the manual GitHub Actions UI.
 
+The `--bootstrap-only` variant of `./scripts/bootstrap-gcp.sh` is the narrowest first-time setup path: it prepares the remote-control-plane resources and remote backend state, then hands the broader platform provisioning to `./scripts/terraform-remote.sh apply`.
+
 ## Shared Repo vs Personal Deployments
 
 The upstream repository workflows are intended for the shared project environment. They use repository-scoped variables, package publishing, and cloud identities that belong to that shared environment.
@@ -213,6 +217,10 @@ Preferred environment: Google Cloud Shell. That keeps the admin toolchain off th
 Run this in Cloud Shell or another admin shell:
 
 `./scripts/bootstrap-gcp.sh`
+
+Optional narrower first-time setup:
+
+`./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions --repo <owner/repo>`
 
 Then do the following in order:
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -272,6 +272,23 @@ resource "google_service_account" "github_deployer" {
   display_name = "GitHub Actions deployer"
 }
 
+resource "google_project_iam_member" "github_project_admin" {
+  for_each = toset([
+    "roles/artifactregistry.admin",
+    "roles/bigquery.admin",
+    "roles/compute.admin",
+    "roles/iam.serviceAccountAdmin",
+    "roles/iam.workloadIdentityPoolAdmin",
+    "roles/resourcemanager.projectIamAdmin",
+    "roles/serviceusage.serviceUsageAdmin",
+    "roles/storage.admin",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
 resource "google_service_account" "cloud_run_runtime" {
   account_id   = "foehncast-cloud-run"
   display_name = "FoehnCast Cloud Run runtime"

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -10,32 +10,32 @@ output "region" {
 
 output "artifact_registry_repository_id" {
   description = "Artifact Registry repository name used for container images."
-  value       = google_artifact_registry_repository.containers.repository_id
+  value       = try(google_artifact_registry_repository.containers.repository_id, var.artifact_registry_repository_id)
 }
 
 output "artifact_registry_repository" {
   description = "Artifact Registry repository path for container images."
-  value       = google_artifact_registry_repository.containers.id
+  value       = try(google_artifact_registry_repository.containers.id, "projects/${var.project_id}/locations/${var.region}/repositories/${var.artifact_registry_repository_id}")
 }
 
 output "artifact_bucket_name" {
   description = "GCS bucket managed by Terraform for artifacts."
-  value       = google_storage_bucket.artifacts.name
+  value       = try(google_storage_bucket.artifacts.name, var.artifact_bucket_name)
 }
 
 output "bigquery_dataset_id" {
   description = "BigQuery dataset for curated feature data."
-  value       = google_bigquery_dataset.feature_store.dataset_id
+  value       = try(google_bigquery_dataset.feature_store.dataset_id, var.bigquery_dataset_id)
 }
 
 output "bigquery_feature_table_id" {
   description = "BigQuery table for curated feature rows."
-  value       = google_bigquery_table.forecast_features.table_id
+  value       = try(google_bigquery_table.forecast_features.table_id, var.bigquery_feature_table_id)
 }
 
 output "github_deployer_service_account" {
   description = "Service account used by GitHub Actions via Workload Identity Federation."
-  value       = google_service_account.github_deployer.email
+  value       = try(google_service_account.github_deployer.email, "github-actions-deployer@${var.project_id}.iam.gserviceaccount.com")
 }
 
 output "github_workload_identity_provider" {
@@ -45,7 +45,7 @@ output "github_workload_identity_provider" {
 
 output "cloud_run_runtime_service_account" {
   description = "Service account intended for Cloud Run runtime execution."
-  value       = google_service_account.cloud_run_runtime.email
+  value       = try(google_service_account.cloud_run_runtime.email, "foehncast-cloud-run@${var.project_id}.iam.gserviceaccount.com")
 }
 
 output "cloud_run_service_name" {


### PR DESCRIPTION
## Summary
- add a bootstrap-only cloud setup path that prepares the remote Terraform control plane without running the full platform apply locally
- store bootstrap-only state in the same remote backend that the GitHub Actions Terraform workflow will use later
- update outputs and operator docs so GitHub Actions variables can be synced after bootstrap-only setup and the remote workflow can take over cleanly

## Testing
- `bash -n scripts/bootstrap-gcp.sh`
- `terraform -chdir=terraform fmt -check`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/python -m mkdocs build -f docs/mkdocs.yml --strict`

Closes #83
