### PR TITLE
test: add bootstrap-only smoke driver

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: bash -n scripts/*.sh
+      - run: bash scripts/terraform-remote.sh --help >/dev/null
+      - run: bash scripts/smoke-bootstrap-only.sh --help >/dev/null
       - run: bash scripts/teardown-gcp.sh --help >/dev/null
       - run: bash scripts/teardown-gcp.sh --plan-only >/dev/null
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,10 @@
-.PHONY: help install install-docs install-feast lock lint format test test-feature check docs-build docs-serve bootstrap-local bootstrap-gcp terraform-remote compose-up compose-down compose-ps compose-logs dev-build dev-rebuild dev-shell notebook-server notebook-stop feast-prepare
+.PHONY: help install install-docs install-feast lock lint format test test-feature check docs-build docs-serve bootstrap-local bootstrap-gcp terraform-remote smoke-bootstrap-only compose-up compose-down compose-ps compose-logs dev-build dev-rebuild dev-shell notebook-server notebook-stop feast-prepare
 
 ROOT_DIR := $(patsubst %/,%,$(dir $(abspath $(lastword $(MAKEFILE_LIST)))))
 DATASET ?= train
 JUPYTER_TOKEN ?= foehncast-local
 TF_REMOTE_ARGS ?= plan
+SMOKE_BOOTSTRAP_ARGS ?=
 
 help:  ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-24s %s\n", $$1, $$2}'
@@ -48,6 +49,9 @@ bootstrap-gcp:  ## Run the cloud-operator GCP bootstrap (prefer Cloud Shell)
 
 terraform-remote:  ## Trigger the remote Terraform workflow with TF_REMOTE_ARGS='<command> [flags]'
 	cd $(ROOT_DIR) && ./scripts/terraform-remote.sh $(TF_REMOTE_ARGS)
+
+smoke-bootstrap-only:  ## Run the disposable bootstrap-only smoke driver with SMOKE_BOOTSTRAP_ARGS='--repo owner/repo'
+	cd $(ROOT_DIR) && ./scripts/smoke-bootstrap-only.sh $(SMOKE_BOOTSTRAP_ARGS)
 
 compose-up:  ## Start the local compose stack
 	cd $(ROOT_DIR) && docker compose up -d

--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ After the first bootstrap, prefer the remote Terraform workflow for day-2 plan, 
 
 If you want the smallest first-time local step, run `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions --repo <owner/repo>`. That path creates only the remote-control-plane prerequisites, stores that bootstrap state in the remote backend, and leaves the broader platform apply for `./scripts/terraform-remote.sh apply`.
 
+Add `--wait` to `./scripts/terraform-remote.sh` when you want the helper to watch the dispatched GitHub Actions run to completion.
+
 Common remote operator commands:
 
 - Review the current remote plan: `./scripts/terraform-remote.sh plan`
@@ -143,6 +145,7 @@ Useful variants:
 
 - Restart from scratch: `rm -f .env terraform/terraform.tfvars && ./scripts/bootstrap-gcp.sh`
 - Bootstrap only the remote-control-plane prerequisites: `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions --repo <owner/repo>`
+- Run a disposable fork-based bootstrap-only smoke pass: `./scripts/smoke-bootstrap-only.sh --repo <your-github-user>/foehncast`
 - Skip prompts when you already know the values: `./scripts/bootstrap-gcp.sh --non-interactive`
 - Configure fork automation during bootstrap: `./scripts/bootstrap-gcp.sh --configure-github-actions --repo <your-github-user>/foehncast`
 
@@ -178,6 +181,8 @@ Cloud Run stays available as an inference-only path for the app service.
 When you finish a disposable cloud test created from the local bootstrap path, run `./scripts/teardown-gcp.sh --plan-only` first to preview the destroy, then rerun without `--plan-only` when you are ready to remove the Terraform-managed resources created from your local `.env` and `terraform/terraform.tfvars`. In a fresh clone with no local Terraform state, the helper skips the Terraform destroy path cleanly. `--clear-github-actions`, `--delete-state-bucket`, and `--delete-project` still work as explicit cleanup actions when you request them. `--delete-project` is intended for disposable smoke environments where you also want the bootstrap-created GCP project queued for deletion, and it prompts for the exact project id unless you also pass `--auto-approve`.
 
 For environments managed through the remote backend, use `./scripts/terraform-remote.sh destroy` and then `./scripts/terraform-remote.sh cleanup --cleanup-delete-state-bucket --cleanup-clear-github-actions` instead of local Terraform.
+
+`./scripts/smoke-bootstrap-only.sh` is intended for a fork or disposable repository because it rewrites and later clears that repository's deployment variables as part of the smoke lifecycle.
 
 ## Deployment Ownership
 

--- a/scripts/smoke-bootstrap-only.sh
+++ b/scripts/smoke-bootstrap-only.sh
@@ -1,0 +1,325 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ENV_FILE=""
+TFVARS_FILE=""
+TARGET_REPO=""
+PROJECT_ID=""
+REGION="europe-west6"
+REF=""
+DRY_RUN=false
+KEEP_ENVIRONMENT=false
+KEEP_TEMP_FILES=false
+ALLOW_SHARED_REPO=false
+CREATED_ENV_FILE=false
+CREATED_TFVARS_FILE=false
+
+# shellcheck disable=SC1091
+source "${ROOT_DIR}/scripts/cli-common.sh"
+# shellcheck disable=SC1091
+source "${ROOT_DIR}/scripts/github-common.sh"
+
+usage() {
+  echo "Usage: $0 --repo owner/repo [--project-id id] [--region region] [--ref branch] [--env-file path] [--tfvars-file path] [--keep-environment] [--keep-temp-files] [--allow-shared-repo] [--dry-run]" >&2
+  echo "Runs an interactive bootstrap-only setup, then drives remote apply, destroy, and cleanup for a disposable smoke environment." >&2
+}
+
+default_project_id() {
+  printf 'fcast-smoke-%s-%04x\n' "$(date +%m%d%H%M)" "$((RANDOM % 65536))"
+}
+
+replace_or_append_line() {
+  local file_path="$1"
+  local regex="$2"
+  local replacement="$3"
+  local temp_file line matched=false
+
+  temp_file="$(mktemp)"
+
+  while IFS= read -r line || [[ -n "$line" ]]; do
+    if [[ "$line" =~ $regex ]]; then
+      printf '%s\n' "$replacement" >> "$temp_file"
+      matched=true
+    else
+      printf '%s\n' "$line" >> "$temp_file"
+    fi
+  done < "$file_path"
+
+  if [[ "$matched" != "true" ]]; then
+    printf '%s\n' "$replacement" >> "$temp_file"
+  fi
+
+  mv "$temp_file" "$file_path"
+}
+
+escape_tfvars_string() {
+  local value="$1"
+
+  value="${value//\\/\\\\}"
+  value="${value//\"/\\\"}"
+  printf '%s' "$value"
+}
+
+set_env_value() {
+  local key="$1"
+  local value="$2"
+
+  replace_or_append_line "$ENV_FILE" "^${key}=" "${key}=${value}"
+}
+
+set_tfvars_string() {
+  local key="$1"
+  local value="$2"
+
+  value="$(escape_tfvars_string "$value")"
+  replace_or_append_line "$TFVARS_FILE" "^[[:space:]]*${key}[[:space:]]*=" "${key} = \"${value}\""
+}
+
+set_tfvars_bool() {
+  local key="$1"
+  local value="$2"
+
+  replace_or_append_line "$TFVARS_FILE" "^[[:space:]]*${key}[[:space:]]*=" "${key} = ${value}"
+}
+
+prepare_file_from_template() {
+  local template_path="$1"
+  local destination_path="$2"
+
+  mkdir -p "$(dirname "$destination_path")"
+  if [[ ! -f "$destination_path" ]]; then
+    cp "$template_path" "$destination_path"
+  fi
+}
+
+ensure_safe_repo() {
+  if [[ -z "$TARGET_REPO" ]]; then
+    echo "--repo owner/repo is required. Use a fork or disposable repository for this smoke pass." >&2
+    exit 1
+  fi
+
+  if [[ "$TARGET_REPO" != */* ]]; then
+    echo "Repository must use owner/repo format, got: ${TARGET_REPO}" >&2
+    exit 1
+  fi
+
+  if [[ "$TARGET_REPO" == "javihslu/foehncast" && "$ALLOW_SHARED_REPO" != "true" ]]; then
+    echo "Refusing to target javihslu/foehncast because this smoke flow rewrites and later clears repository variables." >&2
+    echo "Use a fork or disposable repository instead, or rerun with --allow-shared-repo if you explicitly want that behavior." >&2
+    exit 1
+  fi
+}
+
+validate_project_id() {
+  if [[ ! "$PROJECT_ID" =~ ^[a-z][a-z0-9-]{4,28}[a-z0-9]$ ]]; then
+    echo "Project id must match GCP constraints: start with a letter, use lowercase letters, digits, or hyphens, and be 6-30 characters long." >&2
+    exit 1
+  fi
+}
+
+prepare_local_inputs() {
+  local repo_owner repo_name artifact_repo artifact_bucket cloud_run_service
+
+  repo_owner="${TARGET_REPO%%/*}"
+  repo_name="${TARGET_REPO#*/}"
+  artifact_repo="foehncast-docker"
+  artifact_bucket="foehncast-artifacts-${PROJECT_ID}"
+  cloud_run_service="foehncast-serve"
+
+  if [[ -z "$ENV_FILE" ]]; then
+    ENV_FILE="$(mktemp "${TMPDIR:-/tmp}/foehncast-smoke.env.XXXXXX")"
+    CREATED_ENV_FILE=true
+  fi
+
+  if [[ -z "$TFVARS_FILE" ]]; then
+    TFVARS_FILE="$(mktemp "${TMPDIR:-/tmp}/foehncast-smoke.tfvars.XXXXXX")"
+    CREATED_TFVARS_FILE=true
+  fi
+
+  prepare_file_from_template "${ROOT_DIR}/.env.example" "$ENV_FILE"
+  prepare_file_from_template "${ROOT_DIR}/terraform/terraform.tfvars.example" "$TFVARS_FILE"
+
+  set_env_value GCP_PROJECT_ID "$PROJECT_ID"
+  set_env_value GCP_LOCATION "$REGION"
+  set_env_value GCP_BUCKET_NAME "$artifact_bucket"
+  set_env_value STORAGE_BIGQUERY_PROJECT_ID "$PROJECT_ID"
+  set_env_value STORAGE_BIGQUERY_DATASET "foehncast"
+  set_env_value STORAGE_BIGQUERY_TABLE "forecast_features"
+  set_env_value CLOUD_RUN_SERVICE_NAME "$cloud_run_service"
+
+  set_tfvars_string project_id "$PROJECT_ID"
+  set_tfvars_string region "$REGION"
+  set_tfvars_string artifact_registry_repository_id "$artifact_repo"
+  set_tfvars_string artifact_bucket_name "$artifact_bucket"
+  set_tfvars_string bigquery_dataset_id "foehncast"
+  set_tfvars_string bigquery_location "$REGION"
+  set_tfvars_string bigquery_feature_table_id "forecast_features"
+  set_tfvars_bool provision_cloud_run_service false
+  set_tfvars_string cloud_run_service_name "$cloud_run_service"
+  set_tfvars_string cloud_run_image "${REGION}-docker.pkg.dev/${PROJECT_ID}/${artifact_repo}/foehncast-app:latest"
+  set_tfvars_bool provision_online_compose_host false
+  set_tfvars_string github_owner "$repo_owner"
+  set_tfvars_string github_repository "$repo_name"
+}
+
+print_command() {
+  printf '+ '
+  printf '%q ' "$@"
+  printf '\n'
+}
+
+run_step() {
+  local message="$1"
+  shift
+
+  echo
+  echo "$message"
+  print_command "$@"
+
+  if [[ "$DRY_RUN" == "true" ]]; then
+    return
+  fi
+
+  "$@"
+}
+
+cleanup_temp_files() {
+  local status="$1"
+
+  if [[ "$status" -ne 0 ]]; then
+    KEEP_TEMP_FILES=true
+  fi
+
+  if [[ "$KEEP_TEMP_FILES" == "true" ]]; then
+    echo
+    echo "Smoke files kept for inspection:"
+    echo "- env file: ${ENV_FILE}"
+    echo "- tfvars file: ${TFVARS_FILE}"
+    return
+  fi
+
+  if [[ "$CREATED_ENV_FILE" == "true" ]]; then
+    rm -f "$ENV_FILE"
+  fi
+  if [[ "$CREATED_TFVARS_FILE" == "true" ]]; then
+    rm -f "$TFVARS_FILE"
+  fi
+}
+
+on_exit() {
+  local status=$?
+
+  cleanup_temp_files "$status"
+  exit "$status"
+}
+
+trap on_exit EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --repo)
+      shift
+      TARGET_REPO="${1:-}"
+      ;;
+    --project-id)
+      shift
+      PROJECT_ID="${1:-}"
+      ;;
+    --region)
+      shift
+      REGION="${1:-}"
+      ;;
+    --ref)
+      shift
+      REF="${1:-}"
+      ;;
+    --env-file)
+      shift
+      ENV_FILE="${1:-}"
+      ;;
+    --tfvars-file)
+      shift
+      TFVARS_FILE="${1:-}"
+      ;;
+    --keep-environment)
+      KEEP_ENVIRONMENT=true
+      ;;
+    --keep-temp-files)
+      KEEP_TEMP_FILES=true
+      ;;
+    --allow-shared-repo)
+      ALLOW_SHARED_REPO=true
+      ;;
+    --dry-run)
+      DRY_RUN=true
+      ;;
+    --help|-h)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+
+  shift
+done
+
+ensure_safe_repo
+
+if [[ -z "$PROJECT_ID" ]]; then
+  PROJECT_ID="$(default_project_id)"
+fi
+
+validate_project_id
+
+if [[ "$DRY_RUN" == "true" || "$KEEP_ENVIRONMENT" == "true" ]]; then
+  KEEP_TEMP_FILES=true
+fi
+
+prepare_local_inputs
+
+echo "Disposable bootstrap-only smoke configuration:"
+echo "- repository: ${TARGET_REPO}"
+echo "- project_id: ${PROJECT_ID}"
+echo "- region: ${REGION}"
+echo "- env file: ${ENV_FILE}"
+echo "- tfvars file: ${TFVARS_FILE}"
+if [[ -n "$REF" ]]; then
+  echo "- workflow ref: ${REF}"
+fi
+if [[ "$KEEP_ENVIRONMENT" == "true" ]]; then
+  echo "- keep environment: true"
+fi
+if [[ "$DRY_RUN" == "true" ]]; then
+  echo "- dry run: true"
+fi
+
+echo
+echo "The bootstrap step may still prompt for gcloud login, project creation, or billing linkage if the disposable project does not exist yet."
+
+bootstrap_args=("${ROOT_DIR}/scripts/bootstrap-gcp.sh" --bootstrap-only --configure-github-actions --repo "$TARGET_REPO" --env-file "$ENV_FILE" --tfvars-file "$TFVARS_FILE" --auto-approve)
+run_step "Bootstrapping the remote-control-plane prerequisites" "${bootstrap_args[@]}"
+
+remote_common_args=(--repo "$TARGET_REPO" --env-file "$ENV_FILE" --project-id "$PROJECT_ID" --region "$REGION" --wait)
+if [[ -n "$REF" ]]; then
+  remote_common_args+=(--ref "$REF")
+fi
+
+run_step "Applying the broader platform through the remote Terraform workflow" "${ROOT_DIR}/scripts/terraform-remote.sh" apply "${remote_common_args[@]}"
+
+if [[ "$KEEP_ENVIRONMENT" == "true" ]]; then
+  echo
+  echo "Bootstrap-only smoke apply completed. The environment was kept for inspection."
+  exit 0
+fi
+
+run_step "Destroying the remote Terraform-managed resources" "${ROOT_DIR}/scripts/terraform-remote.sh" destroy "${remote_common_args[@]}"
+run_step "Clearing the remote backend state bucket and repository variables" "${ROOT_DIR}/scripts/terraform-remote.sh" cleanup "${remote_common_args[@]}" --cleanup-delete-state-bucket --cleanup-clear-github-actions
+run_step "Queuing the disposable GCP project for deletion" "${ROOT_DIR}/scripts/teardown-gcp.sh" --env-file "$ENV_FILE" --tfvars-file "$TFVARS_FILE" --delete-project --auto-approve
+
+echo
+echo "Bootstrap-only smoke pass completed."

--- a/scripts/terraform-remote.sh
+++ b/scripts/terraform-remote.sh
@@ -11,6 +11,8 @@ COMMAND=""
 PROJECT_ID=""
 REGION=""
 DRY_RUN=false
+WAIT_FOR_COMPLETION=false
+WATCH_INTERVAL=3
 CLEANUP_CLEAR_GITHUB_ACTIONS=false
 CLEANUP_DELETE_STATE_BUCKET=false
 EXTRA_INPUTS=()
@@ -23,7 +25,69 @@ source "${ROOT_DIR}/scripts/github-common.sh"
 source "${ROOT_DIR}/scripts/gcp-common.sh"
 
 usage() {
-  echo "Usage: $0 <plan|apply|destroy|cleanup> [--repo owner/repo] [--ref branch] [--env-file path] [--project-id id] [--region region] [--input key=value] [--cleanup-clear-github-actions] [--cleanup-delete-state-bucket] [--dry-run]" >&2
+  echo "Usage: $0 <plan|apply|destroy|cleanup> [--repo owner/repo] [--ref branch] [--env-file path] [--project-id id] [--region region] [--input key=value] [--cleanup-clear-github-actions] [--cleanup-delete-state-bucket] [--wait] [--watch-interval seconds] [--dry-run]" >&2
+}
+
+resolve_watch_ref() {
+  local repository_path="$1"
+
+  if [[ -n "$REF" ]]; then
+    printf '%s\n' "$REF"
+    return
+  fi
+
+  gh repo view "$repository_path" --json defaultBranchRef --jq '.defaultBranchRef.name'
+}
+
+latest_workflow_run_id() {
+  local repository_path="$1"
+  local branch_ref="$2"
+  local triggering_user="${3:-}"
+  local args
+
+  args=(run list --repo "$repository_path" --workflow "$WORKFLOW_FILE" --event workflow_dispatch --limit 1 --json databaseId)
+  if [[ -n "$branch_ref" ]]; then
+    args+=(--branch "$branch_ref")
+  fi
+  if [[ -n "$triggering_user" ]]; then
+    args+=(--user "$triggering_user")
+  fi
+
+  gh "${args[@]}" --jq '.[0].databaseId // ""' 2>/dev/null || true
+}
+
+wait_for_dispatched_run() {
+  local repository_path="$1"
+  local branch_ref="$2"
+  local previous_run_id="$3"
+  local triggering_user="$4"
+  local run_id=""
+  local attempt=0
+  local run_url=""
+
+  while (( attempt < 20 )); do
+    run_id="$(latest_workflow_run_id "$repository_path" "$branch_ref" "$triggering_user")"
+    if [[ -n "$run_id" && "$run_id" != "$previous_run_id" ]]; then
+      break
+    fi
+
+    attempt=$((attempt + 1))
+    sleep "$WATCH_INTERVAL"
+  done
+
+  if [[ -z "$run_id" || "$run_id" == "$previous_run_id" ]]; then
+    echo "Unable to resolve the newly triggered Terraform workflow run on ${repository_path}." >&2
+    exit 1
+  fi
+
+  run_url="$(gh run view "$run_id" --repo "$repository_path" --json url --jq '.url' 2>/dev/null || true)"
+  if [[ -n "$run_url" ]]; then
+    echo "Watching workflow run: ${run_url}"
+  else
+    echo "Watching workflow run id: ${run_id}"
+  fi
+
+  gh run watch "$run_id" --repo "$repository_path" --interval "$WATCH_INTERVAL" --exit-status
 }
 
 normalize_bool() {
@@ -154,6 +218,17 @@ while [[ $# -gt 0 ]]; do
     --dry-run)
       DRY_RUN=true
       ;;
+    --wait)
+      WAIT_FOR_COMPLETION=true
+      ;;
+    --watch-interval)
+      shift
+      WATCH_INTERVAL="${1:-}"
+      if [[ -z "$WATCH_INTERVAL" || ! "$WATCH_INTERVAL" =~ ^[0-9]+$ || "$WATCH_INTERVAL" -lt 1 ]]; then
+        echo "--watch-interval expects a positive integer number of seconds." >&2
+        exit 1
+      fi
+      ;;
     --help|-h)
       usage
       exit 0
@@ -217,6 +292,15 @@ if [[ "$COMMAND" == "cleanup" && "$CLEANUP_CLEAR_GITHUB_ACTIONS" != "true" && "$
   exit 1
 fi
 
+WATCH_REF=""
+PREVIOUS_RUN_ID=""
+TRIGGERING_USER=""
+if [[ "$WAIT_FOR_COMPLETION" == "true" ]]; then
+  WATCH_REF="$(resolve_watch_ref "$REPOSITORY_PATH")"
+  TRIGGERING_USER="$(gh api user --jq '.login' 2>/dev/null || true)"
+  PREVIOUS_RUN_ID="$(latest_workflow_run_id "$REPOSITORY_PATH" "$WATCH_REF" "$TRIGGERING_USER")"
+fi
+
 run_args=(gh workflow run "$WORKFLOW_FILE" --repo "$REPOSITORY_PATH")
 if [[ -n "$REF" ]]; then
   run_args+=(--ref "$REF")
@@ -244,9 +328,11 @@ if [[ "$COMMAND" == "cleanup" ]]; then
   run_args+=( -f "cleanup_delete_state_bucket=${CLEANUP_DELETE_STATE_BUCKET}" )
 fi
 
-for input in "${EXTRA_INPUTS[@]}"; do
-  run_args+=( -f "$input" )
-done
+if (( ${#EXTRA_INPUTS[@]} > 0 )); then
+  for input in "${EXTRA_INPUTS[@]}"; do
+    run_args+=( -f "$input" )
+  done
+fi
 
 echo "Triggering remote Terraform workflow on ${REPOSITORY_PATH}"
 echo "- command: ${COMMAND}"
@@ -261,6 +347,9 @@ fi
 if [[ -n "$REGION" ]]; then
   echo "- region: ${REGION}"
 fi
+if [[ "$WAIT_FOR_COMPLETION" == "true" ]]; then
+  echo "- wait: true"
+fi
 if [[ "$COMMAND" == "cleanup" ]]; then
   echo "- cleanup_clear_github_actions: ${CLEANUP_CLEAR_GITHUB_ACTIONS}"
   echo "- cleanup_delete_state_bucket: ${CLEANUP_DELETE_STATE_BUCKET}"
@@ -274,3 +363,7 @@ if [[ "$DRY_RUN" == "true" ]]; then
 fi
 
 "${run_args[@]}"
+
+if [[ "$WAIT_FOR_COMPLETION" == "true" ]]; then
+  wait_for_dispatched_run "$REPOSITORY_PATH" "$WATCH_REF" "$PREVIOUS_RUN_ID" "$TRIGGERING_USER"
+fi

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -151,12 +151,16 @@ Use `.github/workflows/terraform.yml` to run validate, plan, apply, destroy, or 
 
 For the common operator path, trigger that workflow with `./scripts/terraform-remote.sh` instead of opening the Actions UI manually.
 
+Add `--wait` when you want the helper to watch the dispatched workflow run until it completes.
+
 Examples:
 
 - `./scripts/terraform-remote.sh plan`
-- `./scripts/terraform-remote.sh apply`
+- `./scripts/terraform-remote.sh apply --wait`
 - `./scripts/terraform-remote.sh destroy`
 - `./scripts/terraform-remote.sh cleanup --cleanup-delete-state-bucket --cleanup-clear-github-actions`
+
+For a disposable manual validation of the bootstrap-only path in a fork or other disposable repository, use `./scripts/smoke-bootstrap-only.sh --repo <your-github-user>/foehncast`. The smoke driver prepares temporary local inputs, runs `bootstrap-gcp.sh --bootstrap-only`, waits on the remote apply, then destroys the remote resources, clears the target repository variables, and queues the disposable GCP project for deletion.
 
 For `command=destroy`, the workflow does not create a missing backend bucket. Instead it fails fast unless the remote state backend already exists, and it requires `destroy_confirmation` to match the resolved GCP project id. That keeps remote teardown explicit and tied to the same state that created the environment.
 


### PR DESCRIPTION
## Summary
- add `scripts/smoke-bootstrap-only.sh` to drive a disposable bootstrap-only smoke pass against a fork or other disposable repository
- teach `scripts/terraform-remote.sh` to wait on the GitHub Actions Terraform workflow it dispatches
- document the new smoke-driver path and validate the new shell entrypoints in CI

Closes #85.

## Validation
- `/bin/bash -n scripts/*.sh`
- `/bin/bash scripts/terraform-remote.sh --help >/dev/null`
- `/bin/bash scripts/terraform-remote.sh plan --repo javihslu/foehncast --project-id fcast-smoke-demo --region europe-west6 --wait --dry-run`
- `/bin/bash scripts/smoke-bootstrap-only.sh --repo example/foehncast --project-id fcast-smoke-demo --env-file /tmp/foehncast-smoke.env --tfvars-file /tmp/foehncast-smoke.tfvars --dry-run`
- `/bin/bash scripts/smoke-bootstrap-only.sh --repo javihslu/foehncast --project-id fcast-smoke-demo --env-file /tmp/foehncast-smoke.env --tfvars-file /tmp/foehncast-smoke.tfvars --dry-run` (expected refusal)
- `uv sync --frozen --only-group docs --no-default-groups`
- `uv run mkdocs build -f docs/mkdocs.yml --strict`
