### PR TITLE
fix: correct bootstrap tfvars formatting in smoke path

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,7 +38,7 @@ AIRFLOW__WEBSERVER__CONFIG_FILE=/opt/airflow/webserver_config.py
 # Airflow owns feature-pipeline orchestration inside the stack.
 # Leave AIRFLOW_FEATURE_SCHEDULE empty, manual, or off to disable recurring refreshes.
 AIRFLOW_FEATURE_DATASET=train
-AIRFLOW_FEATURE_SCHEDULE=0 */6 * * *
+AIRFLOW_FEATURE_SCHEDULE="0 */6 * * *"
 
 # App
 APP_BIND_HOST=127.0.0.1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - uses: actions/checkout@v4
       - run: bash -n scripts/*.sh
       - run: bash scripts/terraform-remote.sh --help >/dev/null
-      - run: bash scripts/smoke-bootstrap-only.sh --help >/dev/null
+      - run: bash scripts/smoke-bootstrap-only.sh --repo example/foehncast --project-id fcast-smoke-ci --dry-run >/dev/null
       - run: bash scripts/teardown-gcp.sh --help >/dev/null
       - run: bash scripts/teardown-gcp.sh --plan-only >/dev/null
 

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -152,6 +152,30 @@ read_tfvars_value() {
     replace_or_append_line "$TFVARS_FILE" "^[[:space:]]*${key}[[:space:]]*=" "${key} = ${value}"
   }
 
+  terraform_fmt_supports_file() {
+    local file_path="$1"
+
+    case "$file_path" in
+      *.tf|*.tfvars|*.tftest.hcl)
+        return 0
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  }
+
+  format_generated_tfvars_file() {
+    local file_path="$1"
+
+    if terraform_fmt_supports_file "$file_path"; then
+      terraform fmt "$file_path" >/dev/null
+      return
+    fi
+
+    echo "Skipping terraform fmt for ${file_path} because the filename does not end with .tf, .tfvars, or .tftest.hcl."
+  }
+
   terraform_remote_state_bucket() {
     printf '%s\n' "${GCP_PROJECT_ID}-foehncast-tfstate"
   }
@@ -631,7 +655,7 @@ fi
 terraform -chdir="${ROOT_DIR}/terraform" "${terraform_init_args[@]}"
 
 echo "Formatting generated Terraform variable files..."
-terraform fmt "$TFVARS_FILE" >/dev/null
+format_generated_tfvars_file "$TFVARS_FILE"
 
 echo "Checking Terraform formatting and validation..."
 terraform -chdir="${ROOT_DIR}/terraform" fmt -check

--- a/scripts/smoke-bootstrap-only.sh
+++ b/scripts/smoke-bootstrap-only.sh
@@ -13,6 +13,7 @@ DRY_RUN=false
 KEEP_ENVIRONMENT=false
 KEEP_TEMP_FILES=false
 ALLOW_SHARED_REPO=false
+TEMP_WORK_DIR=""
 CREATED_ENV_FILE=false
 CREATED_TFVARS_FILE=false
 
@@ -94,6 +95,14 @@ prepare_file_from_template() {
   fi
 }
 
+ensure_temp_workspace() {
+  if [[ -n "$TEMP_WORK_DIR" ]]; then
+    return
+  fi
+
+  TEMP_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/foehncast-smoke.XXXXXX")"
+}
+
 ensure_safe_repo() {
   if [[ -z "$TARGET_REPO" ]]; then
     echo "--repo owner/repo is required. Use a fork or disposable repository for this smoke pass." >&2
@@ -129,12 +138,14 @@ prepare_local_inputs() {
   cloud_run_service="foehncast-serve"
 
   if [[ -z "$ENV_FILE" ]]; then
-    ENV_FILE="$(mktemp "${TMPDIR:-/tmp}/foehncast-smoke.env.XXXXXX")"
+    ensure_temp_workspace
+    ENV_FILE="${TEMP_WORK_DIR}/foehncast-smoke.env"
     CREATED_ENV_FILE=true
   fi
 
   if [[ -z "$TFVARS_FILE" ]]; then
-    TFVARS_FILE="$(mktemp "${TMPDIR:-/tmp}/foehncast-smoke.tfvars.XXXXXX")"
+    ensure_temp_workspace
+    TFVARS_FILE="${TEMP_WORK_DIR}/foehncast-smoke.tfvars"
     CREATED_TFVARS_FILE=true
   fi
 
@@ -205,6 +216,9 @@ cleanup_temp_files() {
   fi
   if [[ "$CREATED_TFVARS_FILE" == "true" ]]; then
     rm -f "$TFVARS_FILE"
+  fi
+  if [[ -n "$TEMP_WORK_DIR" ]]; then
+    rmdir "$TEMP_WORK_DIR" 2>/dev/null || true
   fi
 }
 


### PR DESCRIPTION
## Summary
- harden `scripts/bootstrap-gcp.sh` so generated tfvars formatting does not abort when callers pass non-Terraform-looking file names
- make `scripts/smoke-bootstrap-only.sh` create temp files inside a dedicated temp directory with a stable `.tfvars` filename
- quote the default Airflow cron schedule in `.env.example` and strengthen shell CI with a real smoke-driver dry-run

Closes #87.

## Validation
- `/bin/bash -n scripts/*.sh`
- `/bin/bash scripts/smoke-bootstrap-only.sh --repo example/foehncast --project-id fcast-smoke-ci --dry-run`
- real disposable smoke rerun against `javihslu/foehncast-smoke` got past the previous `terraform fmt` and `.env` sourcing failures and reached live bootstrap-only Terraform apply for project `fcast-smoke-05070335-4061`
- queued deletion for disposable projects `fcast-smoke-05070321-7805` and `fcast-smoke-05070335-4061`
