### PR TITLE
docs(site): simplify README and project docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # FoehnCast
 
-FoehnCast ranks Swiss kiteboarding options for one rider profile. It combines forecast weather, engineered wind features, drive-time information, and a trained quality model to answer one practical question: which spot is worth the trip next?
+FoehnCast ranks Swiss kiteboarding spots for one rider profile. It combines forecast weather, engineered wind features, drive-time data, and a trained quality model to answer one practical question: which spot is worth the trip next?
 
-The project keeps one stable Feature-Training-Inference split across all runtime modes. What changes is the hosting model around that split, not the application structure. In practice, the repo supports three operator paths: a local evaluation baseline, collaborator-owned GCP provisioning, and maintainer-managed shared deployment automation.
+The repo keeps one stable Feature-Training-Inference split across local evaluation, hosted deployment, and CI/CD. The front page stays short on purpose. The detailed setup and architecture notes live in the project docs: <https://javihslu.github.io/foehncast/>.
 
-## System Shape
+## At A Glance
 
 ```mermaid
 flowchart LR
@@ -12,55 +12,44 @@ flowchart LR
     Features --> Curated[Curated features]
     Curated --> Training[Training pipeline]
     Training --> Registry[MLflow registry]
-    Registry --> API[FastAPI health, predict, and rank]
+    Registry --> API[FastAPI predict and rank API]
     Forecasts --> API
-    Drive[OSRM drive time] --> API
+    Drive[OSRM drive times] --> API
     Curated --> Feast[Optional Feast layer]
     Feast --> API
 ```
 
-## Runtime Modes
+## Current Scope
 
-| Mode | What runs there | Main use |
-|------|-----------------|----------|
-| Local Compose baseline | Airflow, MLflow, FastAPI, and the development container | default development and evaluation path |
-| Online compose host | the full Airflow, MLflow, and API stack on one GCP host | simplest way to keep the whole project online |
-| Optional Cloud Run path | the FastAPI inference service only | inference-only deployment surface |
-| GitHub automation | image publishing and Terraform workflows | GitOps for the hosted paths, not ML pipeline orchestration |
+| Area | Status | Summary |
+|------|--------|---------|
+| Feature pipeline | Working | Airflow ingests, engineers, validates, and stores curated weather features |
+| Training pipeline | Working | Airflow labels data, trains the model, evaluates it, and registers versions in MLflow |
+| Inference pipeline | Working | FastAPI serves `/health`, `/spots`, `/predict`, `/rank`, and optional online-feature routes |
+| Hosted runtime | Working | Terraform plus `docker-compose.cloud.yml` can run Airflow, MLflow, and the API on a GCP host |
+| Automation | Working | GitHub Actions publishes images, validates infrastructure, and drives remote Terraform workflows |
+
+## Choose Your Path
+
+| Path | Use it when | Start here |
+|------|-------------|------------|
+| Local evaluator | You want the default development and evaluation path with no GCP setup | `./scripts/bootstrap-local.sh` |
+| Cloud operator | You want to provision a hosted environment in your own GCP project | `./scripts/bootstrap-gcp.sh` |
+| Remote day-2 operations | You already bootstrapped cloud prerequisites and want repeatable plan, apply, destroy, and cleanup commands | `./scripts/terraform-remote.sh` |
 
 ```mermaid
 flowchart TB
-    subgraph Local
-        LocalAirflow[Airflow]
-        LocalMLflow[MLflow]
-        LocalAPI[FastAPI]
-    end
-    subgraph Online
-        GHCR[GHCR runtime images]
-        Terraform[Terraform workflow]
-        Host[GCP online compose host]
-        CloudRun[Optional Cloud Run app]
-    end
-    GHCR --> Host
-    Terraform --> Host
-    Terraform --> CloudRun
+    Local[Local evaluator path] --> Compose[Airflow + MLflow + FastAPI]
+    Cloud[Cloud operator bootstrap] --> Remote[Remote Terraform workflow]
+    Remote --> Host[Online compose host]
+    Remote --> Run[Optional Cloud Run service]
 ```
 
-## What Works Today
+## Quick Start
 
-| Area | Current state | Meaning |
-|------|---------------|---------|
-| Feature pipeline | Working | Airflow can ingest, engineer, validate, and store curated weather features |
-| Training pipeline | Working | Airflow can label data, train the model, evaluate it, and register a version in MLflow |
-| Inference pipeline | Working | the app serves `/health`, `/spots`, `/predict`, `/rank`, and the optional online-feature routes |
-| Online runtime | Working | `docker-compose.cloud.yml` plus Terraform can run Airflow, MLflow, and the API on one online host |
-| Cloud Run path | Available | the inference API can also be provisioned separately as a Cloud Run service |
-| CI/CD path | Working | GitHub Actions publishes runtime images and can drive Terraform remotely |
-| Local reproducibility | Working | `./scripts/bootstrap-local.sh` builds the local stack from a clean state and validates it |
+### Local evaluator
 
-## Local Evaluator Quick Start
-
-This is the default path for a fresh machine, and it is intentionally GCP-free.
+This is the default path for a fresh machine.
 
 1. Install Docker.
 2. Clone the repository.
@@ -68,31 +57,11 @@ This is the default path for a fresh machine, and it is intentionally GCP-free.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 
-`make` is optional in this repository. The committed `Makefile` only provides shortcut targets for the same `uv`, Docker Compose, and helper-script commands documented here. Contributors who do not use `make` can run the underlying commands directly, and Windows users may prefer WSL for the shell-based shortcuts.
-
-The script initializes `.env` from `.env.example` when needed, builds the local stack, runs the feature and training DAGs, and waits for the API to become healthy.
-
-After it finishes, the main endpoints are:
+After bootstrap completes, the main local endpoints are:
 
 - App: `http://127.0.0.1:8000`
 - Airflow: `http://127.0.0.1:8080`
 - MLflow: `http://127.0.0.1:5001`
-
-Airflow and MLflow open directly in local mode. The bootstrap path resets Docker volumes before starting so the evaluator workflow begins from a clean state. Raw landing, if retained locally, can stay file-based; curated feature storage defaults to local parquet files, and optional S3-compatible settings are only needed for non-default experiments.
-Feature refresh scheduling stays inside Airflow. `AIRFLOW_FEATURE_SCHEDULE` defaults to `0 */6 * * *`; set it to an empty value, `manual`, or `off` when you want a purely manual local stack.
-
-For stepwise debugging, use notebooks against the `development_env` container rather than embedding notebook logic into the pipelines themselves. The development container keeps its own Linux virtual environment and masks the host `.venv`; the image now installs the locked Python environment at build time, and startup only registers the `FoehnCast (development_env)` Jupyter kernel. In VS Code attached to `development_env`, select that kernel or `/home/appuser/.venv/bin/python` directly. Rebuild the development image after changing `pyproject.toml` or `uv.lock`.
-
-If you want to keep editing locally but run notebooks in the container, start the container-backed Jupyter server and connect VS Code to it as an existing Jupyter server:
-
-```bash
-docker compose up -d development_env
-docker compose exec -d development_env start-jupyter-server.sh
-```
-
-Equivalent optional shortcut: `make notebook-server`
-
-Then point VS Code Jupyter at `http://127.0.0.1:8888/?token=foehncast-local`. The port is bound to localhost only so it is not exposed on your LAN.
 
 Example check:
 
@@ -102,131 +71,31 @@ curl -fsS -X POST http://127.0.0.1:8000/rank \
   -d '{"spot_ids":["silvaplana","urnersee"]}'
 ```
 
-## Cloud Operator Quick Start
+### Cloud operator
 
-Use this only when you want to provision a hosted FoehnCast environment in a GCP project you control. This is a separate operator path from the default local evaluator setup.
-
-Preferred environment:
+Use this only when you want to run FoehnCast in a GCP project you control. Prefer Google Cloud Shell for the first bootstrap.
 
 1. Open Google Cloud Shell.
-2. Clone the repository there.
+2. Clone the repository.
 3. Run `./scripts/bootstrap-gcp.sh`.
+4. After bootstrap, use `./scripts/terraform-remote.sh plan|apply|destroy|cleanup` for day-2 operations.
 
-This keeps `gcloud`, Terraform, project creation, billing linkage, and Terraform state handling in an admin shell instead of on the evaluator machine.
+## Repository Map
 
-Alternative local admin shell:
+- `src/foehncast/`: application code for configuration, feature engineering, training, inference, monitoring, and spot metadata
+- `dags/`: Airflow entry points for the feature and training workflows
+- `scripts/`: local bootstrap, cloud bootstrap, remote Terraform, and operator helpers
+- `terraform/`: hosted infrastructure definition and operator notes
+- `tests/`: regression coverage for pipeline logic and API behavior
+- `docs/`: GitHub Pages source for the public project documentation
+- `ui/`: Streamlit demo surface
 
-- Google Cloud CLI (`gcloud`)
-- Terraform
-- GitHub CLI (`gh`) only if you want GitHub Actions in your own fork to publish and redeploy automatically
+## Read More
 
-Run:
-
-```bash
-./scripts/bootstrap-gcp.sh
-```
-
-The interactive setup signs you into GCP, lets you pick or create a project, confirms region and storage defaults, optionally provisions Cloud Run, and can align GitHub Actions variables for your own fork. During setup it writes `.env` and `terraform/terraform.tfvars`, then refreshes them from Terraform outputs after apply.
-
-After the first bootstrap, prefer the remote Terraform workflow for day-2 plan, apply, destroy, and cleanup operations.
-
-If you want the smallest first-time local step, run `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions --repo <owner/repo>`. That path creates only the remote-control-plane prerequisites, stores that bootstrap state in the remote backend, and leaves the broader platform apply for `./scripts/terraform-remote.sh apply`.
-
-Add `--wait` to `./scripts/terraform-remote.sh` when you want the helper to watch the dispatched GitHub Actions run to completion.
-
-Common remote operator commands:
-
-- Review the current remote plan: `./scripts/terraform-remote.sh plan`
-- Apply the current remote configuration: `./scripts/terraform-remote.sh apply`
-- Retire a remote environment: `./scripts/terraform-remote.sh destroy`
-- Follow destroy with post-destroy cleanup: `./scripts/terraform-remote.sh cleanup --cleanup-delete-state-bucket --cleanup-clear-github-actions`
-
-Useful variants:
-
-- Restart from scratch: `rm -f .env terraform/terraform.tfvars && ./scripts/bootstrap-gcp.sh`
-- Bootstrap only the remote-control-plane prerequisites: `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions --repo <owner/repo>`
-- Run a disposable fork-based bootstrap-only smoke pass: `./scripts/smoke-bootstrap-only.sh --repo <your-github-user>/foehncast`
-- Skip prompts when you already know the values: `./scripts/bootstrap-gcp.sh --non-interactive`
-- Configure fork automation during bootstrap: `./scripts/bootstrap-gcp.sh --configure-github-actions --repo <your-github-user>/foehncast`
-
-## Hosted Paths
-
-### Full online stack
-
-Use the online compose-host path when you want Airflow, MLflow, and the API running together in the cloud.
-
-1. Publish the runtime images with the `Publish Runtime Images` workflow, or let the host build once from the repo if the images are not published yet.
-2. Run `./scripts/terraform-remote.sh apply --input provision_online_compose_host=true`, or trigger the `Terraform` workflow manually with the same input.
-3. Provide at least:
-   - `project_id`
-   - `artifact_bucket_name`
-   - the repository OIDC variables from `./scripts/configure-github-actions.sh`
-4. Read the Terraform output for the public app URL:
-   - `online_compose_app_url`
-5. Retrieve the generated Airflow admin password from the host when you need UI access:
-   - `gcloud compute ssh <host> --zone <zone> --project <project> --command 'sudo cat /opt/foehncast/airflow/.admin-password'`
-
-The online host clones the repo, writes a runtime `.env` file with the Terraform-managed GCP and BigQuery settings, pulls the GHCR images when available, and falls back to local Docker builds on the host if needed.
-
-Only the app is exposed publicly by default. Airflow and MLflow stay bound to the host loopback interface unless you explicitly add `8080` or `5001` to `online_compose_public_ports`.
-
-### Optional Cloud Run service
-
-Cloud Run stays available as an inference-only path for the app service.
-
-- Set `provision_cloud_run_service=true` in the Terraform inputs.
-- Provide `mlflow_tracking_uri` so the service can reach the registry.
-- Publish the app image through the Artifact Registry plus Cloud Run workflow path.
-
-When you finish a disposable cloud test created from the local bootstrap path, run `./scripts/teardown-gcp.sh --plan-only` first to preview the destroy, then rerun without `--plan-only` when you are ready to remove the Terraform-managed resources created from your local `.env` and `terraform/terraform.tfvars`. In a fresh clone with no local Terraform state, the helper skips the Terraform destroy path cleanly. `--clear-github-actions`, `--delete-state-bucket`, and `--delete-project` still work as explicit cleanup actions when you request them. `--delete-project` is intended for disposable smoke environments where you also want the bootstrap-created GCP project queued for deletion, and it prompts for the exact project id unless you also pass `--auto-approve`.
-
-For environments managed through the remote backend, use `./scripts/terraform-remote.sh destroy` and then `./scripts/terraform-remote.sh cleanup --cleanup-delete-state-bucket --cleanup-clear-github-actions` instead of local Terraform.
-
-`./scripts/smoke-bootstrap-only.sh` is intended for a fork or disposable repository because it rewrites and later clears that repository's deployment variables as part of the smoke lifecycle.
-
-## Deployment Ownership
-
-- The upstream repository is a public source, journal, and automation surface for the shared project.
-- Public container images are convenience artifacts, not a shared hosting promise.
-- Anyone who wants an online instance should deploy in a fork or in a cloud account they control.
-- Compute, storage, network, and managed-service costs stay with the operator of that deployment.
-- State-changing upstream workflows are guarded and intended for the shared project environment.
-
-## GitHub Automation
-
-- Airflow owns feature and training pipeline execution inside the ML stack. GitHub Actions is reserved for GitOps concerns such as image publishing, Terraform, and deployment automation.
-- `.github/workflows/publish-runtime-images.yml`: publishes app, Airflow, MLflow, and development images to GHCR.
-- `.github/workflows/terraform.yml`: runs Terraform validate on changes and supports manual remote plan or apply with a GCS backend.
-- `.github/workflows/publish-app-image.yml`: keeps the optional Artifact Registry plus Cloud Run path for the inference API.
-
-`./scripts/configure-github-actions.sh` syncs the GCP deploy variables plus the Terraform state bucket defaults back into the repository. When Cloud Run is not provisioned yet, it leaves `GCP_CLOUD_RUN_SERVICE` unset so the guarded workflow stays skipped without carrying stale values. After that initial sync, use `./scripts/terraform-remote.sh` for common remote Terraform commands instead of keeping local Terraform in the loop.
-
-## Optional Feast
-
-Feast stays optional and layered on the same curated features.
-
-1. Install: `uv sync --group feast`
-2. Prepare local Feast state: `./scripts/prepare-feast-local.sh` or `make feast-prepare`
-3. Materialize: `cd feature_repo && uv run --group feast feast materialize-incremental "$(date -u +"%Y-%m-%dT%H:%M:%S")"`
-4. Query the helper or HTTP route:
-   - `uv run --group feast python -c "from foehncast.inference_pipeline.online_features import get_online_spot_features; print(get_online_spot_features(['silvaplana'], ['wind_speed_10m', 'gust_factor']))"`
-   - `curl -fsS -X POST http://127.0.0.1:8000/features/online -H 'content-type: application/json' -d '{"spot_ids":["silvaplana"],"feature_names":["wind_speed_10m","gust_factor"]}'`
-
-The local Feast path keeps using an exported parquet file plus a local SQLite online store. It does not require MinIO or a local S3-compatible object store.
-
-In the cloud, the intended split is different by data role rather than by one storage system doing everything:
-
-- raw landing and archive live in GCS
-- curated feature rows live in native BigQuery tables
-- Feast offline reads from a curated BigQuery table or view
-- Feast registry and staging artifacts live in GCS
-
-Feast is not the raw landing layer. It sits on top of curated features only.
-
-## More Detail
-
-- `containers/README.md`
-- `terraform/README.md`
-- `docs/site/system/feature-pipeline.md`
-- `docs/site/system/cloud-mapping.md`
-- `feature_repo/README.md`
+- Docs home: <https://javihslu.github.io/foehncast/>
+- Getting started: <https://javihslu.github.io/foehncast/getting-started/>
+- Architecture: <https://javihslu.github.io/foehncast/system/architecture/>
+- Cloud mapping: <https://javihslu.github.io/foehncast/system/cloud-mapping/>
+- Feature pipeline: <https://javihslu.github.io/foehncast/system/feature-pipeline/>
+- Terraform operator detail: `terraform/README.md`
+- Container detail: `containers/README.md`

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,6 +1,6 @@
-site_name: FoehnCast Journal
+site_name: FoehnCast Docs
 site_url: https://javihslu.github.io/foehncast/
-site_description: Course project journal and architecture guide for FoehnCast
+site_description: Setup, architecture, and milestone guide for FoehnCast
 repo_url: https://github.com/javihslu/foehncast
 repo_name: javihslu/foehncast
 
@@ -47,17 +47,18 @@ plugins:
   - search
 
 nav:
-  - Journal: index.md
-  - Milestones:
-      - Overview: milestones/index.md
-      - MS1 Proposal: milestones/ms1.md
-      - MS2 Backend: milestones/ms2.md
-      - MS3 Presentation: milestones/ms3.md
-      - MS4 Final Code: milestones/ms4.md
+  - Home: index.md
+  - Getting Started: getting-started.md
   - System:
-      - Use Case and Data: system/use-case.md
-      - Architecture: system/architecture.md
-      - Feature Pipeline: system/feature-pipeline.md
-      - Cloud Mapping: system/cloud-mapping.md
-      - Seasonality: system/seasonality.md
-      - Repository: system/repository.md
+    - Architecture: system/architecture.md
+    - Feature Pipeline: system/feature-pipeline.md
+    - Cloud Mapping: system/cloud-mapping.md
+    - Repository: system/repository.md
+    - Use Case and Data: system/use-case.md
+    - Seasonality: system/seasonality.md
+  - Milestones:
+    - Overview: milestones/index.md
+    - MS1 Proposal: milestones/ms1.md
+    - MS2 Backend: milestones/ms2.md
+    - MS3 Presentation: milestones/ms3.md
+    - MS4 Final Code: milestones/ms4.md

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -1,0 +1,76 @@
+# Getting Started
+
+This page keeps the operator choices simple. Start with the local evaluator path unless you explicitly need to provision cloud infrastructure.
+
+## Choose The Right Path
+
+| Path | Use it when | Main command |
+|------|-------------|--------------|
+| Local evaluator | You want the default development and evaluation flow with no GCP setup | `./scripts/bootstrap-local.sh` |
+| Cloud operator | You want to provision a hosted environment in your own GCP project | `./scripts/bootstrap-gcp.sh` |
+| Remote day-2 operations | You already bootstrapped the cloud prerequisites and want repeatable plan, apply, destroy, and cleanup commands | `./scripts/terraform-remote.sh` |
+
+## Local Evaluator
+
+This is the default path for a fresh machine.
+
+1. Install Docker.
+2. Clone the repository.
+3. Run `./scripts/bootstrap-local.sh`.
+
+You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
+
+After bootstrap completes, the main local endpoints are:
+
+- App: `http://127.0.0.1:8000`
+- Airflow: `http://127.0.0.1:8080`
+- MLflow: `http://127.0.0.1:5001`
+
+Example check:
+
+```bash
+curl -fsS -X POST http://127.0.0.1:8000/rank \
+  -H 'content-type: application/json' \
+  -d '{"spot_ids":["silvaplana","urnersee"]}'
+```
+
+## Cloud Operator
+
+Use this path only when you want to run FoehnCast in a GCP project you control.
+
+Preferred first bootstrap:
+
+1. Open Google Cloud Shell.
+2. Clone the repository.
+3. Run `./scripts/bootstrap-gcp.sh`.
+
+That keeps `gcloud`, Terraform, project creation, billing linkage, and Terraform state handling in an admin shell instead of on the evaluator machine.
+
+After bootstrap, use the remote helper for normal operations:
+
+```bash
+./scripts/terraform-remote.sh plan
+./scripts/terraform-remote.sh apply
+./scripts/terraform-remote.sh destroy
+./scripts/terraform-remote.sh cleanup --cleanup-delete-state-bucket --cleanup-clear-github-actions
+```
+
+If you want the helper to watch the GitHub Actions workflow it dispatches, add `--wait`.
+
+## What Lives Where
+
+- `src/foehncast/`: application code for feature engineering, training, inference, monitoring, and configuration
+- `dags/`: Airflow workflow entry points
+- `scripts/`: local bootstrap, cloud bootstrap, remote Terraform, and helper scripts
+- `terraform/`: hosted infrastructure definition and operator notes
+- `tests/`: regression coverage for the pipeline and API behavior
+- `docs/`: GitHub Pages source for the public documentation
+- `ui/`: Streamlit demo surface
+
+## Read Next
+
+- [Architecture](system/architecture.md)
+- [Feature Pipeline](system/feature-pipeline.md)
+- [Cloud Mapping](system/cloud-mapping.md)
+- [Repository](system/repository.md)
+- [Milestones](milestones/index.md)

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,47 +1,33 @@
-# FoehnCast Journal
+# FoehnCast Docs
 
-FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live weather forecasts, engineered wind features, drive-time information, and a trained quality model. This journal explains how the project is designed, how it is set up, and how it is operated across local, online, and CI/CD paths.
+FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live weather forecasts, engineered wind features, drive-time information, and a trained quality model. Use the repository README for the short summary. Use this site for the setup details, architecture notes, and milestone-level documentation.
 
-## What This Site Covers
+## Start Here
 
-- the working local stack for feature, training, and inference
-- the operating modes used for local evaluation, online hosting, and CI/CD
-- the milestone-by-milestone story behind the course submission
-- the cloud mapping that keeps the same application boundaries in a hosted environment
+| Need | Read this |
+|------|-----------|
+| Run the project locally with the default evaluator workflow | [Getting Started](getting-started.md) |
+| Understand the Feature-Training-Inference split | [Architecture](system/architecture.md) |
+| See how the hosted path maps onto GCP | [Cloud Mapping](system/cloud-mapping.md) |
+| Understand the main code and folder layout | [Repository](system/repository.md) |
+| Review the course delivery story | [Milestones](milestones/index.md) |
 
 ## Operating Model
 
-| Mode | Who operates it | Who pays for it | Purpose |
-|------|-----------------|-----------------|---------|
-| Local stack | Any reader or contributor | The person running Docker locally | Development, evaluation, and reproducible local validation |
-| Online stack | The operator of a fork or a local cloud setup | The operator's own cloud account | A full online deployment of Airflow, MLflow, and the API |
-| Upstream CI/CD | Repository maintainer | The upstream repository account | Validation, docs publishing, and reference image publishing |
-| Fork CI/CD | Fork owner | The fork owner's GitHub and cloud accounts | Personal or team-specific automation without using the upstream environment |
+| Mode | Who runs it | Purpose |
+|------|-------------|---------|
+| Local stack | Any reader or contributor | Development, evaluation, and reproducible validation |
+| Online stack | The operator of a fork or a personal cloud setup | Full hosted deployment of Airflow, MLflow, and the API |
+| GitHub automation | Repository maintainer or fork owner | Image publishing, Terraform workflows, and docs publishing |
 
-Public GHCR images are convenience artifacts for reuse. They do not provide shared hosting, and deployment costs still belong to the operator running the stack.
+Public images are convenience artifacts, not a shared hosting promise. If you want a running online environment, deploy it in infrastructure you control.
 
-The repository keeps local evaluation and maintainer-managed automation separate, so forks can reuse the same deployment shape with their own approvals and cloud accounts.
-
-Default onboarding follows that same split: use `./scripts/bootstrap-local.sh` for a GCP-free local evaluator path, and use `./scripts/bootstrap-gcp.sh` only for cloud operator bootstrap, preferably from Google Cloud Shell.
-
-## What Works
-
-| Area | Current state | What it means |
-|------|---------------|---------------|
-| Feature pipeline | Working | Airflow can ingest, engineer, validate, and store curated weather features for the configured spots |
-| Training pipeline | Working | Airflow can label data, train the model, evaluate it, and register a version in MLflow |
-| Inference pipeline | Working | The app serves `/health`, `/spots`, `/predict`, and `/rank` from the registered model |
-| Optional Feast path | Working | Curated local features can be exported, materialized, and queried through Feast, the helper, the API, and the demo page |
-| Online runtime | Working | `docker-compose.cloud.yml` plus Terraform can run Airflow, MLflow, and the API on a single online host |
-| CI/CD path | Working | GitHub Actions can publish images, validate infrastructure, and drive the online deployment path |
-| Local reproducibility | Working | `bootstrap-local.sh` brings the stack up from a clean state and validates the local path |
-
-## End-to-End Local Flow
+## System In One View
 
 <div class="mermaid">
 flowchart LR
     OME[Open-Meteo forecast] --> FEAT[Feature DAG]
-    FEAT --> PAR[(Curated feature parquet)]
+    FEAT --> PAR[(Curated features)]
     PAR --> TRAIN[Training DAG]
     TRAIN --> MLF[(MLflow registry)]
 
@@ -50,30 +36,25 @@ flowchart LR
     MLF --> APP
     APP --> API[Predict and rank endpoints]
 
-    PAR --> FEXP[Optional Feast export]
-    FEXP --> FEAST[(Feast online store)]
+    PAR --> FEAST[(Optional Feast lookup)]
     FEAST --> APP
-    APP --> FEATAPI[Online feature endpoint and demo]
 </div>
 
-## Short Roadmap
+## Current Status
 
-The core idea is fixed: keep the same Feature-Training-Inference split and change the infrastructure in small steps instead of redesigning the code.
+| Area | Status | Meaning |
+|------|--------|---------|
+| Feature pipeline | Working | The feature DAG ingests, engineers, validates, and stores curated weather features |
+| Training pipeline | Working | The training DAG labels data, trains the model, evaluates it, and registers versions in MLflow |
+| Inference pipeline | Working | The app serves the model-backed API routes used for health, prediction, and ranking |
+| Hosted runtime | Working | Terraform plus the online compose stack can run Airflow, MLflow, and the API on GCP |
+| CI/CD | Working | GitHub Actions validates docs and infrastructure and supports remote Terraform operations |
 
-<div class="mermaid">
-flowchart LR
-    LOCAL[Local stack<br/>runs with real data] --> DATA[Cloud data path<br/>BigQuery and GCS-backed services]
-    DATA --> DEPLOY[Managed runtime<br/>same app and DAG split]
-    DEPLOY --> FINAL[Operations<br/>monitoring and final wrap-up]
-</div>
+## Documentation Map
 
-- **Local stack**: the proof that the pipelines run together.
-- **Cloud data path**: reuse the same boundaries with BigQuery for curated data and GCS-backed artifacts.
-- **Managed runtime**: move orchestration and serving to managed GCP services or an online compose host instead of changing the application shape.
-- **Operations**: finish automation, monitoring, and final delivery material.
-
-## Reading Guide
-
-- **Journal**: operating model, design framing, and roadmap.
-- **Milestones**: course-facing progress by submission checkpoint.
-- **System**: the working architecture, cloud target, and repository layout.
+- [Getting Started](getting-started.md): choose the right operator path and run the first commands.
+- [Architecture](system/architecture.md): the stable Feature-Training-Inference split and runtime surfaces.
+- [Feature Pipeline](system/feature-pipeline.md): how data moves from forecast ingestion to curated features.
+- [Cloud Mapping](system/cloud-mapping.md): how local boundaries map onto hosted storage and runtime choices.
+- [Repository](system/repository.md): where the code, orchestration, tests, docs, and demo live.
+- [Milestones](milestones/index.md): the course-facing delivery narrative.

--- a/docs/site/milestones/index.md
+++ b/docs/site/milestones/index.md
@@ -1,26 +1,19 @@
 # Milestones
 
-The milestone pages mirror the four course checkpoints and are written as stable reference pages. Together they show how the project moves from proposal, to validated local execution, to presentation, to final integration.
+These pages track the four course checkpoints. Read them as a delivery narrative: proposal first, working backend second, presentation framing third, and final integration last.
 
-| Milestone | Checkpoint state | What the page covers |
-|-----------|------------------|----------------------|
-| MS1 Proposal | Submitted | Problem framing, data, features, and baseline architecture |
-| MS2 Backend | Validated locally | Feature, training, and inference paths running together |
-| MS3 Presentation | Presentation scope | The demonstration story and the system explanation used for the checkpoint |
-| MS4 Final Code | Final integration | Cloud mapping, automation, monitoring, and final packaging |
+| Milestone | Role in the project | Read it for |
+|-----------|---------------------|-------------|
+| MS1 Proposal | Project baseline | Problem framing, rider profile, data sources, and the first FTI architecture |
+| MS2 Backend | First working system | What runs locally today and how the proposal became runnable code |
+| MS3 Presentation | Demo checkpoint | The story, flow, and reviewer takeaways for the presentation |
+| MS4 Final Code | Final handoff | Integration priorities for cloud mapping, automation, monitoring, and documentation |
 
-<div class="grid cards" markdown>
+## Reading Order
 
-- **Start with MS1**
+1. Start with [MS1 Proposal](ms1.md) for the original scope and design baseline.
+2. Continue with [MS2 Backend](ms2.md) for the validated local system.
+3. Use [MS3 Presentation](ms3.md) for the demo narrative built on top of that backend.
+4. Finish with [MS4 Final Code](ms4.md) for the integration path to the final submission.
 
-  This page expands the design choices behind the submitted proposal.
-
-- **Then read MS2**
-
-  This page shows the backend that already runs locally.
-
-- **Use MS3 and MS4 as the bridge to delivery**
-
-  These pages connect the validated local backend to the presentation story and the final system handoff.
-
-</div>
+The milestone pages are intentionally lighter than the system pages. For the detailed current design, use [Architecture](../system/architecture.md) and [Cloud Mapping](../system/cloud-mapping.md).

--- a/docs/site/milestones/ms2.md
+++ b/docs/site/milestones/ms2.md
@@ -2,35 +2,23 @@
 
 <span class="fc-pill fc-pill--done">Completed</span>
 
-MS2 is where the proposal became runnable software. The local stack executes the feature, training, and inference paths together with real forecast data and a working API surface.
+MS2 is where the proposal became runnable software. The important result is simple: the local stack now executes the feature, training, and inference paths together with real forecast data and a working API surface.
 
 !!! note "How to read this page"
 
-    MS1 defined the baseline idea. MS2 is the first milestone where that idea exists as a working local backend.
-    This page focuses on what is implemented and locally validated, not on the later hosted or automation paths.
+    MS1 defined the baseline idea.
+    MS2 is the first checkpoint where that idea exists as a working local backend.
+    This page stays focused on the validated local system, not on later cloud or automation detail.
 
-## MS2 In One View
+## MS2 Outcome
 
-<div class="grid cards">
-<ul>
-<li>
-<p><strong>Feature path</strong></p>
-<p>Weather forecasts are ingested, engineered, validated, and stored as curated feature rows.</p>
-</li>
-<li>
-<p><strong>Training path</strong></p>
-<p>The curated rows are labeled, used for model training, and registered through MLflow.</p>
-</li>
-<li>
-<p><strong>Inference path</strong></p>
-<p>The API serves health, predict, rank, and spot-list endpoints from the trained model.</p>
-</li>
-<li>
-<p><strong>Optional online features</strong></p>
-<p>The same curated features can also be surfaced through an optional Feast-backed lookup path.</p>
-</li>
-</ul>
-</div>
+| Area | What MS2 established |
+|------|----------------------|
+| Feature path | forecast data can be ingested, engineered, validated, and stored as curated rows |
+| Training path | curated rows can be labeled, trained on, evaluated, and registered through MLflow |
+| Inference path | the app serves health, predict, rank, and spot-list endpoints from a trained model |
+| Local runtime | Docker Compose runs Airflow, MLflow, the API, and the development container together |
+| Optional online features | curated features can also be surfaced through an optional Feast-backed lookup path |
 
 ## What Runs End To End
 
@@ -48,30 +36,7 @@ flowchart LR
     FEAST --> APP
 </div>
 
-## From Proposal To Running Backend
-
-| MS1 baseline | What MS2 turned it into |
-|--------------|--------------------------|
-| FTI architecture | runnable feature, training, and inference modules |
-| Local-first path | a working Compose stack with Airflow, MLflow, and the API |
-| MLflow registry baseline | tracked training runs plus a serving model version |
-| Wind-quality feature engineering | implemented feature functions plus cyclical time features |
-| Personalized spot ranking | working prediction and ranking endpoints |
-| Feast in the stack story | an optional layer instead of a mandatory runtime dependency |
-
-## Backend Surface
-
-| Area | State | Notes |
-|------|-------|-------|
-| Configuration | implemented | `config.py` loads the shared YAML configuration used across the pipelines |
-| Feature pipeline | implemented | ingest, engineer, validate, and store are all present in runnable code |
-| Training pipeline | implemented | label, train, evaluate, and register feed MLflow |
-| Inference pipeline | implemented | `/health`, `/spots`, `/predict`, `/rank`, `/features/online`, and `/features/online/demo` are defined in the app |
-| Orchestration | implemented locally | Airflow runs the feature and training DAGs |
-| Local runtime | implemented | Compose brings up Airflow, MLflow, the API, and the development container |
-| Optional Feast path | implemented as an option | curated local features can also be exported, materialized, and queried online |
-
-## Representative Local Validation
+## Representative Validation
 
 | Check | What it proves |
 |-------|----------------|
@@ -81,14 +46,7 @@ flowchart LR
 | `curl -fsS -X POST http://127.0.0.1:8000/predict ...` | the app returns live per-spot predictions |
 | `docker compose exec -T development_env uv run pytest` | the local stack still passes the regression suite after initialization |
 
-## Why MS2 Is The Real Backend Baseline
-
-- The full FTI split exists in runnable code instead of stubs.
-- Airflow already exercises the feature and training paths.
-- The app already serves the inference path from a registered model version.
-- The local stack is a proof of execution, not a mock-up.
-
-## What Changed After MS1
+## What Changed From MS1
 
 | Proposal expectation | MS2 refinement |
 |----------------------|----------------|
@@ -96,8 +54,13 @@ flowchart LR
 | feature-store language suggests a heavier default stack | the current baseline keeps local storage as the default and Feast as optional |
 | inference is a planned API layer | inference now includes health, list, predict, rank, and optional online-feature routes |
 
-## Next Step Toward The Cloud
+## Why MS2 Matters
 
-MS2 proves that the backend runs locally in containers. The next step is to keep the same pipeline boundaries while moving the supporting infrastructure toward the hosted paths described in the system section.
+- The full FTI split exists in runnable code instead of stubs.
+- Airflow already exercises the feature and training paths.
+- The app already serves the inference path from a registered model version.
+- The local stack is a proof of execution, not a mock-up.
+
+MS2 proves that the backend runs locally in containers. The next step is to keep the same pipeline boundaries while improving the presentation story and then the hosted operating model.
 
 See [MS1 Proposal](ms1.md) for the original baseline and [Architecture](../system/architecture.md) for the current system view.

--- a/docs/site/milestones/ms3.md
+++ b/docs/site/milestones/ms3.md
@@ -2,33 +2,33 @@
 
 <span class="fc-pill fc-pill--progress">Presentation scope</span>
 
-MS3 is the presentation checkpoint. Its job is to explain one working system clearly: a local stack that already runs the feature, training, and inference paths together with real forecast data.
+MS3 is the presentation checkpoint. Its job is not to introduce a new system. Its job is to explain the working local system clearly and show why the architecture is credible beyond the demo.
 
 ## Presentation Arc
 
 <div class="mermaid">
 flowchart LR
-  A[Working local stack] --> B[Health, predict, and rank endpoints]
+  A[Working local stack] --> B[Ranked spot outcome]
   B --> C[Feature and training DAGs]
-  C --> D[Optional online feature lookup]
-  D --> E[Cloud mapping]
+  C --> D[Stable FTI architecture]
+  D --> E[Cloud direction]
 </div>
 
 ## What The Presentation Covers
 
 <div class="grid cards" markdown>
 
-- **Working local proof**
+- **One real system**
 
-  The demo starts from a real local stack, not slides alone, so reviewers can see one path from forecast ingestion to ranking.
+  The presentation starts from the validated local stack, not from a hypothetical future deployment.
 
 - **Pipeline split**
 
-  The explanation ties the feature, training, and inference modules back to the FTI structure used throughout the repository.
+  The explanation ties the feature, training, and inference modules back to the same FTI structure used throughout the repository.
 
-- **User-facing result**
+- **User-facing outcome**
 
-  The API responses and optional online-feature lookup keep the presentation grounded in the rider-facing outcome.
+  Ranked spots and API responses keep the checkpoint grounded in the rider-facing result.
 
 - **Cloud direction**
 
@@ -36,9 +36,19 @@ flowchart LR
 
 </div>
 
+## Suggested Demo Sequence
+
+1. Start from the rider question and the configured spots.
+2. Show the local stack responding through `/health`, `/predict`, or `/rank`.
+3. Connect that output back to the feature and training DAGs.
+4. Use the architecture diagram to explain why the backend is structured as feature, training, and inference instead of one monolith.
+5. Finish by showing that the hosted path extends the validated backend instead of replacing it.
+
 ## What A Reviewer Should Take Away
 
 - The pipelines already run end to end locally with real data.
 - Airflow already executes the feature and training jobs in that local stack.
-- The app already serves predictions, ranking, and optional online feature lookup.
+- The app already serves predictions and ranking from the same model pipeline used in training.
 - The cloud roadmap extends the validated backend instead of replacing it with a second architecture.
+
+See [MS2 Backend](ms2.md) for the validated local baseline and [Architecture](../system/architecture.md) for the system view that supports the presentation.

--- a/docs/site/milestones/ms4.md
+++ b/docs/site/milestones/ms4.md
@@ -2,7 +2,7 @@
 
 <span class="fc-pill fc-pill--progress">Final integration</span>
 
-MS4 is the wrap-up milestone. The local stack already runs end to end with real forecast data, so the final focus is integration: turn the validated backend into a clearer public handoff, strengthen the hosted path, and document the final operating model.
+MS4 is the wrap-up milestone. The local stack already runs end to end with real forecast data, so the final work is integration: keep the validated backend intact while improving the hosted path, automation, monitoring, and public handoff.
 
 ## MS4 Focus
 
@@ -28,3 +28,14 @@ flowchart LR
 - The local stack is not a mock-up. It already executes the real pipeline split.
 - The cloud plan reuses the validated modules instead of inventing a new architecture.
 - The last step is operational maturity: repeatable delivery, monitoring, and final packaging.
+
+## Current Integration Priorities
+
+| Priority | Why it matters |
+|----------|----------------|
+| Simpler public documentation | the repo and docs should explain the system quickly without burying the core story |
+| Cleaner hosted operator path | cloud setup should stay repeatable and easier to reason about than ad hoc manual steps |
+| Stronger automation | the remote Terraform and image-publishing flow should remain the default repeatable delivery path |
+| Enough monitoring for handoff | the final submission should show service and model visibility, not just raw deployment |
+
+See [Cloud Mapping](../system/cloud-mapping.md) for the hosted direction and [Getting Started](../getting-started.md) for the operator-facing setup split.

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -7,28 +7,67 @@ FoehnCast keeps one stable Feature-Training-Inference split across every runtime
     The validated baseline is the local Compose stack.
     The hosted paths reuse the same feature, training, and inference modules, but move storage, auth, and runtime services onto GCP in different ways.
 
-## Architecture In One View
+## System In One View
 
-<div class="grid cards">
-<ul>
-<li>
-<p><strong>Feature pipeline</strong></p>
-<p>Forecast data is ingested, engineered, validated, and stored as curated feature rows.</p>
-</li>
-<li>
-<p><strong>Training pipeline</strong></p>
-<p>Curated rows are labeled, used for training and evaluation, and registered through MLflow.</p>
-</li>
-<li>
-<p><strong>Inference pipeline</strong></p>
-<p>The FastAPI app serves health, predict, rank, and optional online-feature routes.</p>
-</li>
-<li>
-<p><strong>Runtime surfaces</strong></p>
-<p>The same pipeline split can run locally, on a full online compose host, or as an inference-only Cloud Run service.</p>
-</li>
-</ul>
+<div class="mermaid">
+flowchart LR
+    subgraph Feature[Feature pipeline]
+        ING[Ingest forecasts]
+        ENG[Engineer features]
+        VAL[Validate rows]
+        STO[Store curated features]
+        ING --> ENG --> VAL --> STO
+    end
+
+    subgraph Training[Training pipeline]
+        LAB[Label rows]
+        TRN[Train and evaluate]
+        REG[Register in MLflow]
+        LAB --> TRN --> REG
+    end
+
+    subgraph Inference[Inference pipeline]
+        API[FastAPI service]
+        RANK[Predict and rank]
+        API --> RANK
+    end
+
+    STO --> LAB
+    REG --> API
+    OME[Open-Meteo] --> ING
+    OME --> API
+    OSRM[OSRM] --> API
+    STO --> FEAST[Optional Feast lookup]
+    FEAST --> API
 </div>
+
+## Stable Pipeline Boundaries
+
+| Layer | Responsibility | Current runtime surface |
+|------|----------------|-------------------------|
+| Feature pipeline | Collect data, engineer curated rows, validate them, and store the result | local Airflow DAG plus the configured storage backend |
+| Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
+| Inference pipeline | Serve health, predict, rank, and spot-list responses | FastAPI app container |
+| Optional online features | Surface curated fields through an online lookup route | optional Feast-backed path plus demo page |
+
+## Runtime Surfaces
+
+<div class="mermaid">
+flowchart LR
+    LOCAL[Validated local Compose stack] --> HOST[Online compose host]
+    LOCAL --> RUN[Optional Cloud Run service]
+    HOST --> SAME[Same FTI boundaries]
+    RUN --> SAME
+</div>
+
+| Mode | What runs there | Purpose |
+|------|-----------------|---------|
+| Local Compose baseline | Airflow, MLflow, FastAPI, and the development container | default validated path for development and course evaluation |
+| Online compose host | the full Airflow, MLflow, and API stack on one GCP host | simplest way to keep the whole project online |
+| Optional Cloud Run path | the FastAPI inference service only | separate deployable serving surface |
+| GitHub automation | image publishing and Terraform workflows | repeatable delivery for the hosted paths |
+
+The online compose host exposes only the app on port `8000` by default. Airflow and MLflow stay private unless their ports are explicitly opened.
 
 ## Current Local Architecture
 
@@ -48,26 +87,6 @@ flowchart TD
     FEAST --> APP
 </div>
 
-## Stable Pipeline Boundaries
-
-| Layer | Responsibility | Current runtime surface |
-|------|----------------|-------------------------|
-| Feature pipeline | Collect data, optionally retain raw inputs, engineer curated rows, validate them, and store the curated result | local Airflow DAG plus the configured storage backend |
-| Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
-| Inference pipeline | Serve health, predict, rank, and spot-list responses | FastAPI app container |
-| Optional online features | Surface curated fields through an online lookup route | optional Feast-backed path plus demo page |
-
-## Current Runtime Surfaces
-
-| Mode | What runs there | Purpose |
-|------|-----------------|---------|
-| Local Compose baseline | Airflow, MLflow, FastAPI, and the development container | default validated path for development and course evaluation |
-| Online compose host | the full Airflow, MLflow, and API stack on one GCP host | simplest way to keep the whole project online |
-| Optional Cloud Run path | the FastAPI inference service only | separate deployable serving surface |
-| GitHub automation | image publishing and Terraform workflows | repeatable delivery for the hosted paths |
-
-The online compose host exposes only the app on port `8000` by default. Airflow and MLflow stay private unless their ports are explicitly opened.
-
 ## Representative Validation
 
 | Check | What it shows |
@@ -77,18 +96,6 @@ The online compose host exposes only the app on port `8000` by default. Airflow 
 | API health and prediction routes | the app serves a real model-backed inference surface |
 | optional Feast lookup path | the curated features can also be surfaced online without changing the base pipeline split |
 | container-side test suite | the local runtime remains reproducible after stack setup |
-
-## How The Hosted Paths Relate
-
-<div class="mermaid">
-flowchart LR
-    LOCAL[Validated local stack] --> HOST[Online compose host<br/>full stack]
-    LOCAL --> RUN[Optional Cloud Run app<br/>inference only]
-    HOST --> NEXT[More managed cloud mapping]
-    RUN --> NEXT
-</div>
-
-The online compose host is the current full-stack hosted path. Cloud Run remains a useful inference-only path. Both reuse the same application structure instead of creating a second architecture.
 
 ## Why This Architecture Holds Up
 

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -8,15 +8,15 @@ The repository keeps runtime code, orchestration, tests, and public documentatio
 src/foehncast/
   config.py
   feature_pipeline/
-    ingest.py
-    engineer.py
-    validate.py
-    store.py
   training_pipeline/
   inference_pipeline/
   monitoring/
   spots/
 dags/
+scripts/
+terraform/
+feature_repo/
+ui/
 tests/
 docs/
 ```
@@ -25,12 +25,16 @@ docs/
 
 - `src/foehncast/`: the application modules for configuration, feature engineering, training, inference, monitoring, and spot metadata.
 - `dags/`: Airflow entry points for the feature and training workflows.
+- `scripts/`: local bootstrap, cloud bootstrap, remote Terraform, and helper scripts.
+- `terraform/`: hosted infrastructure definition plus operator-facing notes.
+- `feature_repo/`: the optional Feast configuration and export surface.
+- `ui/`: the Streamlit demo surface.
 - `tests/`: regression coverage for the core pipeline logic and API behavior.
-- `docs/`: the public journal, milestone pages, and system notes used in the course handoff.
+- `docs/`: the public documentation site, milestone pages, and system notes used in the course handoff.
 
 ## Why The Layout Matters
 
-The runtime code lives under one package, while orchestration, tests, and docs stay beside it instead of being mixed into the same folder tree. That makes it easier to explain which parts define the model pipeline, which parts schedule it, and which parts document it.
+The runtime code lives under one package, while orchestration, operator scripts, infrastructure, tests, and docs stay beside it instead of being mixed into the same folder tree. That makes it easier to explain which parts define the model pipeline, which parts schedule it, which parts provision hosted environments, and which parts document the result.
 
 Central configuration lives in `config.yaml` and `src/foehncast/config.py`, so the feature, training, and inference paths read from the same settings model instead of scattering constants across modules.
 


### PR DESCRIPTION
### What Changed
- simplified the repository README into a concise front page with clear path selection and links to the docs site
- restructured the docs site landing page and navigation, including a dedicated getting-started page
- trimmed the milestone pages and concentrated the system explanation in the architecture and repository reference pages

### Why
- the README had become too long and was acting like an operator manual instead of a concise project overview
- the docs site is the better place for detailed setup, architecture, and milestone narrative
- the milestone pages needed less repetition and a clearer checkpoint-specific story

### Verification
- uv run --offline mkdocs build -f docs/mkdocs.yml --strict
- reviewed the rendered home, getting-started, and architecture pages via the local MkDocs preview

### Closes
- Closes #20
