### PR TITLE
fix(ci): exclude local-only development image from runtime publishing

### DIFF
--- a/.github/workflows/publish-runtime-images.yml
+++ b/.github/workflows/publish-runtime-images.yml
@@ -8,7 +8,6 @@ on:
       - containers/app/**
       - containers/airflow/**
       - containers/mlflow/**
-      - containers/development_env/**
       - src/**
       - pyproject.toml
       - uv.lock
@@ -36,9 +35,6 @@ jobs:
           - image_name: foehncast-mlflow
             context: containers/mlflow
             dockerfile: containers/mlflow/Dockerfile
-          - image_name: foehncast-development-env
-            context: containers/development_env
-            dockerfile: containers/development_env/Dockerfile
     steps:
       - uses: actions/checkout@v4
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -219,6 +219,19 @@ def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> N
     )
 
 
+def test_publish_runtime_images_excludes_local_only_development_env() -> None:
+    workflow = _workflow_yaml(".github/workflows/publish-runtime-images.yml")
+    push_paths = workflow["on"]["push"]["paths"]
+    image_targets = workflow["jobs"]["publish"]["strategy"]["matrix"]["include"]
+
+    assert "containers/development_env/**" not in push_paths
+    assert {target["image_name"] for target in image_targets} == {
+        "foehncast-app",
+        "foehncast-airflow",
+        "foehncast-mlflow",
+    }
+
+
 def test_terraform_declares_gcs_backend_for_remote_state() -> None:
     providers = _read_text("terraform/providers.tf")
 


### PR DESCRIPTION
What changed:\n- remove the local-only development_env image from the runtime image publishing workflow\n- add a regression test that keeps the hosted runtime image set limited to the supported images\n\nWhy:\n- development_env is part of the local baseline, not a hosted runtime target\n- the publish workflow built it with a non-root context that cannot satisfy the Dockerfile inputs\n\nVerification:\n- uv run pytest tests/test_cloud_operator_contract.py -q\n\nCloses: #92