### PR TITLE
feature(monitoring): add local monitoring stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,6 +54,16 @@ FOEHNCAST_APP_IMAGE=foehncast-app:local
 FOEHNCAST_AIRFLOW_IMAGE=foehncast-airflow:local
 FOEHNCAST_MLFLOW_IMAGE=foehncast-mlflow:local
 
+# Monitoring
+PROMETHEUS_BIND_HOST=127.0.0.1
+PROMETHEUS_PORT=9090
+STATSD_BIND_HOST=127.0.0.1
+STATSD_PORT=8125
+STATSD_EXPORTER_BIND_HOST=127.0.0.1
+STATSD_EXPORTER_PORT=9102
+GRAFANA_BIND_HOST=127.0.0.1
+GRAFANA_PORT=3000
+
 # Feast runtime binding
 # Feast is the online-serving path in both local and hosted runtimes.
 FOEHNCAST_FEAST_SOURCE=local

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ keys/
 *.key
 *.json
 !config.json
+!grafana_work/dashboards/foehncast-overview.json
 
 # Terraform
 terraform/.terraform/

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ flowchart LR
 | Inference pipeline | Working | FastAPI serves `/health`, `/spots`, `/predict`, `/rank`, and online-feature routes |
 | Hosted runtime | Working | Terraform can provision either a hosted full-stack target on one GCP host or an inference-only Cloud Run service |
 | Automation | Working | GitHub Actions publishes images, validates infrastructure, and drives remote Terraform workflows |
+| Monitoring | Working | Docker Compose provisions Prometheus, a StatsD exporter, and Grafana; the app exposes `/metrics`; and Grafana loads starter dashboards plus alert rules from checked-in config |
 
 ## Default Setup
 
@@ -50,21 +51,28 @@ This is the default path for a fresh machine.
 3. Run `./scripts/bootstrap-local.sh`.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
-The local bootstrap uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, and it prepares Feast against the bundled Datastore-mode emulator before declaring the stack ready. If the preferred host ports are already busy, the helper moves the local bindings to the next free ports and prints the resolved endpoints.
+The local bootstrap uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, prepares Feast against the bundled Datastore-mode emulator, and confirms Grafana loaded the checked-in dashboard plus alerting resources before declaring the stack ready. If the preferred host ports are already busy, the helper moves the local bindings to the next free ports and prints the resolved endpoints.
 On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically; the `training_pipeline` DAG remains manual.
 The optional `development_env` notebook container stays out of the default runtime path and starts only when you explicitly target the notebook or dev-shell Makefile commands.
 
 After bootstrap completes, the main local endpoints are:
 
 - App: `http://127.0.0.1:8000`
+- App metrics: `http://127.0.0.1:8000/metrics`
 - Airflow: `http://127.0.0.1:8080`
 - MLflow: `http://127.0.0.1:5001`
+- Prometheus: `http://127.0.0.1:9090`
+- Grafana: `http://127.0.0.1:3000`
+- StatsD UDP sink: `127.0.0.1:8125`
+- StatsD exporter: `http://127.0.0.1:9102/metrics`
 
 The bootstrap summary also prints the resolved objectstore and Feast online-store emulator endpoints.
 
 Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl`. That runtime log lets the monitoring layer compare recent model outputs against earlier outputs from the same model version without mixing disposable service state into `data/`.
 
-The local bootstrap resets Docker volumes and disposable runtime artifacts, then verifies the live `/features/online` route before it reports the stack ready.
+Grafana also provisions a starter email contact point for the checked-in alert rules. The local Docker path keeps that route on the built-in placeholder address.
+
+The local bootstrap resets Docker volumes and disposable runtime artifacts, then verifies the live `/features/online` route plus the Grafana provisioning API before it reports the stack ready.
 
 Example check:
 
@@ -93,6 +101,7 @@ Hosted deployment keeps its scope narrow. The cloud targets deploy runtime servi
 - `scripts/`: local bootstrap plus maintainer utilities
 - `terraform/`: maintainer cloud infrastructure definition and reference
 - `feature_repo/`: Feast integration surface and config repo
+- `prometheus_config/` and `grafana_work/`: checked-in monitoring stack configuration for Prometheus and Grafana
 - `tests/`: regression coverage for pipeline logic and API behavior
 - `docs/`: GitHub Pages source for the public project documentation
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -10,6 +10,7 @@ flowchart LR
 		Airflow[Airflow services]
 		MLflow[MLflow]
 		API[FastAPI app]
+		Monitor[Prometheus + StatsD exporter + Grafana]
 	end
 	subgraph LocalOnly[Local-only services]
 		Dev[optional development_env]
@@ -21,6 +22,7 @@ flowchart LR
 	Objectstore --> Airflow
 	Objectstore --> API
 	Emulator --> API
+	API --> Monitor
 	Dev --> Tests[Local tools and tests]
 ```
 
@@ -44,6 +46,7 @@ flowchart LR
 |---------------|-----------------|--------------------------|-------------------------|
 | optional `development_env`, MinIO, Feast emulator | yes | no | no |
 | Airflow, MLflow, app | yes | yes | app only |
+| Prometheus, StatsD exporter, Grafana | yes | yes | no |
 
 ## Main Components
 
@@ -69,19 +72,27 @@ flowchart LR
 - `app`: runs the FastAPI inference service in its own container so prediction and ranking are part of the stack.
 - the runtime image includes Feast support and the bundled `feature_repo/` contract so online feature access is part of the deployable app surface.
 
+### `monitoring/`
+
+- `prometheus`: scrapes the app `/metrics` route, the StatsD exporter, and stack monitoring surfaces.
+- `statsd`: exposes the UDP sink that FoehnCast monitoring helpers push to, then republishes them in Prometheus format.
+- `grafana`: provisions the Prometheus datasource, starter FoehnCast dashboard, alert rules, and a starter notification route from checked-in config.
+
+The starter notification route stays on a built-in placeholder address for the local Docker path. If the hosted full-stack target needs real mail delivery, inject `FOEHNCAST_GRAFANA_ALERT_EMAIL` through Terraform `online_compose_env_vars` and add Grafana SMTP settings for that tenant.
+
 ### `feast_online_store/`
 
 - `feast-online-store`: runs the Firestore emulator in Datastore mode so the local Feast online store matches the hosted Datastore contract more closely without requiring local `gcloud`.
 
 ## Default Local Path
 
-For the shortest evaluator path, run `./scripts/bootstrap-local.sh` from the repo root. It builds the local stack, seeds the feature and training DAGs, and checks the API health endpoint.
+For the shortest evaluator path, run `./scripts/bootstrap-local.sh` from the repo root. It builds the local stack, seeds the feature and training DAGs, and checks the app plus Grafana monitoring surfaces.
 
 This path is intentionally GCP-free. You do not need `gcloud`, Terraform, GitHub Actions variables, or Cloud Shell to run it.
 
 The default local path uses the bundled MinIO service for curated feature storage and MLflow artifacts, starts Airflow and MLflow without a login, prepares Feast against the bundled Datastore-mode emulator, and resets Docker volumes plus disposable local runtime artifacts for a clean run each time. The helper keeps the container-side endpoints on `objectstore:9000` and `feast-online-store:8080`, and can shift the host-exposed ports when the preferred defaults are already occupied.
 The optional `development_env` container now stays off unless you explicitly target it through the dedicated Makefile notebook and dev-shell commands.
-The app image itself is Feast-capable, and the local bootstrap prepares Feast state and verifies the online-feature route before declaring the stack ready.
+The app image itself is Feast-capable, and the local bootstrap prepares Feast state, verifies the online-feature route, and confirms that Grafana loaded the checked-in dashboard and alerting resources before declaring the stack ready.
 
 The initialized local runtime file is `.env`. The bootstrap script creates it from `.env.example` on first run if it does not exist yet.
 
@@ -91,7 +102,10 @@ Run these checks before deployment work:
 2. `docker compose -f docker-compose.yml -f docker-compose.objectstore.yml ps -a`
 3. `curl -fsS http://127.0.0.1:8080/api/v2/monitor/health`
 4. `curl -fsS http://127.0.0.1:8000/health`
-5. `docker compose -f docker-compose.yml -f docker-compose.objectstore.yml exec -T airflow-scheduler airflow dags list`
+5. `curl -fsS http://127.0.0.1:8000/metrics`
+6. `curl -fsS http://127.0.0.1:9090/-/ready`
+7. `curl -fsS http://127.0.0.1:3000/api/health`
+8. `docker compose -f docker-compose.yml -f docker-compose.objectstore.yml exec -T airflow-scheduler airflow dags list`
 
 ## Hosted Reuse
 

--- a/containers/app/docker-compose.yml
+++ b/containers/app/docker-compose.yml
@@ -17,6 +17,9 @@ services:
     environment:
       MLFLOW_TRACKING_URI: http://model-registry:5001
       GOOGLE_CLOUD_PROJECT: ${GCP_PROJECT_ID:-}
+      FOEHNCAST_STATSD_HOST: statsd
+      FOEHNCAST_STATSD_PORT: 8125
+      FOEHNCAST_STATSD_PREFIX: ${FOEHNCAST_STATSD_PREFIX:-drift_metrics}
       UVICORN_HOST: 0.0.0.0
       UVICORN_PORT: 8000
     volumes:

--- a/containers/monitoring/docker-compose.yml
+++ b/containers/monitoring/docker-compose.yml
@@ -1,0 +1,49 @@
+services:
+  statsd:
+    container_name: statsd
+    image: prom/statsd-exporter
+    command:
+      - --statsd.mapping-config=/etc/statsd-exporter/statsd_metrics-mapping.yml
+      - --statsd.listen-udp=:8125
+      - --web.listen-address=:9102
+    ports:
+      - ${STATSD_BIND_HOST:-127.0.0.1}:${STATSD_PORT:-8125}:8125/udp
+      - ${STATSD_EXPORTER_BIND_HOST:-127.0.0.1}:${STATSD_EXPORTER_PORT:-9102}:9102
+    volumes:
+      - ../../prometheus_config/statsd_metrics-mapping.yml:/etc/statsd-exporter/statsd_metrics-mapping.yml:ro
+    networks:
+      - development
+      - production
+
+  prometheus:
+    container_name: prometheus
+    image: prom/prometheus
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+    ports:
+      - ${PROMETHEUS_BIND_HOST:-127.0.0.1}:${PROMETHEUS_PORT:-9090}:9090
+    volumes:
+      - ../../prometheus_config:/etc/prometheus:ro
+      - prometheus_data:/prometheus
+    networks:
+      - production
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana
+    depends_on:
+      - prometheus
+    environment:
+      FOEHNCAST_GRAFANA_ALERT_EMAIL: ${FOEHNCAST_GRAFANA_ALERT_EMAIL:-alerts@example.invalid}
+    ports:
+      - ${GRAFANA_BIND_HOST:-127.0.0.1}:${GRAFANA_PORT:-3000}:3000
+    volumes:
+      - ../../grafana_work/etc:/etc/grafana:ro
+      - ../../grafana_work/data:/var/lib/grafana
+      - ../../grafana_work/dashboards:/opt/grafana/dashboards:ro
+    networks:
+      - production
+
+volumes:
+  prometheus_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,4 +4,4 @@ include:
   - containers/airflow/docker-compose.yml
   - containers/mlflow/docker-compose.yml
   - containers/app/docker-compose.yml
-#  - containers/monitoring/docker-compose.yml
+  - containers/monitoring/docker-compose.yml

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -12,7 +12,7 @@ This is the default path for a fresh machine.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 
-The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
+The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. The same local stack now includes Prometheus, a StatsD exporter, and Grafana from checked-in monitoring config, and the bootstrap helper verifies that Grafana loaded its starter resources before reporting success. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
 The optional `development_env` notebook container stays off by default and only starts when you explicitly target the notebook or dev-shell Makefile commands.
 
 Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl`, so the monitoring layer can compare recent model outputs against earlier outputs from the same model version without mixing runtime state into `data/`.
@@ -20,8 +20,11 @@ Prediction requests also append flattened local inference rows to `.state/monito
 After bootstrap completes, the main local endpoints are:
 
 - App: `http://127.0.0.1:8000`
+- App metrics: `http://127.0.0.1:8000/metrics`
 - Airflow: `http://127.0.0.1:8080`
 - MLflow: `http://127.0.0.1:5001`
+- Prometheus: `http://127.0.0.1:9090`
+- Grafana: `http://127.0.0.1:3000`
 - Objectstore UI: printed by the bootstrap helper when the stack comes up
 - Feast online store emulator: printed by the bootstrap helper when the stack comes up
 

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -49,6 +49,7 @@ flowchart LR
 | Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
 | Inference pipeline | Serve health, predict, rank, and spot-list responses | FastAPI app container |
 | Online features | Surface curated fields through an online lookup route | Feast-backed path plus demo page |
+| Monitoring | Scrape runtime metrics, collect pushed gauges, and visualize starter alerts | Prometheus, StatsD exporter, and Grafana |
 
 ## Deployment Targets
 
@@ -62,8 +63,8 @@ flowchart LR
 
 | Target | Deploys | Leaves out | Primary use |
 |------|---------|------------|-------------|
-| Local evaluator target | Airflow, MLflow, FastAPI, MinIO, the Feast Datastore emulator, and optional `development_env` tooling | shared GCP baseline | default development and course evaluation |
-| Hosted full-stack target | Airflow, MLflow, and FastAPI on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | keep the whole stack online |
+| Local evaluator target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, Grafana, MinIO, the Feast Datastore emulator, and optional `development_env` tooling | shared GCP baseline | default development and course evaluation |
+| Hosted full-stack target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, and Grafana on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | keep the whole stack online |
 | Hosted inference target | FastAPI only, backed by shared GCP services | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | publish the inference API as a smaller hosted surface |
 | GitHub automation | image publishing and Terraform workflows | runtime services | repeatable delivery, not a runtime target |
 
@@ -85,6 +86,7 @@ flowchart TD
     PAR --> OFF[Feast offline export]
     OFF --> FEAST[(Datastore-mode emulator)]
     FEAST --> APP
+    APP --> MON[Prometheus + StatsD exporter + Grafana]
 </div>
 
 ## Hosted Runtime Detail

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -16,6 +16,8 @@ dags/
 scripts/
 terraform/
 feature_repo/
+prometheus_config/
+grafana_work/
 tests/
 docs/
 ```
@@ -27,6 +29,7 @@ docs/
 - `scripts/`: local bootstrap, cloud bootstrap, remote Terraform, and helper scripts.
 - `terraform/`: hosted infrastructure definition plus operator-facing notes.
 - `feature_repo/`: the Feast integration repo and configuration surface.
+- `prometheus_config/` and `grafana_work/`: the checked-in monitoring stack configuration for Prometheus and Grafana.
 - `tests/`: regression coverage for the core pipeline logic and API behavior.
 - `docs/`: the public documentation site, milestone pages, and system notes used in the course handoff.
 

--- a/grafana_work/dashboards/foehncast-overview.json
+++ b/grafana_work/dashboards/foehncast-overview.json
@@ -1,0 +1,453 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": false,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 6,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "targets": [
+        {
+          "expr": "foehncast_feature_pipeline_summary_count",
+          "legendFormat": "summary files",
+          "refId": "A"
+        }
+      ],
+      "title": "Feature Pipeline Summary Count",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 6,
+        "y": 0
+      },
+      "id": 2,
+      "targets": [
+        {
+          "expr": "max by (dataset, storage_backend) (foehncast_feature_pipeline_run_success)",
+          "legendFormat": "{{dataset}} / {{storage_backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Latest Run Success",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 9,
+        "x": 15,
+        "y": 0
+      },
+      "id": 3,
+      "targets": [
+        {
+          "expr": "sum by (dataset, storage_backend) (foehncast_feature_pipeline_failed_spot_count)",
+          "legendFormat": "{{dataset}} / {{storage_backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Failed Spots",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "targets": [
+        {
+          "expr": "sum by (dataset, storage_backend) (foehncast_feature_pipeline_spot_feast_projection_ready)",
+          "legendFormat": "{{dataset}} / {{storage_backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Spots Ready For Feast",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "targets": [
+        {
+          "expr": "up{job=~\"foehncast_app|statsd_exporter|grafana|prometheus\"}",
+          "legendFormat": "{{job}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Monitoring Targets Up",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.15
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 16
+      },
+      "id": 6,
+      "targets": [
+        {
+          "expr": "max by (dataset_name, dataset_version) (foehncast_drift_metric{column_name=\"dataset\", metric_name=\"share_of_drifted_columns\", dataset_name!=\"inference_predictions\"})",
+          "legendFormat": "{{dataset_name}} / {{dataset_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Feature Drift Share",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0.15
+              },
+              {
+                "color": "red",
+                "value": 0.3
+              }
+            ]
+          },
+          "unit": "percentunit"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 16
+      },
+      "id": 7,
+      "targets": [
+        {
+          "expr": "max by (dataset_version) (foehncast_drift_metric{dataset_name=\"inference_predictions\", column_name=\"dataset\", metric_name=\"share_of_drifted_columns\"})",
+          "legendFormat": "model {{dataset_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Inference Drift Share",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 16
+      },
+      "id": 8,
+      "targets": [
+        {
+          "expr": "max by (dataset_version) (foehncast_drift_metric{dataset_name=\"inference_predictions\", column_name=\"quality_index\", metric_name=\"drift_score\"})",
+          "legendFormat": "model {{dataset_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Inference Quality Drift Score",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 0,
+        "y": 24
+      },
+      "id": 9,
+      "targets": [
+        {
+          "expr": "foehncast_prediction_log_total_row_count",
+          "legendFormat": "retained rows",
+          "refId": "A"
+        }
+      ],
+      "title": "Prediction Log Total Rows",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 8,
+        "y": 24
+      },
+      "id": 10,
+      "targets": [
+        {
+          "expr": "foehncast_prediction_log_model_count",
+          "legendFormat": "retained models",
+          "refId": "A"
+        }
+      ],
+      "title": "Prediction Log Models",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 8,
+        "x": 16,
+        "y": 24
+      },
+      "id": 11,
+      "targets": [
+        {
+          "expr": "foehncast_prediction_log_row_count",
+          "legendFormat": "model {{model_version}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Prediction Log Rows By Model",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 30
+      },
+      "id": 12,
+      "targets": [
+        {
+          "expr": "sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result=\"failed\"}[15m]))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Prediction Monitoring Schedule Failures (15m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 30
+      },
+      "id": 13,
+      "targets": [
+        {
+          "expr": "sum by (endpoint) (increase(foehncast_prediction_monitoring_execution_total{result=\"failed\"}[15m]))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Prediction Monitoring Execution Failures (15m)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 30
+      },
+      "id": 14,
+      "targets": [
+        {
+          "expr": "time() - max by (endpoint) (foehncast_prediction_monitoring_last_execution_timestamp_seconds{result=\"succeeded\"})",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Seconds Since Last Successful Monitoring",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "15s",
+  "schemaVersion": 39,
+  "tags": [
+    "foehncast",
+    "monitoring"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-6h",
+    "to": "now"
+  },
+  "timezone": "browser",
+  "title": "FoehnCast Monitoring",
+  "uid": "foehncast-monitoring",
+  "version": 5,
+  "weekStart": ""
+}

--- a/grafana_work/etc/grafana.ini
+++ b/grafana_work/etc/grafana.ini
@@ -1,0 +1,20 @@
+[auth]
+disable_login_form = true
+
+[auth.anonymous]
+enabled = true
+org_role = Admin
+
+[analytics]
+reporting_enabled = false
+check_for_updates = false
+check_for_plugin_updates = false
+
+[plugins]
+public_key_retrieval_disabled = true
+
+[metrics]
+enabled = true
+
+[dashboards]
+default_home_dashboard_path = /opt/grafana/dashboards/foehncast-overview.json

--- a/grafana_work/etc/provisioning/alerting/foehncast-alert-rules.yml
+++ b/grafana_work/etc/provisioning/alerting/foehncast-alert-rules.yml
@@ -1,0 +1,278 @@
+apiVersion: 1
+
+groups:
+  - orgId: 1
+    name: foehncast-monitoring-alerts
+    folder: FoehnCast Monitoring
+    interval: 1m
+    rules:
+      - uid: foehncast_predmon_schedule_fail
+        title: FoehnCast Prediction Monitoring Schedule Failures
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: 'sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="failed"}[15m]))'
+              instant: true
+              intervalMs: 1000
+              legendFormat: "{{endpoint}}"
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: "__expr__"
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: "__expr__"
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: foehncast-monitoring
+        panelId: 12
+        noDataState: OK
+        execErrState: Error
+        for: 0s
+        annotations:
+          __dashboardUid__: foehncast-monitoring
+          __panelId__: "12"
+          summary: Recent prediction-monitoring background scheduling failures detected.
+        labels:
+          component: inference-monitoring
+          severity: warning
+        isPaused: false
+      - uid: foehncast_predmon_execution_fail
+        title: FoehnCast Prediction Monitoring Execution Failures
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: 'sum by (endpoint) (increase(foehncast_prediction_monitoring_execution_total{result="failed"}[15m]))'
+              instant: true
+              intervalMs: 1000
+              legendFormat: "{{endpoint}}"
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: "__expr__"
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: "__expr__"
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: foehncast-monitoring
+        panelId: 13
+        noDataState: OK
+        execErrState: Error
+        for: 0s
+        annotations:
+          __dashboardUid__: foehncast-monitoring
+          __panelId__: "13"
+          summary: Recent prediction-monitoring background execution failures detected.
+        labels:
+          component: inference-monitoring
+          severity: warning
+        isPaused: false
+      - uid: foehncast_predmon_stale_success
+        title: FoehnCast Prediction Monitoring Stale Success
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: '((time() - max by (endpoint) (foehncast_prediction_monitoring_last_execution_timestamp_seconds{result="succeeded"})) * on (endpoint) (sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="scheduled"}[15m])) > bool 0))'
+              instant: true
+              intervalMs: 1000
+              legendFormat: '{{endpoint}}'
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: '__expr__'
+            model:
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: '__expr__'
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: '__expr__'
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 900
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: '__expr__'
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: foehncast-monitoring
+        panelId: 14
+        noDataState: OK
+        execErrState: Error
+        for: 0s
+        annotations:
+          __dashboardUid__: foehncast-monitoring
+          __panelId__: '14'
+          summary: Prediction monitoring has been active without a successful background execution for more than 15 minutes.
+        labels:
+          component: inference-monitoring
+          severity: warning
+        isPaused: false

--- a/grafana_work/etc/provisioning/alerting/foehncast-contact-points.yml
+++ b/grafana_work/etc/provisioning/alerting/foehncast-contact-points.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+contactPoints:
+  - orgId: 1
+    name: foehncast-email
+    receivers:
+      - uid: foehncast_email
+        type: email
+        settings:
+          addresses: $FOEHNCAST_GRAFANA_ALERT_EMAIL

--- a/grafana_work/etc/provisioning/alerting/foehncast-notification-policies.yml
+++ b/grafana_work/etc/provisioning/alerting/foehncast-notification-policies.yml
@@ -1,0 +1,22 @@
+apiVersion: 1
+
+policies:
+  - orgId: 1
+    receiver: foehncast-email
+    group_by:
+      - alertname
+      - severity
+    group_wait: 30s
+    group_interval: 15m
+    repeat_interval: 4h
+    routes:
+      - receiver: foehncast-email
+        object_matchers:
+          - [component, "=", inference-monitoring]
+        group_by:
+          - alertname
+          - endpoint
+          - severity
+        group_wait: 0s
+        group_interval: 15m
+        repeat_interval: 4h

--- a/grafana_work/etc/provisioning/dashboards/default.yml
+++ b/grafana_work/etc/provisioning/dashboards/default.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: FoehnCast
+    orgId: 1
+    folder: FoehnCast
+    type: file
+    disableDeletion: true
+    editable: false
+    options:
+      path: /opt/grafana/dashboards

--- a/grafana_work/etc/provisioning/datasources/foehncast-prometheus-datasource.yml
+++ b/grafana_work/etc/provisioning/datasources/foehncast-prometheus-datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    uid: prometheus
+    editable: false

--- a/prometheus_config/prometheus.yml
+++ b/prometheus_config/prometheus.yml
@@ -1,0 +1,28 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ["prometheus:9090"]
+
+  - job_name: foehncast_app
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["app:8000"]
+        labels:
+          service: app
+
+  - job_name: statsd_exporter
+    static_configs:
+      - targets: ["statsd:9102"]
+        labels:
+          service: statsd
+
+  - job_name: grafana
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["grafana:3000"]
+        labels:
+          service: grafana

--- a/prometheus_config/statsd_metrics-mapping.yml
+++ b/prometheus_config/statsd_metrics-mapping.yml
@@ -1,0 +1,10 @@
+mappings:
+  # Future drift metrics follow the planned issue #17 contract:
+  # drift_metrics.<dataset>.<version>.<column>.<metric>
+  - match: "drift_metrics.*.*.*.*"
+    name: "foehncast_drift_metric"
+    labels:
+      dataset_name: "$1"
+      dataset_version: "$2"
+      column_name: "$3"
+      metric_name: "$4"

--- a/scripts/bootstrap-local.sh
+++ b/scripts/bootstrap-local.sh
@@ -10,6 +10,8 @@ TRAINING_DATE="${TRAINING_DATE:-2024-01-02}"
 AIRFLOW_HEALTH_URL="${AIRFLOW_HEALTH_URL:-http://127.0.0.1:8080/api/v2/monitor/health}"
 APP_HEALTH_URL="${APP_HEALTH_URL:-http://127.0.0.1:8000/health}"
 ONLINE_FEATURES_URL="${ONLINE_FEATURES_URL:-http://127.0.0.1:8000/features/online}"
+GRAFANA_BASE_URL="${GRAFANA_BASE_URL:-http://127.0.0.1:3000}"
+GRAFANA_HEALTH_URL="${GRAFANA_HEALTH_URL:-${GRAFANA_BASE_URL}/api/health}"
 # shellcheck disable=SC1091
 source "${ROOT_DIR}/scripts/cli-common.sh"
 
@@ -123,6 +125,9 @@ BOOTSTRAP_SERVICES=(
   airflow-scheduler
   airflow-triggerer
   app
+  statsd
+  prometheus
+  grafana
 )
 
 compose() {
@@ -217,6 +222,83 @@ wait_for_service_health() {
   return 1
 }
 
+grafana_api_get() {
+  local path="$1"
+
+  curl --retry 60 --retry-all-errors --retry-delay 2 -fsS "${GRAFANA_BASE_URL}${path}"
+}
+
+require_payload_pattern() {
+  local payload="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if ! printf '%s' "$payload" | grep -Eq "$pattern"; then
+    echo "Grafana provisioning check failed: expected ${description}." >&2
+    printf '%s\n' "$payload" >&2
+    return 1
+  fi
+}
+
+verify_grafana_provisioning() {
+  local dashboard_payload alert_rules_payload contact_points_payload policies_payload
+
+  echo "Waiting for Grafana health..."
+  curl --retry 60 --retry-all-errors --retry-delay 2 -fsS "$GRAFANA_HEALTH_URL" >/dev/null
+
+  echo "Checking Grafana dashboard provisioning..."
+  dashboard_payload="$(grafana_api_get "/api/search?dashboardUIDs=foehncast-monitoring")"
+  require_payload_pattern \
+    "$dashboard_payload" \
+    '"uid"[[:space:]]*:[[:space:]]*"foehncast-monitoring"' \
+    'dashboard uid foehncast-monitoring'
+  require_payload_pattern \
+    "$dashboard_payload" \
+    '"title"[[:space:]]*:[[:space:]]*"FoehnCast Monitoring"' \
+    'dashboard title FoehnCast Monitoring'
+
+  echo "Checking Grafana alert-rule provisioning..."
+  alert_rules_payload="$(grafana_api_get "/api/v1/provisioning/alert-rules")"
+  require_payload_pattern \
+    "$alert_rules_payload" \
+    '"uid"[[:space:]]*:[[:space:]]*"foehncast_predmon_schedule_fail"' \
+    'schedule failure alert rule'
+  require_payload_pattern \
+    "$alert_rules_payload" \
+    '"uid"[[:space:]]*:[[:space:]]*"foehncast_predmon_execution_fail"' \
+    'execution failure alert rule'
+  require_payload_pattern \
+    "$alert_rules_payload" \
+    '"uid"[[:space:]]*:[[:space:]]*"foehncast_predmon_stale_success"' \
+    'stale success alert rule'
+
+  echo "Checking Grafana contact point provisioning..."
+  contact_points_payload="$(grafana_api_get "/api/v1/provisioning/contact-points?name=foehncast-email")"
+  require_payload_pattern \
+    "$contact_points_payload" \
+    '"uid"[[:space:]]*:[[:space:]]*"foehncast_email"' \
+    'foehncast email contact point uid'
+  require_payload_pattern \
+    "$contact_points_payload" \
+    '"name"[[:space:]]*:[[:space:]]*"foehncast-email"' \
+    'foehncast email contact point name'
+
+  echo "Checking Grafana notification policy provisioning..."
+  policies_payload="$(grafana_api_get "/api/v1/provisioning/policies")"
+  require_payload_pattern \
+    "$policies_payload" \
+    '"receiver"[[:space:]]*:[[:space:]]*"foehncast-email"' \
+    'notification policy receiver foehncast-email'
+  require_payload_pattern \
+    "$policies_payload" \
+    '"object_matchers"' \
+    'notification policy route matchers'
+  require_payload_pattern \
+    "$policies_payload" \
+    '"inference-monitoring"' \
+    'notification policy inference-monitoring matcher'
+}
+
 RUN_MODE_LABEL="local MinIO-backed objectstore baseline"
 
 export STORAGE_BACKEND="s3"
@@ -290,6 +372,8 @@ curl --retry 30 --retry-all-errors --retry-delay 2 -fsS -X POST "$FEAST_DATASTOR
 echo "Waiting for Airflow API server health..."
 curl --retry 60 --retry-all-errors --retry-delay 2 -fsS "$AIRFLOW_HEALTH_URL" >/dev/null
 
+verify_grafana_provisioning
+
 echo "Running feature pipeline for ${FEATURE_DATE}..."
 compose exec -T airflow-webserver airflow dags test feature_pipeline "$FEATURE_DATE"
 
@@ -314,6 +398,7 @@ echo "Profile:  ${RUN_MODE_LABEL}"
 echo "App:      http://127.0.0.1:8000"
 echo "Airflow:  http://127.0.0.1:8080"
 echo "MLflow:   http://127.0.0.1:5001"
+echo "Grafana:  ${GRAFANA_BASE_URL}"
 echo "Feast:    /features/online verified"
 echo "Airflow UI/API and MLflow open directly in local mode."
 echo "This bootstrap path resets local Docker volumes and disposable local runtime artifacts so each run starts clean."
@@ -322,7 +407,7 @@ echo "This keeps the local object-access layer aligned with the hosted GCS-facin
 echo "Objectstore API: ${OBJECTSTORE_ENDPOINT}"
 echo "Objectstore UI:  http://${OBJECTSTORE_BIND_HOST}:${OBJECTSTORE_CONSOLE_PORT}"
 echo "Feast online store: http://${DATASTORE_EMULATOR_HOST}"
-echo "The local bootstrap also prepares Feast state and verifies the online-feature route against the running app."
+echo "The local bootstrap also prepares Feast state, verifies the online-feature route, and confirms Grafana loaded the checked-in dashboard and alerting resources."
 echo
 echo "Sample check:"
 echo "curl -fsS -X POST http://127.0.0.1:8000/rank -H 'content-type: application/json' -d '{\"spot_ids\":[\"silvaplana\",\"urnersee\"]}'"

--- a/tests/test_monitoring_stack.py
+++ b/tests/test_monitoring_stack.py
@@ -1,0 +1,281 @@
+"""Contract tests for the modular monitoring stack."""
+
+from __future__ import annotations
+
+import configparser
+import json
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text()
+
+
+def _read_yaml(relative_path: str) -> dict:
+    return yaml.safe_load(_read_text(relative_path))
+
+
+def _read_json(relative_path: str) -> dict:
+    return json.loads(_read_text(relative_path))
+
+
+def test_root_compose_includes_monitoring_module() -> None:
+    compose = _read_yaml("docker-compose.yml")
+
+    assert "containers/monitoring/docker-compose.yml" in compose["include"]
+
+
+def test_monitoring_compose_defines_expected_services() -> None:
+    compose = _read_yaml("containers/monitoring/docker-compose.yml")
+    services = compose["services"]
+
+    assert {"statsd", "prometheus", "grafana"}.issubset(services)
+    assert "development" in services["statsd"]["networks"]
+    assert "production" in services["statsd"]["networks"]
+    assert "production" in services["prometheus"]["networks"]
+    assert "production" in services["grafana"]["networks"]
+    assert any(":8125/udp" in port for port in services["statsd"]["ports"])
+    assert (
+        "../../prometheus_config:/etc/prometheus:ro"
+        in services["prometheus"]["volumes"]
+    )
+    assert (
+        "../../grafana_work/dashboards:/opt/grafana/dashboards:ro"
+        in services["grafana"]["volumes"]
+    )
+    assert services["grafana"]["environment"]["FOEHNCAST_GRAFANA_ALERT_EMAIL"] == (
+        "${FOEHNCAST_GRAFANA_ALERT_EMAIL:-alerts@example.invalid}"
+    )
+
+
+def test_prometheus_scrapes_app_statsd_and_grafana_targets() -> None:
+    config = _read_yaml("prometheus_config/prometheus.yml")
+    jobs = {job["job_name"]: job for job in config["scrape_configs"]}
+
+    assert jobs["foehncast_app"]["metrics_path"] == "/metrics"
+    assert jobs["foehncast_app"]["static_configs"][0]["targets"] == ["app:8000"]
+    assert jobs["statsd_exporter"]["static_configs"][0]["targets"] == ["statsd:9102"]
+    assert jobs["grafana"]["static_configs"][0]["targets"] == ["grafana:3000"]
+
+
+def test_statsd_mapping_preserves_drift_metric_labels() -> None:
+    mapping = _read_yaml("prometheus_config/statsd_metrics-mapping.yml")
+
+    assert mapping["mappings"][0]["match"] == "drift_metrics.*.*.*.*"
+    assert mapping["mappings"][0]["name"] == "foehncast_drift_metric"
+
+
+def test_grafana_provisioning_points_to_prometheus_dashboard_dir() -> None:
+    datasource = _read_yaml(
+        "grafana_work/etc/provisioning/datasources/foehncast-prometheus-datasource.yml"
+    )["datasources"][0]
+    dashboard_provider = _read_yaml(
+        "grafana_work/etc/provisioning/dashboards/default.yml"
+    )["providers"][0]
+    dashboard = _read_json("grafana_work/dashboards/foehncast-overview.json")
+
+    assert datasource["url"] == "http://prometheus:9090"
+    assert datasource["uid"] == "prometheus"
+    assert dashboard_provider["options"]["path"] == "/opt/grafana/dashboards"
+    assert dashboard["title"] == "FoehnCast Monitoring"
+    assert any(
+        panel["title"] == "Feature Pipeline Summary Count"
+        for panel in dashboard["panels"]
+    )
+
+
+def test_grafana_alerting_provisions_background_monitoring_rules() -> None:
+    alerting = _read_yaml(
+        "grafana_work/etc/provisioning/alerting/foehncast-alert-rules.yml"
+    )
+    group = alerting["groups"][0]
+    rules = {rule["title"]: rule for rule in group["rules"]}
+
+    assert alerting["apiVersion"] == 1
+    assert group["folder"] == "FoehnCast Monitoring"
+    assert group["interval"] == "1m"
+    assert (
+        rules["FoehnCast Prediction Monitoring Schedule Failures"]["data"][0]["model"][
+            "expr"
+        ]
+        == 'sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="failed"}[15m]))'
+    )
+    assert rules["FoehnCast Prediction Monitoring Schedule Failures"]["panelId"] == 12
+    assert (
+        rules["FoehnCast Prediction Monitoring Execution Failures"]["data"][0]["model"][
+            "expr"
+        ]
+        == 'sum by (endpoint) (increase(foehncast_prediction_monitoring_execution_total{result="failed"}[15m]))'
+    )
+    assert rules["FoehnCast Prediction Monitoring Execution Failures"]["panelId"] == 13
+    assert (
+        rules["FoehnCast Prediction Monitoring Stale Success"]["data"][0]["model"][
+            "expr"
+        ]
+        == '((time() - max by (endpoint) (foehncast_prediction_monitoring_last_execution_timestamp_seconds{result="succeeded"})) * on (endpoint) (sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="scheduled"}[15m])) > bool 0))'
+    )
+    assert rules["FoehnCast Prediction Monitoring Stale Success"]["panelId"] == 14
+    assert all(
+        rule["dashboardUid"] == "foehncast-monitoring" for rule in rules.values()
+    )
+
+
+def test_grafana_alerting_provisions_contact_point_and_policy_tree() -> None:
+    contact_points = _read_yaml(
+        "grafana_work/etc/provisioning/alerting/foehncast-contact-points.yml"
+    )
+    policies = _read_yaml(
+        "grafana_work/etc/provisioning/alerting/foehncast-notification-policies.yml"
+    )
+
+    contact_point = contact_points["contactPoints"][0]
+    receiver = contact_point["receivers"][0]
+    policy = policies["policies"][0]
+    route = policy["routes"][0]
+
+    assert contact_points["apiVersion"] == 1
+    assert contact_point["name"] == "foehncast-email"
+    assert receiver["uid"] == "foehncast_email"
+    assert receiver["type"] == "email"
+    assert receiver["settings"]["addresses"] == "$FOEHNCAST_GRAFANA_ALERT_EMAIL"
+
+    assert policies["apiVersion"] == 1
+    assert policy["receiver"] == "foehncast-email"
+    assert policy["group_by"] == ["alertname", "severity"]
+    assert route["receiver"] == "foehncast-email"
+    assert route["object_matchers"] == [["component", "=", "inference-monitoring"]]
+    assert route["group_by"] == ["alertname", "endpoint", "severity"]
+
+
+def test_grafana_dashboard_includes_feature_and_inference_drift_panels() -> None:
+    dashboard = _read_json("grafana_work/dashboards/foehncast-overview.json")
+    panels = {panel["title"]: panel for panel in dashboard["panels"]}
+
+    assert (
+        panels["Feature Drift Share"]["targets"][0]["expr"]
+        == 'max by (dataset_name, dataset_version) (foehncast_drift_metric{column_name="dataset", metric_name="share_of_drifted_columns", dataset_name!="inference_predictions"})'
+    )
+    assert (
+        panels["Feature Drift Share"]["fieldConfig"]["defaults"]["thresholds"]["steps"][
+            1
+        ]["value"]
+        == 0.15
+    )
+    assert (
+        panels["Inference Drift Share"]["targets"][0]["expr"]
+        == 'max by (dataset_version) (foehncast_drift_metric{dataset_name="inference_predictions", column_name="dataset", metric_name="share_of_drifted_columns"})'
+    )
+    assert (
+        panels["Inference Drift Share"]["fieldConfig"]["defaults"]["thresholds"][
+            "steps"
+        ][2]["value"]
+        == 0.3
+    )
+    assert (
+        panels["Inference Quality Drift Score"]["targets"][0]["expr"]
+        == 'max by (dataset_version) (foehncast_drift_metric{dataset_name="inference_predictions", column_name="quality_index", metric_name="drift_score"})'
+    )
+    assert (
+        panels["Prediction Log Total Rows"]["targets"][0]["expr"]
+        == "foehncast_prediction_log_total_row_count"
+    )
+    assert (
+        panels["Prediction Log Models"]["targets"][0]["expr"]
+        == "foehncast_prediction_log_model_count"
+    )
+    assert (
+        panels["Prediction Log Rows By Model"]["targets"][0]["expr"]
+        == "foehncast_prediction_log_row_count"
+    )
+    assert (
+        panels["Prediction Monitoring Schedule Failures (15m)"]["targets"][0]["expr"]
+        == 'sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="failed"}[15m]))'
+    )
+    assert (
+        panels["Prediction Monitoring Schedule Failures (15m)"]["fieldConfig"][
+            "defaults"
+        ]["thresholds"]["steps"][1]["value"]
+        == 0.5
+    )
+    assert (
+        panels["Prediction Monitoring Execution Failures (15m)"]["targets"][0]["expr"]
+        == 'sum by (endpoint) (increase(foehncast_prediction_monitoring_execution_total{result="failed"}[15m]))'
+    )
+    assert (
+        panels["Prediction Monitoring Execution Failures (15m)"]["fieldConfig"][
+            "defaults"
+        ]["thresholds"]["steps"][1]["value"]
+        == 0.5
+    )
+    assert (
+        panels["Seconds Since Last Successful Monitoring"]["targets"][0]["expr"]
+        == 'time() - max by (endpoint) (foehncast_prediction_monitoring_last_execution_timestamp_seconds{result="succeeded"})'
+    )
+
+
+def test_grafana_ini_enables_anonymous_access_and_metrics() -> None:
+    config = configparser.ConfigParser()
+    config.read_string(_read_text("grafana_work/etc/grafana.ini"))
+
+    assert config.getboolean("auth.anonymous", "enabled")
+    assert config.getboolean("metrics", "enabled")
+    assert (
+        config["dashboards"]["default_home_dashboard_path"]
+        == "/opt/grafana/dashboards/foehncast-overview.json"
+    )
+
+
+def test_local_bootstrap_verifies_grafana_provisioning() -> None:
+    bootstrap = _read_text("scripts/bootstrap-local.sh")
+
+    assert "verify_grafana_provisioning" in bootstrap
+    assert "/api/search?dashboardUIDs=foehncast-monitoring" in bootstrap
+    assert "/api/v1/provisioning/alert-rules" in bootstrap
+    assert "foehncast_predmon_schedule_fail" in bootstrap
+    assert "foehncast_predmon_execution_fail" in bootstrap
+    assert "foehncast_predmon_stale_success" in bootstrap
+    assert "/api/v1/provisioning/contact-points?name=foehncast-email" in bootstrap
+    assert "/api/v1/provisioning/policies" in bootstrap
+
+
+def test_app_compose_routes_monitoring_metrics_to_statsd_service() -> None:
+    compose = _read_yaml("containers/app/docker-compose.yml")
+    environment = compose["services"]["app"]["environment"]
+
+    assert environment["FOEHNCAST_STATSD_HOST"] == "statsd"
+    assert environment["FOEHNCAST_STATSD_PORT"] == 8125
+    assert (
+        environment["FOEHNCAST_STATSD_PREFIX"]
+        == "${FOEHNCAST_STATSD_PREFIX:-drift_metrics}"
+    )
+
+
+def test_local_bootstrap_verifies_grafana_before_pipeline_runs() -> None:
+    bootstrap = _read_text("scripts/bootstrap-local.sh")
+
+    assert bootstrap.index("verify_grafana_provisioning") < bootstrap.index(
+        'echo "Running feature pipeline for ${FEATURE_DATE}..."'
+    )
+
+
+def test_local_bootstrap_waits_for_app_health_after_training_pipeline() -> None:
+    bootstrap = _read_text("scripts/bootstrap-local.sh")
+
+    assert bootstrap.index(
+        'echo "Running training pipeline for ${TRAINING_DATE}..."'
+    ) < bootstrap.index('echo "Waiting for app health..."')
+
+
+def test_local_bootstrap_starts_monitoring_services_without_development_env() -> None:
+    bootstrap = _read_text("scripts/bootstrap-local.sh")
+    services = bootstrap.split("BOOTSTRAP_SERVICES=(", 1)[1].split(")", 1)[0]
+
+    assert "statsd" in services
+    assert "prometheus" in services
+    assert "grafana" in services
+    assert "development_env" not in services


### PR DESCRIPTION
What changed:
- add a Prometheus, StatsD exporter, and Grafana compose module with checked-in provisioning
- verify Grafana dashboard and alerting resources during the local bootstrap path
- document the monitoring stack and add contract coverage for the local monitoring surface

Why:
- provide a runnable monitoring surface around the existing pipeline and inference metrics

Verification:
- uv run ruff check tests/test_monitoring_stack.py
- uv run pytest tests/test_monitoring_stack.py tests/test_pipeline_prometheus.py tests/test_pipeline_metrics.py -q
- docker compose -f docker-compose.yml config >/dev/null

Closes: #18