### PR TITLE
feature(monitoring): add drift and prediction logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ After bootstrap completes, the main local endpoints are:
 
 The bootstrap summary also prints the resolved objectstore and Feast online-store emulator endpoints.
 
+Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl`. That runtime log lets the monitoring layer compare recent model outputs against earlier outputs from the same model version without mixing disposable service state into `data/`.
+
 The local bootstrap resets Docker volumes and disposable runtime artifacts, then verifies the live `/features/online` route before it reports the stack ready.
 
 Example check:

--- a/config.yaml
+++ b/config.yaml
@@ -264,3 +264,4 @@ inference:
 monitoring:
   drift_threshold: 0.15
   evaluation_window_days: 30
+  prediction_log_retention_days: 60

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -14,6 +14,8 @@ You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compil
 
 The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
 
+Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl`, so the monitoring layer can compare recent model outputs against earlier outputs from the same model version without mixing runtime state into `data/`.
+
 After bootstrap completes, the main local endpoints are:
 
 - App: `http://127.0.0.1:8000`

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -30,7 +30,7 @@ docs/
 - `tests/`: regression coverage for the core pipeline logic and API behavior.
 - `docs/`: the public documentation site, milestone pages, and system notes used in the course handoff.
 
-One local workload data root lives under `data/`, while local runtime state stays separate. For example, curated feature rows and Feast offline parquet belong under `data/`, but local Feast registry and rendered runtime config belong under `.state/feast/` instead of mixing service state into the workload dataset tree.
+One local workload data root lives under `data/`, while local runtime state stays separate. For example, curated feature rows and Feast offline parquet belong under `data/`, but local Feast registry, rendered runtime config, and inference prediction logs belong under `.state/` instead of mixing service state into the workload dataset tree.
 
 ## Why The Layout Matters
 
@@ -49,6 +49,7 @@ There is currently no separate product UI package in the repository. The optiona
 - `terraform/terraform.tfvars`: infrastructure desired state such as regions, buckets, service names, machine shape, and deployment toggles.
 - `feature_repo/feature_store*.yaml`: checked-in Feast reference configs that stay separate from the base application config.
 - `.state/feast/feature_store.runtime.yaml`: the rendered runtime Feast binding generated from environment and used by the app and host-side Feast CLI commands.
+- `.state/monitoring/prediction-log.jsonl`: the local inference monitoring log used to compare current model outputs against earlier outputs from the same model version.
 
 The supported curated-storage backends are intentionally narrow: `s3` for the local MinIO-backed baseline and `bigquery` for the hosted analytical surface. The older file-backed curated-store compatibility path is no longer part of the runtime contract.
 
@@ -57,7 +58,7 @@ The same ownership rule now applies to MLflow connection details: the tracked ex
 ## Local Data And State Boundary
 
 - `data/`: workload data such as curated parquet outputs and Feast offline export files.
-- `.state/`: local runtime or integration state such as Feast registry and rendered runtime configuration.
+- `.state/`: local runtime or integration state such as Feast registry, rendered runtime configuration, and the local prediction-monitoring log.
 
 This matters because local development should still be inspectable, but the repo should not treat runtime state as if it were part of the workload dataset contract.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
     "scikit-learn>=1.5",
     "s3fs>=2024.0",
     "uvicorn>=0.30",
+    "evidently>=0.7.21",
 ]
 
 [dependency-groups]

--- a/src/foehncast/inference_pipeline/serve.py
+++ b/src/foehncast/inference_pipeline/serve.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+import logging
 from typing import Any
 
-from fastapi import FastAPI, HTTPException, Response
+from fastapi import BackgroundTasks, FastAPI, HTTPException, Response
 from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 
@@ -18,10 +19,22 @@ from foehncast.inference_pipeline.predict import (
     predict_spots,
 )
 from foehncast.inference_pipeline.rank import rank_spots
+from foehncast.monitoring.prediction_log import emit_prediction_drift_metrics
 from foehncast.monitoring.pipeline_prometheus import (
     CONTENT_TYPE_LATEST,
     render_feature_pipeline_prometheus_metrics,
 )
+from foehncast.monitoring.prediction_monitoring_prometheus import (
+    record_prediction_monitoring_execution,
+    record_prediction_monitoring_schedule,
+    render_prediction_monitoring_prometheus_metrics,
+)
+from foehncast.monitoring.prediction_prometheus import (
+    render_prediction_log_prometheus_metrics,
+)
+
+
+logger = logging.getLogger(__name__)
 
 
 class PredictionRequest(BaseModel):
@@ -38,13 +51,64 @@ def _not_found(exc: KeyError) -> HTTPException:
     return HTTPException(status_code=404, detail=message)
 
 
-def _rank_response(spot_ids: list[str] | None) -> dict[str, Any]:
-    prediction_payload = predict_spots(spot_ids)
+def _emit_prediction_monitoring(
+    prediction_payload: dict[str, Any],
+    *,
+    endpoint: str,
+    spot_ids: list[str] | None,
+) -> None:
+    try:
+        emit_prediction_drift_metrics(
+            prediction_payload,
+            endpoint=endpoint,
+            spot_ids=spot_ids,
+        )
+        record_prediction_monitoring_execution(endpoint, "succeeded")
+    except Exception:
+        record_prediction_monitoring_execution(endpoint, "failed")
+        logger.exception(
+            "Failed to emit prediction monitoring for endpoint '%s'",
+            endpoint,
+        )
+
+
+def _schedule_prediction_monitoring(
+    background_tasks: BackgroundTasks,
+    prediction_payload: dict[str, Any],
+    *,
+    endpoint: str,
+    spot_ids: list[str] | None,
+) -> None:
+    try:
+        background_tasks.add_task(
+            _emit_prediction_monitoring,
+            prediction_payload,
+            endpoint=endpoint,
+            spot_ids=spot_ids,
+        )
+        record_prediction_monitoring_schedule(endpoint, "scheduled")
+    except Exception:
+        record_prediction_monitoring_schedule(endpoint, "failed")
+        logger.exception(
+            "Failed to schedule prediction monitoring for endpoint '%s'",
+            endpoint,
+        )
+
+
+def _rank_response(prediction_payload: dict[str, Any]) -> dict[str, Any]:
     ranked_spots = rank_spots(prediction_payload, get_rider_config())
     return {
         "model_version": prediction_payload["model_version"],
         "ranked_spots": [asdict(spot) for spot in ranked_spots],
     }
+
+
+def _metrics_payload() -> bytes:
+    return (
+        render_feature_pipeline_prometheus_metrics()
+        + render_prediction_log_prometheus_metrics()
+        + render_prediction_monitoring_prometheus_metrics()
+    )
 
 
 def create_app() -> FastAPI:
@@ -66,16 +130,36 @@ def create_app() -> FastAPI:
         return list_available_spots()
 
     @app.post("/predict")
-    def predict(request: PredictionRequest) -> dict[str, Any]:
+    def predict(
+        request: PredictionRequest,
+        background_tasks: BackgroundTasks,
+    ) -> dict[str, Any]:
         try:
-            return predict_spots(request.spot_ids)
+            prediction_payload = predict_spots(request.spot_ids)
+            _schedule_prediction_monitoring(
+                background_tasks,
+                prediction_payload,
+                endpoint="predict",
+                spot_ids=request.spot_ids,
+            )
+            return prediction_payload
         except KeyError as exc:
             raise _not_found(exc) from exc
 
     @app.post("/rank")
-    def rank(request: PredictionRequest) -> dict[str, Any]:
+    def rank(
+        request: PredictionRequest,
+        background_tasks: BackgroundTasks,
+    ) -> dict[str, Any]:
         try:
-            return _rank_response(request.spot_ids)
+            prediction_payload = predict_spots(request.spot_ids)
+            _schedule_prediction_monitoring(
+                background_tasks,
+                prediction_payload,
+                endpoint="rank",
+                spot_ids=request.spot_ids,
+            )
+            return _rank_response(prediction_payload)
         except KeyError as exc:
             raise _not_found(exc) from exc
 
@@ -97,7 +181,7 @@ def create_app() -> FastAPI:
     @app.get("/metrics")
     def metrics() -> Response:
         return Response(
-            content=render_feature_pipeline_prometheus_metrics(),
+            content=_metrics_payload(),
             headers={"Content-Type": CONTENT_TYPE_LATEST},
         )
 

--- a/src/foehncast/monitoring/__init__.py
+++ b/src/foehncast/monitoring/__init__.py
@@ -1,5 +1,12 @@
 """Monitoring helpers for pipeline observability, drift, and model tracking."""
 
+from foehncast.monitoring.drift import (
+    DriftMetric,
+    DriftReport,
+    detect_data_drift,
+    detect_prediction_drift,
+    push_drift_metrics,
+)
 from foehncast.monitoring.pipeline_metrics import (
     FEATURE_PIPELINE_METRIC_CONTRACT,
     emit_feature_pipeline_run_summary,
@@ -7,11 +14,30 @@ from foehncast.monitoring.pipeline_metrics import (
     feature_pipeline_summary_path,
     read_feature_pipeline_run_summary,
 )
+from foehncast.monitoring.prediction_log import (
+    append_prediction_log,
+    emit_prediction_drift_metrics,
+    read_prediction_log,
+)
+from foehncast.monitoring.prediction_prometheus import (
+    build_prediction_log_prometheus_registry,
+    render_prediction_log_prometheus_metrics,
+)
 
 __all__ = [
+    "DriftMetric",
+    "DriftReport",
     "FEATURE_PIPELINE_METRIC_CONTRACT",
+    "append_prediction_log",
+    "build_prediction_log_prometheus_registry",
+    "detect_data_drift",
+    "detect_prediction_drift",
+    "emit_prediction_drift_metrics",
     "emit_feature_pipeline_run_summary",
     "feature_pipeline_stage_overview",
     "feature_pipeline_summary_path",
+    "push_drift_metrics",
+    "read_prediction_log",
     "read_feature_pipeline_run_summary",
+    "render_prediction_log_prometheus_metrics",
 ]

--- a/src/foehncast/monitoring/drift.py
+++ b/src/foehncast/monitoring/drift.py
@@ -1,1 +1,484 @@
-"""Evidently drift detection on feature and label distributions."""
+"""Drift detection helpers backed by Evidently and StatsD."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import UTC, datetime
+import os
+import re
+import socket
+from typing import Any
+
+import pandas as pd
+
+from foehncast.config import get_monitoring_config
+
+_DEFAULT_DRIFT_THRESHOLD = 0.15
+_DEFAULT_EVALUATION_WINDOW_DAYS = 30
+_DEFAULT_STATSD_HOST = "127.0.0.1"
+_DEFAULT_STATSD_PORT = 8125
+_DEFAULT_STATSD_PREFIX = "drift_metrics"
+_PREDICTION_TIME_COLUMNS = (
+    "prediction_timestamp",
+    "timestamp",
+    "created_at",
+    "event_time",
+    "time",
+)
+_PREDICTION_PRIORITY_COLUMNS = (
+    "prediction",
+    "predicted_quality_index",
+    "quality_index",
+    "score",
+)
+_PREDICTION_EXCLUDED_COLUMNS = {
+    "spot_id",
+    "model_version",
+    "request_id",
+    "user_id",
+    "session_id",
+}
+
+
+@dataclass(frozen=True)
+class DriftMetric:
+    """Column-level drift result extracted from Evidently output."""
+
+    column_name: str
+    drift_score: float | None
+    drift_detected: bool
+    threshold: float | None = None
+    method: str | None = None
+
+
+@dataclass(frozen=True)
+class DriftReport:
+    """Stable drift report contract used by monitoring and tests."""
+
+    report_kind: str
+    dataset_name: str
+    dataset_version: str
+    threshold: float
+    reference_row_count: int
+    current_row_count: int
+    column_count: int
+    drifted_column_count: int
+    share_of_drifted_columns: float
+    dataset_drift: bool
+    generated_at: str
+    metrics: tuple[DriftMetric, ...]
+    raw_metrics: tuple[dict[str, Any], ...] = ()
+
+
+def detect_data_drift(
+    reference_df: pd.DataFrame,
+    current_df: pd.DataFrame,
+    threshold: float | None = None,
+) -> DriftReport:
+    """Detect drift between two feature datasets."""
+    dataset_name, dataset_version = _report_identity(
+        current_df,
+        default_name="data",
+        default_version="v1",
+    )
+    reference_frame, current_frame = _prepare_drift_frames(reference_df, current_df)
+    resolved_threshold = _resolved_drift_threshold(threshold)
+    return _build_drift_report(
+        report_kind="data",
+        dataset_name=dataset_name,
+        dataset_version=dataset_version,
+        reference_frame=reference_frame,
+        current_frame=current_frame,
+        threshold=resolved_threshold,
+    )
+
+
+def detect_prediction_drift(predictions_log: pd.DataFrame) -> DriftReport:
+    """Detect drift in logged predictions between reference and recent windows."""
+    if predictions_log.empty:
+        raise ValueError("Prediction log must not be empty")
+
+    dataset_name, dataset_version = _report_identity(
+        predictions_log,
+        default_name="prediction",
+        default_version="v1",
+    )
+
+    reference_frame, current_frame = _split_prediction_log(
+        predictions_log, _resolved_evaluation_window_days()
+    )
+    selected_columns = _prediction_columns(reference_frame, current_frame)
+    if not selected_columns:
+        raise ValueError(
+            "Prediction log does not contain comparable prediction columns"
+        )
+
+    return _build_drift_report(
+        report_kind="prediction",
+        dataset_name=dataset_name,
+        dataset_version=dataset_version,
+        reference_frame=reference_frame[selected_columns].copy(),
+        current_frame=current_frame[selected_columns].copy(),
+        threshold=_resolved_drift_threshold(),
+    )
+
+
+def push_drift_metrics(report: DriftReport) -> None:
+    """Push drift metrics to StatsD for Prometheus scraping."""
+    host = os.getenv("FOEHNCAST_STATSD_HOST", _DEFAULT_STATSD_HOST).strip()
+    port = int(os.getenv("FOEHNCAST_STATSD_PORT", str(_DEFAULT_STATSD_PORT)).strip())
+    prefix = os.getenv("FOEHNCAST_STATSD_PREFIX", _DEFAULT_STATSD_PREFIX).strip()
+
+    with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as client:
+        for line in _statsd_lines(report, prefix or _DEFAULT_STATSD_PREFIX):
+            client.sendto(line.encode("utf-8"), (host or _DEFAULT_STATSD_HOST, port))
+
+
+def _build_drift_report(
+    *,
+    report_kind: str,
+    dataset_name: str,
+    dataset_version: str,
+    reference_frame: pd.DataFrame,
+    current_frame: pd.DataFrame,
+    threshold: float,
+) -> DriftReport:
+    raw_metrics = tuple(
+        _run_evidently_data_drift(reference_frame, current_frame, threshold)
+    )
+    metrics, drifted_column_count, share_of_drifted_columns = _parse_column_metrics(
+        raw_metrics, len(reference_frame.columns)
+    )
+
+    return DriftReport(
+        report_kind=report_kind,
+        dataset_name=dataset_name,
+        dataset_version=dataset_version,
+        threshold=threshold,
+        reference_row_count=int(len(reference_frame)),
+        current_row_count=int(len(current_frame)),
+        column_count=int(len(reference_frame.columns)),
+        drifted_column_count=drifted_column_count,
+        share_of_drifted_columns=share_of_drifted_columns,
+        dataset_drift=share_of_drifted_columns >= threshold,
+        generated_at=datetime.now(UTC).isoformat(),
+        metrics=metrics,
+        raw_metrics=raw_metrics,
+    )
+
+
+def _run_evidently_data_drift(
+    reference_frame: pd.DataFrame,
+    current_frame: pd.DataFrame,
+    threshold: float,
+) -> list[dict[str, Any]]:
+    report_class, drift_preset_class = _evidently_classes()
+    snapshot = report_class([drift_preset_class(drift_share=threshold)]).run(
+        current_data=current_frame,
+        reference_data=reference_frame,
+    )
+    return list(snapshot.dict().get("metrics", []))
+
+
+def _evidently_classes() -> tuple[Any, Any]:
+    try:
+        from evidently import Report
+        from evidently.presets import DataDriftPreset
+    except ImportError as exc:  # pragma: no cover - guarded by dependency setup
+        raise RuntimeError(
+            "Evidently is required for drift detection. Install the 'evidently' package."
+        ) from exc
+
+    return Report, DataDriftPreset
+
+
+def _prepare_drift_frames(
+    reference_df: pd.DataFrame,
+    current_df: pd.DataFrame,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    if reference_df.empty or current_df.empty:
+        raise ValueError("Reference and current datasets must not be empty")
+
+    common_columns = [
+        column for column in reference_df.columns if column in current_df.columns
+    ]
+    if not common_columns:
+        raise ValueError("Reference and current datasets share no comparable columns")
+
+    return (
+        reference_df[common_columns].copy().reset_index(drop=True),
+        current_df[common_columns].copy().reset_index(drop=True),
+    )
+
+
+def _report_identity(
+    frame: pd.DataFrame,
+    *,
+    default_name: str,
+    default_version: str,
+) -> tuple[str, str]:
+    attrs = getattr(frame, "attrs", {}) or {}
+    dataset_name = str(attrs.get("dataset_name", "")).strip() or default_name
+    dataset_version = str(attrs.get("dataset_version", "")).strip() or default_version
+    return dataset_name, dataset_version
+
+
+def _resolved_drift_threshold(threshold: float | None = None) -> float:
+    if threshold is not None:
+        return float(threshold)
+
+    monitoring_config = get_monitoring_config()
+    return float(monitoring_config.get("drift_threshold", _DEFAULT_DRIFT_THRESHOLD))
+
+
+def _resolved_evaluation_window_days() -> int:
+    monitoring_config = get_monitoring_config()
+    return int(
+        monitoring_config.get(
+            "evaluation_window_days",
+            _DEFAULT_EVALUATION_WINDOW_DAYS,
+        )
+    )
+
+
+def _prediction_time_column(frame: pd.DataFrame) -> str | None:
+    for column in _PREDICTION_TIME_COLUMNS:
+        if column in frame.columns:
+            return column
+    return None
+
+
+def _split_prediction_log(
+    predictions_log: pd.DataFrame,
+    evaluation_window_days: int,
+) -> tuple[pd.DataFrame, pd.DataFrame]:
+    if len(predictions_log) < 2:
+        raise ValueError("Prediction log must contain at least two rows")
+
+    time_column = _prediction_time_column(predictions_log)
+    if time_column is not None:
+        timestamps = pd.to_datetime(
+            predictions_log[time_column], errors="coerce", utc=True
+        )
+        valid_rows = timestamps.notna()
+        if valid_rows.any():
+            ordered = predictions_log.loc[valid_rows].copy()
+            ordered[time_column] = timestamps.loc[valid_rows]
+            ordered = ordered.sort_values(time_column).reset_index(drop=True)
+            cutoff = ordered[time_column].max() - pd.Timedelta(
+                days=evaluation_window_days
+            )
+            reference_frame = ordered.loc[ordered[time_column] < cutoff]
+            current_frame = ordered.loc[ordered[time_column] >= cutoff]
+            if not reference_frame.empty and not current_frame.empty:
+                return reference_frame.reset_index(
+                    drop=True
+                ), current_frame.reset_index(drop=True)
+
+    midpoint = len(predictions_log) // 2
+    if midpoint == 0 or midpoint == len(predictions_log):
+        raise ValueError("Prediction log must contain two comparable windows")
+
+    ordered = predictions_log.reset_index(drop=True)
+    return ordered.iloc[:midpoint].copy(), ordered.iloc[midpoint:].copy()
+
+
+def _prediction_columns(
+    reference_frame: pd.DataFrame,
+    current_frame: pd.DataFrame,
+) -> list[str]:
+    common_columns = [
+        column
+        for column in reference_frame.columns
+        if column in current_frame.columns
+        and column not in _PREDICTION_EXCLUDED_COLUMNS
+        and column not in _PREDICTION_TIME_COLUMNS
+        and not column.endswith("_id")
+    ]
+    preferred = [
+        column
+        for column in common_columns
+        if column in _PREDICTION_PRIORITY_COLUMNS or "prediction" in column.lower()
+    ]
+    if preferred:
+        return preferred
+
+    return [
+        column
+        for column in common_columns
+        if pd.api.types.is_numeric_dtype(reference_frame[column])
+        or pd.api.types.is_bool_dtype(reference_frame[column])
+        or pd.api.types.is_string_dtype(reference_frame[column])
+        or pd.api.types.is_object_dtype(reference_frame[column])
+    ]
+
+
+def _parse_column_metrics(
+    raw_metrics: tuple[dict[str, Any], ...],
+    column_count: int,
+) -> tuple[tuple[DriftMetric, ...], int, float]:
+    drifted_column_count: int | None = None
+    share_of_drifted_columns: float | None = None
+    column_metrics: list[DriftMetric] = []
+
+    # Evidently 0.7 emits a flat metric list rather than the older nested result object.
+    for metric in raw_metrics:
+        config = metric.get("config", {})
+        metric_type = str(config.get("type", ""))
+        value = metric.get("value")
+
+        if metric_type.endswith(":DriftedColumnsCount") and isinstance(value, dict):
+            drifted_column_count = int(float(value.get("count", 0.0)))
+            share_of_drifted_columns = float(value.get("share", 0.0))
+            continue
+
+        if not metric_type.endswith(":ValueDrift"):
+            continue
+
+        score = _safe_float(value)
+        threshold = _safe_float(config.get("threshold"))
+        method = str(config.get("method", "")).strip() or None
+        column_metrics.append(
+            DriftMetric(
+                column_name=str(config.get("column", "unknown")),
+                drift_score=score,
+                drift_detected=_is_drift_detected(score, threshold, method),
+                threshold=threshold,
+                method=method,
+            )
+        )
+
+    if drifted_column_count is None:
+        drifted_column_count = sum(metric.drift_detected for metric in column_metrics)
+    if share_of_drifted_columns is None:
+        divisor = column_count or len(column_metrics) or 1
+        share_of_drifted_columns = float(drifted_column_count / divisor)
+
+    return tuple(column_metrics), drifted_column_count, share_of_drifted_columns
+
+
+def _safe_float(value: Any) -> float | None:
+    if value is None:
+        return None
+    numeric = float(value)
+    if pd.isna(numeric):
+        return None
+    return numeric
+
+
+def _is_drift_detected(
+    score: float | None,
+    threshold: float | None,
+    method: str | None,
+) -> bool:
+    if score is None or threshold is None:
+        return False
+
+    normalized_method = (method or "").lower()
+    if "p_value" in normalized_method or "p-value" in normalized_method:
+        return score <= threshold
+    return score >= threshold
+
+
+def _statsd_lines(report: DriftReport, prefix: str) -> list[str]:
+    dataset_name = _sanitize_metric_segment(report.dataset_name)
+    dataset_version = _sanitize_metric_segment(report.dataset_version)
+    lines = [
+        _statsd_line(
+            prefix,
+            dataset_name,
+            dataset_version,
+            "dataset",
+            "threshold",
+            report.threshold,
+        ),
+        _statsd_line(
+            prefix,
+            dataset_name,
+            dataset_version,
+            "dataset",
+            "drifted_column_count",
+            float(report.drifted_column_count),
+        ),
+        _statsd_line(
+            prefix,
+            dataset_name,
+            dataset_version,
+            "dataset",
+            "share_of_drifted_columns",
+            report.share_of_drifted_columns,
+        ),
+        _statsd_line(
+            prefix,
+            dataset_name,
+            dataset_version,
+            "dataset",
+            "dataset_drift",
+            float(report.dataset_drift),
+        ),
+    ]
+
+    for metric in report.metrics:
+        column_name = _sanitize_metric_segment(metric.column_name)
+        lines.append(
+            _statsd_line(
+                prefix,
+                dataset_name,
+                dataset_version,
+                column_name,
+                "drift_detected",
+                float(metric.drift_detected),
+            )
+        )
+        if metric.drift_score is not None:
+            lines.append(
+                _statsd_line(
+                    prefix,
+                    dataset_name,
+                    dataset_version,
+                    column_name,
+                    "drift_score",
+                    metric.drift_score,
+                )
+            )
+        if metric.threshold is not None:
+            lines.append(
+                _statsd_line(
+                    prefix,
+                    dataset_name,
+                    dataset_version,
+                    column_name,
+                    "threshold",
+                    metric.threshold,
+                )
+            )
+
+    return lines
+
+
+def _statsd_line(
+    prefix: str,
+    dataset_name: str,
+    dataset_version: str,
+    column_name: str,
+    metric_name: str,
+    value: float,
+) -> str:
+    return (
+        f"{_sanitize_metric_segment(prefix)}.{dataset_name}.{dataset_version}."
+        f"{column_name}.{_sanitize_metric_segment(metric_name)}:{value}|g"
+    )
+
+
+def _sanitize_metric_segment(value: str) -> str:
+    sanitized = re.sub(r"[^A-Za-z0-9]+", "_", value).strip("_")
+    return sanitized or "unknown"
+
+
+__all__ = [
+    "DriftMetric",
+    "DriftReport",
+    "detect_data_drift",
+    "detect_prediction_drift",
+    "push_drift_metrics",
+]

--- a/src/foehncast/monitoring/prediction_log.py
+++ b/src/foehncast/monitoring/prediction_log.py
@@ -1,0 +1,313 @@
+"""Prediction log persistence and model-side drift monitoring helpers."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any
+
+import pandas as pd
+
+from foehncast.config import get_monitoring_config
+from foehncast.monitoring.drift import (
+    DriftReport,
+    detect_prediction_drift,
+    push_drift_metrics,
+)
+from foehncast.paths import project_root
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_PREDICTION_LOG_MAX_ROWS = 2048
+_DEFAULT_PREDICTION_LOG_RETENTION_DAYS = 60
+
+
+def _default_prediction_log_path() -> Path:
+    return project_root() / ".state" / "monitoring" / "prediction-log.jsonl"
+
+
+def _prediction_log_max_rows(configured: int | None = None) -> int:
+    if configured is not None:
+        return max(int(configured), 2)
+
+    raw_value = os.getenv(
+        "FOEHNCAST_PREDICTION_LOG_MAX_ROWS",
+        str(_DEFAULT_PREDICTION_LOG_MAX_ROWS),
+    ).strip()
+    try:
+        parsed = int(raw_value)
+    except ValueError:
+        logger.warning(
+            "Invalid FOEHNCAST_PREDICTION_LOG_MAX_ROWS=%r; using %s",
+            raw_value,
+            _DEFAULT_PREDICTION_LOG_MAX_ROWS,
+        )
+        return _DEFAULT_PREDICTION_LOG_MAX_ROWS
+
+    return max(parsed, 2)
+
+
+def _prediction_log_lines(source: Path) -> list[str]:
+    return [
+        line for line in source.read_text(encoding="utf-8").splitlines() if line.strip()
+    ]
+
+
+def _prediction_log_retention_days(configured: int | None = None) -> int:
+    if configured is not None:
+        return max(int(configured), 1)
+
+    monitoring_config = get_monitoring_config()
+    evaluation_window_days = max(
+        int(monitoring_config.get("evaluation_window_days", 30)),
+        1,
+    )
+    configured_retention_days = int(
+        monitoring_config.get(
+            "prediction_log_retention_days",
+            _DEFAULT_PREDICTION_LOG_RETENTION_DAYS,
+        )
+    )
+    return max(configured_retention_days, evaluation_window_days * 2)
+
+
+def _normalized_model_version(value: Any) -> str:
+    return str(value or "unknown").strip() or "unknown"
+
+
+def _retained_prediction_log_lines(
+    lines: list[str],
+    *,
+    max_rows: int,
+    retention_days: int,
+    model_version: str | None = None,
+) -> list[str]:
+    entries: list[dict[str, Any]] = []
+    valid_timestamps: list[pd.Timestamp] = []
+
+    for index, line in enumerate(lines):
+        record = json.loads(line)
+        prediction_timestamp = pd.to_datetime(
+            record.get("prediction_timestamp"),
+            errors="coerce",
+            utc=True,
+        )
+        if pd.notna(prediction_timestamp):
+            valid_timestamps.append(prediction_timestamp)
+        entries.append(
+            {
+                "index": index,
+                "line": line,
+                "model_version": _normalized_model_version(record.get("model_version")),
+                "prediction_timestamp": prediction_timestamp,
+            }
+        )
+
+    if valid_timestamps:
+        cutoff = max(valid_timestamps) - pd.Timedelta(days=retention_days)
+        entries = [
+            entry
+            for entry in entries
+            if pd.notna(entry["prediction_timestamp"])
+            and entry["prediction_timestamp"] >= cutoff
+        ]
+
+    if model_version is not None:
+        normalized_model_version = _normalized_model_version(model_version)
+        return [
+            entry["line"]
+            for entry in entries
+            if entry["model_version"] == normalized_model_version
+        ][-max_rows:]
+
+    retained_indices_by_model: dict[str, list[int]] = {}
+
+    for entry in entries:
+        indices = retained_indices_by_model.setdefault(entry["model_version"], [])
+        indices.append(entry["index"])
+        if len(indices) > max_rows:
+            indices.pop(0)
+
+    retained_indices = {
+        index for indices in retained_indices_by_model.values() for index in indices
+    }
+    return [entry["line"] for entry in entries if entry["index"] in retained_indices]
+
+
+def _trim_prediction_log(
+    source: Path,
+    *,
+    max_rows: int,
+    retention_days: int,
+) -> None:
+    lines = _prediction_log_lines(source)
+    retained_lines = _retained_prediction_log_lines(
+        lines,
+        max_rows=max_rows,
+        retention_days=retention_days,
+    )
+
+    if retained_lines == lines:
+        return
+
+    source.write_text(
+        "".join(f"{line}\n" for line in retained_lines),
+        encoding="utf-8",
+    )
+
+
+def _flatten_prediction_payload(
+    prediction_payload: dict[str, Any],
+    *,
+    endpoint: str,
+    spot_ids: list[str] | None = None,
+    logged_at: datetime | None = None,
+) -> list[dict[str, Any]]:
+    resolved_timestamp = (logged_at or datetime.now(UTC)).isoformat()
+    model_version = _normalized_model_version(prediction_payload.get("model_version"))
+    requested_spot_ids = list(spot_ids or [])
+    rows: list[dict[str, Any]] = []
+
+    for prediction in prediction_payload.get("predictions", []):
+        for forecast in prediction.get("forecast", []):
+            rows.append(
+                {
+                    "prediction_timestamp": resolved_timestamp,
+                    "forecast_time": forecast.get("time"),
+                    "quality_index": float(forecast["quality_index"]),
+                    "endpoint": endpoint,
+                    "model_version": model_version,
+                    "spot_id": prediction.get("spot_id"),
+                    "spot_name": prediction.get("spot_name"),
+                    "requested_spot_ids": requested_spot_ids,
+                }
+            )
+
+    return rows
+
+
+def append_prediction_log(
+    prediction_payload: dict[str, Any],
+    *,
+    endpoint: str,
+    spot_ids: list[str] | None = None,
+    path: Path | None = None,
+    logged_at: datetime | None = None,
+    max_rows: int | None = None,
+    retention_days: int | None = None,
+) -> Path | None:
+    rows = _flatten_prediction_payload(
+        prediction_payload,
+        endpoint=endpoint,
+        spot_ids=spot_ids,
+        logged_at=logged_at,
+    )
+    if not rows:
+        return None
+
+    destination = path or _default_prediction_log_path()
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    with destination.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+    _trim_prediction_log(
+        destination,
+        max_rows=_prediction_log_max_rows(max_rows),
+        retention_days=_prediction_log_retention_days(retention_days),
+    )
+
+    return destination
+
+
+def read_prediction_log(
+    path: Path | None = None,
+    *,
+    max_rows: int | None = None,
+    model_version: str | None = None,
+    retention_days: int | None = None,
+) -> pd.DataFrame:
+    source = path or _default_prediction_log_path()
+    if not source.exists():
+        return pd.DataFrame()
+
+    lines = _retained_prediction_log_lines(
+        _prediction_log_lines(source),
+        max_rows=_prediction_log_max_rows(max_rows),
+        retention_days=_prediction_log_retention_days(retention_days),
+        model_version=model_version,
+    )
+
+    rows = [json.loads(line) for line in lines]
+    frame = pd.DataFrame(rows)
+    if frame.empty:
+        return frame
+
+    for column in ("prediction_timestamp", "forecast_time"):
+        if column in frame.columns:
+            frame[column] = pd.to_datetime(frame[column], errors="coerce", utc=True)
+
+    return frame
+
+
+def emit_prediction_drift_metrics(
+    prediction_payload: dict[str, Any],
+    *,
+    endpoint: str,
+    spot_ids: list[str] | None = None,
+    path: Path | None = None,
+    max_rows: int | None = None,
+    retention_days: int | None = None,
+) -> DriftReport | None:
+    try:
+        model_version = _normalized_model_version(
+            prediction_payload.get("model_version")
+        )
+        log_path = append_prediction_log(
+            prediction_payload,
+            endpoint=endpoint,
+            spot_ids=spot_ids,
+            path=path,
+            max_rows=max_rows,
+            retention_days=retention_days,
+        )
+        if log_path is None:
+            return None
+
+        predictions_log = read_prediction_log(
+            log_path,
+            max_rows=max_rows,
+            model_version=model_version,
+            retention_days=retention_days,
+        )
+        if predictions_log.empty:
+            return None
+
+        if len(predictions_log) < 2:
+            return None
+
+        predictions_log.attrs.update(
+            {
+                "dataset_name": "inference_predictions",
+                "dataset_version": model_version,
+            }
+        )
+        report = detect_prediction_drift(predictions_log)
+        push_drift_metrics(report)
+        return report
+    except Exception:
+        logger.exception(
+            "Failed to append prediction log or emit prediction drift metrics"
+        )
+        return None
+
+
+__all__ = [
+    "append_prediction_log",
+    "emit_prediction_drift_metrics",
+    "read_prediction_log",
+]

--- a/src/foehncast/monitoring/prediction_monitoring_prometheus.py
+++ b/src/foehncast/monitoring/prediction_monitoring_prometheus.py
@@ -1,0 +1,118 @@
+"""Prometheus export helpers for in-process prediction-monitoring runtime signals."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from threading import Lock
+
+from prometheus_client import CollectorRegistry, Counter, Gauge, generate_latest
+
+_state_lock = Lock()
+_schedule_counts: dict[tuple[str, str], int] = {}
+_execution_counts: dict[tuple[str, str], int] = {}
+_schedule_timestamps: dict[tuple[str, str], float] = {}
+_execution_timestamps: dict[tuple[str, str], float] = {}
+
+
+def _normalized_label(value: str | None) -> str:
+    return str(value or "unknown").strip() or "unknown"
+
+
+def _timestamp_seconds(when: datetime | None) -> float:
+    resolved = when or datetime.now(UTC)
+    if resolved.tzinfo is None:
+        resolved = resolved.replace(tzinfo=UTC)
+    return resolved.timestamp()
+
+
+def record_prediction_monitoring_schedule(
+    endpoint: str,
+    result: str,
+    *,
+    when: datetime | None = None,
+) -> None:
+    key = (_normalized_label(endpoint), _normalized_label(result))
+    with _state_lock:
+        _schedule_counts[key] = _schedule_counts.get(key, 0) + 1
+        _schedule_timestamps[key] = _timestamp_seconds(when)
+
+
+def record_prediction_monitoring_execution(
+    endpoint: str,
+    result: str,
+    *,
+    when: datetime | None = None,
+) -> None:
+    key = (_normalized_label(endpoint), _normalized_label(result))
+    with _state_lock:
+        _execution_counts[key] = _execution_counts.get(key, 0) + 1
+        _execution_timestamps[key] = _timestamp_seconds(when)
+
+
+def _reset_prediction_monitoring_state() -> None:
+    with _state_lock:
+        _schedule_counts.clear()
+        _execution_counts.clear()
+        _schedule_timestamps.clear()
+        _execution_timestamps.clear()
+
+
+def build_prediction_monitoring_prometheus_registry() -> CollectorRegistry:
+    """Render in-process prediction-monitoring state into a scrapeable registry."""
+    registry = CollectorRegistry()
+
+    schedule_total = Counter(
+        "foehncast_prediction_monitoring_schedule_total",
+        "Total prediction-monitoring background task scheduling attempts by endpoint and result.",
+        labelnames=("endpoint", "result"),
+        registry=registry,
+    )
+    execution_total = Counter(
+        "foehncast_prediction_monitoring_execution_total",
+        "Total prediction-monitoring background task executions by endpoint and result.",
+        labelnames=("endpoint", "result"),
+        registry=registry,
+    )
+    last_schedule_timestamp = Gauge(
+        "foehncast_prediction_monitoring_last_schedule_timestamp_seconds",
+        "Unix timestamp of the latest prediction-monitoring scheduling event by endpoint and result.",
+        labelnames=("endpoint", "result"),
+        registry=registry,
+    )
+    last_execution_timestamp = Gauge(
+        "foehncast_prediction_monitoring_last_execution_timestamp_seconds",
+        "Unix timestamp of the latest prediction-monitoring execution event by endpoint and result.",
+        labelnames=("endpoint", "result"),
+        registry=registry,
+    )
+
+    with _state_lock:
+        schedule_counts = dict(_schedule_counts)
+        execution_counts = dict(_execution_counts)
+        schedule_timestamps = dict(_schedule_timestamps)
+        execution_timestamps = dict(_execution_timestamps)
+
+    for labels, count in schedule_counts.items():
+        schedule_total.labels(*labels).inc(float(count))
+    for labels, count in execution_counts.items():
+        execution_total.labels(*labels).inc(float(count))
+    for labels, timestamp in schedule_timestamps.items():
+        last_schedule_timestamp.labels(*labels).set(timestamp)
+    for labels, timestamp in execution_timestamps.items():
+        last_execution_timestamp.labels(*labels).set(timestamp)
+
+    return registry
+
+
+def render_prediction_monitoring_prometheus_metrics() -> bytes:
+    """Return Prometheus exposition text for in-process prediction monitoring."""
+    registry = build_prediction_monitoring_prometheus_registry()
+    return generate_latest(registry)
+
+
+__all__ = [
+    "build_prediction_monitoring_prometheus_registry",
+    "record_prediction_monitoring_execution",
+    "record_prediction_monitoring_schedule",
+    "render_prediction_monitoring_prometheus_metrics",
+]

--- a/src/foehncast/monitoring/prediction_prometheus.py
+++ b/src/foehncast/monitoring/prediction_prometheus.py
@@ -1,0 +1,100 @@
+"""Prometheus export helpers for persisted prediction-log monitoring state."""
+
+from __future__ import annotations
+
+import pandas as pd
+from prometheus_client import CollectorRegistry, Gauge, generate_latest
+
+from foehncast.monitoring.prediction_log import read_prediction_log
+
+
+def build_prediction_log_prometheus_registry(
+    predictions_log: pd.DataFrame | None = None,
+) -> CollectorRegistry:
+    """Render the retained prediction log into a scrapeable registry."""
+    resolved_log = (
+        read_prediction_log() if predictions_log is None else predictions_log.copy()
+    )
+    registry = CollectorRegistry()
+
+    total_rows = Gauge(
+        "foehncast_prediction_log_total_row_count",
+        "Number of retained prediction-log rows available for inference monitoring.",
+        registry=registry,
+    )
+    model_count = Gauge(
+        "foehncast_prediction_log_model_count",
+        "Number of retained model versions present in the prediction log.",
+        registry=registry,
+    )
+    row_count = Gauge(
+        "foehncast_prediction_log_row_count",
+        "Retained prediction-log row count for one model version.",
+        labelnames=("model_version",),
+        registry=registry,
+    )
+    latest_prediction_timestamp = Gauge(
+        "foehncast_prediction_log_latest_prediction_timestamp_seconds",
+        "Unix timestamp of the latest retained prediction-log write for one model version.",
+        labelnames=("model_version",),
+        registry=registry,
+    )
+    latest_forecast_timestamp = Gauge(
+        "foehncast_prediction_log_latest_forecast_timestamp_seconds",
+        "Unix timestamp of the latest retained forecast timestamp for one model version.",
+        labelnames=("model_version",),
+        registry=registry,
+    )
+
+    total_rows.set(float(len(resolved_log)))
+    if resolved_log.empty:
+        model_count.set(0.0)
+        return registry
+
+    grouped = resolved_log.groupby(
+        resolved_log["model_version"].astype(str),
+        dropna=False,
+    )
+    model_count.set(float(len(grouped)))
+
+    for model_version, frame in grouped:
+        labels = (str(model_version).strip() or "unknown",)
+        row_count.labels(*labels).set(float(len(frame)))
+
+        if "prediction_timestamp" in frame.columns:
+            prediction_timestamps = pd.to_datetime(
+                frame["prediction_timestamp"],
+                errors="coerce",
+                utc=True,
+            )
+            if prediction_timestamps.notna().any():
+                latest_prediction_timestamp.labels(*labels).set(
+                    prediction_timestamps.max().timestamp()
+                )
+
+        if "forecast_time" in frame.columns:
+            forecast_timestamps = pd.to_datetime(
+                frame["forecast_time"],
+                errors="coerce",
+                utc=True,
+            )
+            if forecast_timestamps.notna().any():
+                latest_forecast_timestamp.labels(*labels).set(
+                    forecast_timestamps.max().timestamp()
+                )
+
+    return registry
+
+
+def render_prediction_log_prometheus_metrics(
+    predictions_log: pd.DataFrame | None = None,
+) -> bytes:
+    """Return Prometheus exposition text for the retained prediction log."""
+    registry = build_prediction_log_prometheus_registry(predictions_log=predictions_log)
+    return generate_latest(registry)
+
+
+__all__ = [
+    "build_prediction_log_prometheus_registry",
+    "render_prediction_log_prometheus_metrics",
+]

--- a/src/foehncast/orchestration.py
+++ b/src/foehncast/orchestration.py
@@ -18,6 +18,7 @@ from foehncast.feature_pipeline.engineer import engineer_features
 from foehncast.feature_pipeline.ingest import fetch_all_spots
 from foehncast.feature_pipeline.store import read_features, write_features
 from foehncast.feature_pipeline.validate import run_validation
+from foehncast.monitoring.drift import detect_data_drift, push_drift_metrics
 from foehncast.monitoring.pipeline_metrics import (
     build_feature_pipeline_run_summary,
     build_feature_pipeline_spot_summary,
@@ -28,6 +29,58 @@ from foehncast.training_pipeline.evaluate import generate_evaluation_report
 from foehncast.training_pipeline.register import promote_model, register_model
 
 logger = logging.getLogger(__name__)
+
+
+def _read_optional_feature_slice(spot_id: str, dataset: str) -> pd.DataFrame:
+    try:
+        return read_features(spot_id=spot_id, dataset=dataset)
+    except FileNotFoundError:
+        return pd.DataFrame()
+    except Exception:
+        logger.exception(
+            "Failed to load prior stored features for drift monitoring on spot '%s'",
+            spot_id,
+        )
+        return pd.DataFrame()
+
+
+def _feature_drift_frame(
+    frame: pd.DataFrame,
+    *,
+    spot_id: str,
+    dataset: str,
+) -> pd.DataFrame:
+    tagged = frame.copy()
+    tagged.attrs = {
+        **getattr(tagged, "attrs", {}),
+        "dataset_name": spot_id,
+        "dataset_version": dataset,
+    }
+    return tagged
+
+
+def _emit_feature_drift_metrics(
+    *,
+    spot_id: str,
+    dataset: str,
+    reference_df: pd.DataFrame,
+    current_df: pd.DataFrame,
+) -> None:
+    if reference_df.empty or current_df.empty:
+        return
+
+    try:
+        report = detect_data_drift(
+            _feature_drift_frame(reference_df, spot_id=spot_id, dataset=dataset),
+            _feature_drift_frame(current_df, spot_id=spot_id, dataset=dataset),
+        )
+        push_drift_metrics(report)
+    except Exception:
+        logger.exception(
+            "Failed to emit feature drift metrics for spot '%s' in dataset '%s'",
+            spot_id,
+            dataset,
+        )
 
 
 def resolve_airflow_schedule(
@@ -49,7 +102,7 @@ def resolve_airflow_schedule(
 
 
 def run_feature_pipeline(dataset: str = "train") -> list[str]:
-    """Fetch, engineer, validate, and store features for all configured spots."""
+    """Fetch, engineer, validate, store, and monitor features for all spots."""
     spots = get_spots()
     forecasts_by_spot: dict[str, pd.DataFrame] = {}
     stored_spots: list[str] = []
@@ -74,6 +127,7 @@ def run_feature_pipeline(dataset: str = "train") -> list[str]:
                 continue
 
             feature_df = pd.DataFrame()
+            previous_stored_df = _read_optional_feature_slice(spot_id, dataset)
             validation = None
             stored_df = pd.DataFrame()
 
@@ -87,6 +141,12 @@ def run_feature_pipeline(dataset: str = "train") -> list[str]:
 
                 write_features(feature_df, spot_id=spot_id, dataset=dataset)
                 stored_df = read_features(spot_id=spot_id, dataset=dataset)
+                _emit_feature_drift_metrics(
+                    spot_id=spot_id,
+                    dataset=dataset,
+                    reference_df=previous_stored_df,
+                    current_df=stored_df,
+                )
             except Exception as exc:
                 spot_summaries.append(
                     build_feature_pipeline_spot_summary(

--- a/tests/test_drift.py
+++ b/tests/test_drift.py
@@ -1,0 +1,208 @@
+"""Tests for drift detection helpers."""
+
+from __future__ import annotations
+
+import socket
+
+import pandas as pd
+import pytest
+
+from foehncast.monitoring import drift
+
+
+def _sample_evidently_metrics() -> list[dict[str, object]]:
+    return [
+        {
+            "metric_name": "DriftedColumnsCount(drift_share=0.25)",
+            "config": {
+                "type": "evidently:metric_v2:DriftedColumnsCount",
+                "drift_share": 0.25,
+            },
+            "value": {"count": 1.0, "share": 0.5},
+        },
+        {
+            "metric_name": "ValueDrift(column=wind_speed_10m,method=ks p_value,threshold=0.05)",
+            "config": {
+                "type": "evidently:metric_v2:ValueDrift",
+                "column": "wind_speed_10m",
+                "method": "ks p_value",
+                "threshold": 0.05,
+            },
+            "value": 0.01,
+        },
+        {
+            "metric_name": "ValueDrift(column=temperature_2m,method=ks p_value,threshold=0.05)",
+            "config": {
+                "type": "evidently:metric_v2:ValueDrift",
+                "column": "temperature_2m",
+                "method": "ks p_value",
+                "threshold": 0.05,
+            },
+            "value": 0.6,
+        },
+    ]
+
+
+def test_detect_data_drift_uses_config_threshold_and_parses_metrics(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def fake_run(
+        reference_frame: pd.DataFrame,
+        current_frame: pd.DataFrame,
+        threshold: float,
+    ) -> list[dict[str, object]]:
+        captured["reference_columns"] = list(reference_frame.columns)
+        captured["current_columns"] = list(current_frame.columns)
+        captured["threshold"] = threshold
+        return _sample_evidently_metrics()
+
+    monkeypatch.setattr(drift, "_run_evidently_data_drift", fake_run)
+    monkeypatch.setattr(
+        drift,
+        "get_monitoring_config",
+        lambda: {"drift_threshold": 0.25, "evaluation_window_days": 30},
+    )
+
+    reference_df = pd.DataFrame(
+        {"wind_speed_10m": [1.0, 2.0], "temperature_2m": [5.0, 6.0]}
+    )
+    current_df = pd.DataFrame(
+        {"wind_speed_10m": [8.0, 9.0], "temperature_2m": [7.0, 8.0]}
+    )
+    current_df.attrs.update({"dataset_name": "silvaplana", "dataset_version": "train"})
+
+    report = drift.detect_data_drift(reference_df, current_df)
+
+    assert captured["reference_columns"] == ["wind_speed_10m", "temperature_2m"]
+    assert captured["current_columns"] == ["wind_speed_10m", "temperature_2m"]
+    assert captured["threshold"] == 0.25
+    assert report.dataset_name == "silvaplana"
+    assert report.dataset_version == "train"
+    assert report.threshold == 0.25
+    assert report.drifted_column_count == 1
+    assert report.share_of_drifted_columns == 0.5
+    assert report.dataset_drift is True
+    assert report.metrics[0].column_name == "wind_speed_10m"
+    assert report.metrics[0].drift_detected is True
+    assert report.metrics[1].drift_detected is False
+
+
+def test_detect_prediction_drift_uses_recent_window_and_prediction_columns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, pd.DataFrame] = {}
+
+    def fake_run(
+        reference_frame: pd.DataFrame,
+        current_frame: pd.DataFrame,
+        threshold: float,
+    ) -> list[dict[str, object]]:
+        captured["reference"] = reference_frame.copy()
+        captured["current"] = current_frame.copy()
+        captured["threshold"] = pd.DataFrame({"threshold": [threshold]})
+        return _sample_evidently_metrics()
+
+    monkeypatch.setattr(drift, "_run_evidently_data_drift", fake_run)
+    monkeypatch.setattr(
+        drift,
+        "get_monitoring_config",
+        lambda: {"drift_threshold": 0.2, "evaluation_window_days": 7},
+    )
+
+    predictions_log = pd.DataFrame(
+        {
+            "prediction_timestamp": pd.to_datetime(
+                [
+                    "2026-05-01T00:00:00Z",
+                    "2026-05-02T00:00:00Z",
+                    "2026-05-10T00:00:00Z",
+                    "2026-05-11T00:00:00Z",
+                ]
+            ),
+            "prediction": [0.1, 0.2, 0.9, 0.95],
+            "spot_id": ["silvaplana", "silvaplana", "urnersee", "urnersee"],
+        }
+    )
+    predictions_log.attrs.update(
+        {"dataset_name": "online_predictions", "dataset_version": "serve_v1"}
+    )
+
+    report = drift.detect_prediction_drift(predictions_log)
+
+    assert list(captured["reference"].columns) == ["prediction"]
+    assert list(captured["current"].columns) == ["prediction"]
+    assert list(captured["reference"]["prediction"]) == [0.1, 0.2]
+    assert list(captured["current"]["prediction"]) == [0.9, 0.95]
+    assert report.report_kind == "prediction"
+    assert report.dataset_name == "online_predictions"
+    assert report.dataset_version == "serve_v1"
+    assert report.threshold == 0.2
+
+
+def test_push_drift_metrics_sends_statsd_gauges(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    sent: list[tuple[str, tuple[str, int]]] = []
+
+    class FakeSocket:
+        def __enter__(self) -> "FakeSocket":
+            return self
+
+        def __exit__(self, exc_type, exc, tb) -> None:
+            return None
+
+        def sendto(self, payload: bytes, address: tuple[str, int]) -> None:
+            sent.append((payload.decode("utf-8"), address))
+
+    monkeypatch.setenv("FOEHNCAST_STATSD_HOST", "127.0.0.1")
+    monkeypatch.setenv("FOEHNCAST_STATSD_PORT", "8125")
+    monkeypatch.setenv("FOEHNCAST_STATSD_PREFIX", "drift.metrics")
+    monkeypatch.setattr(socket, "socket", lambda *args, **kwargs: FakeSocket())
+
+    report = drift.DriftReport(
+        report_kind="data",
+        dataset_name="forecast features",
+        dataset_version="v1",
+        threshold=0.15,
+        reference_row_count=48,
+        current_row_count=24,
+        column_count=2,
+        drifted_column_count=1,
+        share_of_drifted_columns=0.5,
+        dataset_drift=True,
+        generated_at="2026-05-11T10:00:00+00:00",
+        metrics=(
+            drift.DriftMetric(
+                column_name="wind_speed_10m",
+                drift_score=0.01,
+                drift_detected=True,
+                threshold=0.05,
+                method="ks p_value",
+            ),
+        ),
+    )
+
+    drift.push_drift_metrics(report)
+
+    payloads = [payload for payload, _ in sent]
+    assert all(address == ("127.0.0.1", 8125) for _, address in sent)
+    assert (
+        "drift_metrics.forecast_features.v1.dataset.share_of_drifted_columns:0.5|g"
+        in payloads
+    )
+    assert "drift_metrics.forecast_features.v1.dataset.dataset_drift:1.0|g" in payloads
+    assert (
+        "drift_metrics.forecast_features.v1.wind_speed_10m.drift_score:0.01|g"
+        in payloads
+    )
+
+
+def test_detect_data_drift_rejects_disjoint_columns() -> None:
+    with pytest.raises(ValueError, match="share no comparable columns"):
+        drift.detect_data_drift(
+            pd.DataFrame({"wind_speed_10m": [1.0, 2.0]}),
+            pd.DataFrame({"temperature_2m": [3.0, 4.0]}),
+            threshold=0.15,
+        )

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -59,11 +59,25 @@ def test_run_feature_pipeline_fetches_validated_features(
         "write_features",
         lambda df, spot_id, dataset: stored.append((spot_id, dataset)),
     )
+
+    read_calls = 0
+
+    def fake_read_features(spot_id: str, dataset: str) -> pd.DataFrame:
+        nonlocal read_calls
+        read_calls += 1
+        if read_calls == 1:
+            raise FileNotFoundError("No stored feature rows yet")
+        return feature_df.assign(gust_factor=1.2)
+
     monkeypatch.setattr(
         orchestration,
         "read_features",
-        lambda spot_id, dataset: feature_df.assign(gust_factor=1.2),
+        fake_read_features,
     )
+    monkeypatch.setattr(
+        orchestration, "detect_data_drift", lambda *args, **kwargs: None
+    )
+    monkeypatch.setattr(orchestration, "push_drift_metrics", lambda report: None)
     monkeypatch.setattr(
         orchestration,
         "emit_feature_pipeline_run_summary",
@@ -78,6 +92,115 @@ def test_run_feature_pipeline_fetches_validated_features(
     assert emitted["summary"]["stored_spot_count"] == 1
     assert emitted["summary"]["spots"][0]["storage"]["stored_rows"] == 1
     assert emitted["summary"]["spots"][0]["feast"]["projection_ready"] is False
+
+
+def test_run_feature_pipeline_emits_drift_metrics_when_previous_slice_exists(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    forecast_df = pd.DataFrame(
+        {
+            "wind_speed_10m": [12.0, 13.0],
+            "wind_gusts_10m": [16.0, 17.0],
+            "wind_direction_10m": [220.0, 221.0],
+        }
+    )
+    previous_stored_df = pd.DataFrame(
+        {
+            "wind_speed_10m": [10.0, 11.0],
+            "wind_gusts_10m": [14.0, 15.0],
+            "wind_direction_10m": [218.0, 219.0],
+            "gust_factor": [1.1, 1.15],
+        }
+    )
+    current_stored_df = pd.DataFrame(
+        {
+            "wind_speed_10m": [12.0, 13.0],
+            "wind_gusts_10m": [16.0, 17.0],
+            "wind_direction_10m": [220.0, 221.0],
+            "gust_factor": [1.2, 1.25],
+        }
+    )
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        orchestration,
+        "get_spots",
+        lambda: [{"id": "silvaplana", "shore_orientation_deg": 225}],
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "fetch_all_spots",
+        lambda: {"silvaplana": forecast_df},
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "engineer_features",
+        lambda df, shore_orientation_deg: df.assign(gust_factor=[1.2, 1.25]),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "run_validation",
+        lambda df, spot_id: SimpleNamespace(
+            is_valid=True,
+            missing_columns=[],
+            null_fractions={"wind_speed_10m": 0.0},
+            range_violations=pd.DataFrame(),
+        ),
+    )
+    monkeypatch.setattr(
+        orchestration, "write_features", lambda df, spot_id, dataset: None
+    )
+
+    read_calls = 0
+
+    def fake_read_features(spot_id: str, dataset: str) -> pd.DataFrame:
+        nonlocal read_calls
+        read_calls += 1
+        if read_calls == 1:
+            return previous_stored_df
+        return current_stored_df
+
+    monkeypatch.setattr(orchestration, "read_features", fake_read_features)
+    monkeypatch.setattr(
+        orchestration,
+        "detect_data_drift",
+        lambda reference_df, current_df, threshold=None: (
+            captured.update(
+                {
+                    "reference_attrs": dict(reference_df.attrs),
+                    "current_attrs": dict(current_df.attrs),
+                    "reference_rows": len(reference_df),
+                    "current_rows": len(current_df),
+                }
+            )
+            or SimpleNamespace(dataset_name="silvaplana", dataset_version="train")
+        ),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "push_drift_metrics",
+        lambda report: captured.update({"pushed_report": report}),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "emit_feature_pipeline_run_summary",
+        lambda summary: None,
+    )
+
+    stored_spots = orchestration.run_feature_pipeline(dataset="train")
+
+    assert stored_spots == ["silvaplana"]
+    assert captured["reference_attrs"] == {
+        "dataset_name": "silvaplana",
+        "dataset_version": "train",
+    }
+    assert captured["current_attrs"] == {
+        "dataset_name": "silvaplana",
+        "dataset_version": "train",
+    }
+    assert captured["reference_rows"] == 2
+    assert captured["current_rows"] == 2
+    assert captured["pushed_report"].dataset_name == "silvaplana"
 
 
 def test_run_feature_pipeline_raises_on_validation_failure(

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 
 import pandas as pd
 import pytest
+from fastapi import BackgroundTasks
 from fastapi.testclient import TestClient
 from prometheus_client import CONTENT_TYPE_LATEST
 
@@ -159,6 +160,40 @@ def test_spots_endpoint_lists_available_spots(
     assert response.json() == [spot]
 
 
+def test_schedule_prediction_monitoring_enqueues_background_task() -> None:
+    payload = {"model_version": "11", "predictions": []}
+    background_tasks = BackgroundTasks()
+
+    serve._schedule_prediction_monitoring(
+        background_tasks,
+        payload,
+        endpoint="predict",
+        spot_ids=["silvaplana"],
+    )
+
+    assert len(background_tasks.tasks) == 1
+    task = background_tasks.tasks[0]
+    assert task.func is serve._emit_prediction_monitoring
+    assert task.args == (payload,)
+    assert task.kwargs == {
+        "endpoint": "predict",
+        "spot_ids": ["silvaplana"],
+    }
+
+
+def test_schedule_prediction_monitoring_ignores_background_task_failure() -> None:
+    class BrokenBackgroundTasks:
+        def add_task(self, *args: object, **kwargs: object) -> None:
+            raise RuntimeError("background queue unavailable")
+
+    serve._schedule_prediction_monitoring(
+        BrokenBackgroundTasks(),
+        {"model_version": "11", "predictions": []},
+        endpoint="predict",
+        spot_ids=["silvaplana"],
+    )
+
+
 def test_predict_endpoint_returns_prediction_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -173,12 +208,29 @@ def test_predict_endpoint_returns_prediction_payload(
         ],
     }
     monkeypatch.setattr(serve, "predict_spots", lambda spot_ids: payload)
+    recorded: dict[str, object] = {}
+    monkeypatch.setattr(
+        serve,
+        "emit_prediction_drift_metrics",
+        lambda prediction_payload, endpoint, spot_ids=None: recorded.update(
+            {
+                "prediction_payload": prediction_payload,
+                "endpoint": endpoint,
+                "spot_ids": spot_ids,
+            }
+        ),
+    )
     client = TestClient(serve.app)
 
     response = client.post("/predict", json={"spot_ids": ["silvaplana"]})
 
     assert response.status_code == 200
     assert response.json() == payload
+    assert recorded == {
+        "prediction_payload": payload,
+        "endpoint": "predict",
+        "spot_ids": ["silvaplana"],
+    }
 
 
 def test_predict_endpoint_returns_404_for_unknown_spot(
@@ -222,6 +274,18 @@ def test_rank_endpoint_returns_ranked_spots_payload(
     ]
 
     monkeypatch.setattr(serve, "predict_spots", lambda spot_ids: payload)
+    recorded: dict[str, object] = {}
+    monkeypatch.setattr(
+        serve,
+        "emit_prediction_drift_metrics",
+        lambda prediction_payload, endpoint, spot_ids=None: recorded.update(
+            {
+                "prediction_payload": prediction_payload,
+                "endpoint": endpoint,
+                "spot_ids": spot_ids,
+            }
+        ),
+    )
     monkeypatch.setattr(
         serve,
         "get_rider_config",
@@ -239,6 +303,31 @@ def test_rank_endpoint_returns_ranked_spots_payload(
         "model_version": "11",
         "ranked_spots": [asdict(ranked_spots[0])],
     }
+    assert recorded == {
+        "prediction_payload": payload,
+        "endpoint": "rank",
+        "spot_ids": ["silvaplana"],
+    }
+
+
+def test_predict_endpoint_ignores_prediction_monitoring_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = {"model_version": "11", "predictions": []}
+    monkeypatch.setattr(serve, "predict_spots", lambda spot_ids: payload)
+    monkeypatch.setattr(
+        serve,
+        "emit_prediction_drift_metrics",
+        lambda prediction_payload, endpoint, spot_ids=None: (_ for _ in ()).throw(
+            RuntimeError("statsd unavailable")
+        ),
+    )
+    client = TestClient(serve.app)
+
+    response = client.post("/predict", json={"spot_ids": ["silvaplana"]})
+
+    assert response.status_code == 200
+    assert response.json() == payload
 
 
 def test_rank_endpoint_returns_404_for_unknown_spot(
@@ -371,19 +460,39 @@ def test_online_features_demo_endpoint_returns_html(
 def test_metrics_endpoint_returns_prometheus_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    payload = (
+    feature_payload = (
         b"# HELP foehncast_feature_pipeline_summary_count example\n"
         b"foehncast_feature_pipeline_summary_count 1\n"
+    )
+    prediction_payload = (
+        b"# HELP foehncast_prediction_log_total_row_count example\n"
+        b"foehncast_prediction_log_total_row_count 2\n"
+    )
+    monitoring_payload = (
+        b"# HELP foehncast_prediction_monitoring_schedule_total example\n"
+        b'foehncast_prediction_monitoring_schedule_total{endpoint="predict",result="scheduled"} 1\n'
     )
     monkeypatch.setattr(
         serve,
         "render_feature_pipeline_prometheus_metrics",
-        lambda: payload,
+        lambda: feature_payload,
+    )
+    monkeypatch.setattr(
+        serve,
+        "render_prediction_log_prometheus_metrics",
+        lambda: prediction_payload,
+    )
+    monkeypatch.setattr(
+        serve,
+        "render_prediction_monitoring_prometheus_metrics",
+        lambda: monitoring_payload,
     )
     client = TestClient(serve.app)
 
     response = client.get("/metrics")
 
     assert response.status_code == 200
-    assert response.content == payload
+    assert response.content == (
+        feature_payload + prediction_payload + monitoring_payload
+    )
     assert response.headers["content-type"] == CONTENT_TYPE_LATEST

--- a/tests/test_prediction_log.py
+++ b/tests/test_prediction_log.py
@@ -1,0 +1,473 @@
+"""Tests for prediction log persistence and drift monitoring."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from pathlib import Path
+from types import SimpleNamespace
+
+import pandas as pd
+import pytest
+
+from foehncast.monitoring import prediction_log
+
+
+def test_append_prediction_log_and_read_prediction_log_round_trip(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+    payload = {
+        "model_version": "7",
+        "predictions": [
+            {
+                "spot_id": "silvaplana",
+                "spot_name": "Silvaplana",
+                "forecast": [
+                    {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.4},
+                    {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.8},
+                ],
+            }
+        ],
+    }
+
+    written = prediction_log.append_prediction_log(
+        payload,
+        endpoint="predict",
+        spot_ids=["silvaplana"],
+        path=log_path,
+        logged_at=datetime(2026, 5, 11, 10, 0, tzinfo=UTC),
+    )
+
+    frame = prediction_log.read_prediction_log(log_path)
+
+    assert written == log_path
+    assert len(frame) == 2
+    assert list(frame["spot_id"]) == ["silvaplana", "silvaplana"]
+    assert list(frame["quality_index"]) == [2.4, 2.8]
+    assert list(frame["endpoint"]) == ["predict", "predict"]
+    assert list(frame["model_version"]) == ["7", "7"]
+    assert (
+        frame["prediction_timestamp"].iloc[0].isoformat() == "2026-05-11T10:00:00+00:00"
+    )
+
+
+def test_append_prediction_log_trims_to_recent_rows(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.1},
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.2},
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        max_rows=3,
+        logged_at=datetime(2026, 5, 11, 10, 0, tzinfo=UTC),
+    )
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T02:00:00+00:00", "quality_index": 2.3},
+                        {"time": "2025-01-01T03:00:00+00:00", "quality_index": 2.4},
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        max_rows=3,
+        logged_at=datetime(2026, 5, 11, 11, 0, tzinfo=UTC),
+    )
+
+    frame = prediction_log.read_prediction_log(log_path, max_rows=3)
+
+    assert len(frame) == 3
+    assert list(frame["quality_index"]) == [2.2, 2.3, 2.4]
+    assert [value.isoformat() for value in frame["forecast_time"]] == [
+        "2025-01-01T01:00:00+00:00",
+        "2025-01-01T02:00:00+00:00",
+        "2025-01-01T03:00:00+00:00",
+    ]
+
+
+def test_append_prediction_log_preserves_recent_rows_per_model_version(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+
+    def append(model_version: str, quality_index: float, hour: int) -> None:
+        prediction_log.append_prediction_log(
+            {
+                "model_version": model_version,
+                "predictions": [
+                    {
+                        "spot_id": "silvaplana",
+                        "spot_name": "Silvaplana",
+                        "forecast": [
+                            {
+                                "time": f"2025-01-01T{hour:02d}:00:00+00:00",
+                                "quality_index": quality_index,
+                            }
+                        ],
+                    }
+                ],
+            },
+            endpoint="predict",
+            path=log_path,
+            max_rows=2,
+            logged_at=datetime(2026, 5, 11, 10, hour, tzinfo=UTC),
+        )
+
+    append("7", 2.1, 0)
+    append("8", 3.1, 1)
+    append("7", 2.2, 2)
+    append("8", 3.2, 3)
+    append("7", 2.3, 4)
+
+    version_7 = prediction_log.read_prediction_log(
+        log_path,
+        max_rows=2,
+        model_version="7",
+    )
+    version_8 = prediction_log.read_prediction_log(
+        log_path,
+        max_rows=2,
+        model_version="8",
+    )
+    all_rows = prediction_log.read_prediction_log(log_path, max_rows=10)
+
+    assert list(version_7["quality_index"]) == [2.2, 2.3]
+    assert list(version_8["quality_index"]) == [3.1, 3.2]
+    assert len(all_rows) == 4
+
+
+def test_append_prediction_log_prunes_stale_model_rows_outside_retention_window(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "6",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 1.5}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        max_rows=2,
+        retention_days=30,
+        logged_at=datetime(2026, 1, 1, 10, 0, tzinfo=UTC),
+    )
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.4},
+                        {"time": "2025-01-01T02:00:00+00:00", "quality_index": 2.6},
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        max_rows=2,
+        retention_days=30,
+        logged_at=datetime(2026, 2, 15, 10, 0, tzinfo=UTC),
+    )
+
+    frame = prediction_log.read_prediction_log(
+        log_path,
+        max_rows=10,
+        retention_days=30,
+    )
+
+    assert list(frame["model_version"]) == ["7", "7"]
+    assert list(frame["quality_index"]) == [2.4, 2.6]
+
+
+def test_read_prediction_log_uses_env_configured_max_rows(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+    monkeypatch.setenv("FOEHNCAST_PREDICTION_LOG_MAX_ROWS", "2")
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.1},
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.2},
+                        {"time": "2025-01-01T02:00:00+00:00", "quality_index": 2.3},
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        logged_at=datetime(2026, 5, 11, 10, 0, tzinfo=UTC),
+    )
+
+    frame = prediction_log.read_prediction_log(log_path)
+
+    assert len(frame) == 2
+    assert list(frame["quality_index"]) == [2.2, 2.3]
+
+
+def test_read_prediction_log_uses_minimum_two_window_retention_from_config(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+    monkeypatch.setattr(
+        prediction_log,
+        "get_monitoring_config",
+        lambda: {
+            "evaluation_window_days": 30,
+            "prediction_log_retention_days": 10,
+        },
+    )
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.1}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        max_rows=2,
+        logged_at=datetime(2026, 1, 25, 10, 0, tzinfo=UTC),
+    )
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.3}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        max_rows=2,
+        logged_at=datetime(2026, 2, 14, 10, 0, tzinfo=UTC),
+    )
+
+    frame = prediction_log.read_prediction_log(log_path, max_rows=10)
+
+    assert len(frame) == 2
+    assert list(frame["quality_index"]) == [2.1, 2.3]
+
+
+def test_emit_prediction_drift_metrics_filters_to_current_model_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+    captured: dict[str, object] = {}
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "6",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 1.5}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        logged_at=datetime(2026, 5, 10, 10, 0, tzinfo=UTC),
+    )
+
+    def fake_detect_prediction_drift(predictions_log: pd.DataFrame) -> SimpleNamespace:
+        captured["rows"] = len(predictions_log)
+        captured["versions"] = list(predictions_log["model_version"])
+        captured["dataset_name"] = predictions_log.attrs["dataset_name"]
+        captured["dataset_version"] = predictions_log.attrs["dataset_version"]
+        return SimpleNamespace(
+            dataset_name=predictions_log.attrs["dataset_name"],
+            dataset_version=predictions_log.attrs["dataset_version"],
+        )
+
+    monkeypatch.setattr(
+        prediction_log,
+        "detect_prediction_drift",
+        fake_detect_prediction_drift,
+    )
+    monkeypatch.setattr(
+        prediction_log,
+        "push_drift_metrics",
+        lambda report: captured.update({"pushed": report}),
+    )
+
+    report = prediction_log.emit_prediction_drift_metrics(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.4},
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.6},
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+    )
+
+    assert report is not None
+    assert captured["rows"] == 2
+    assert captured["versions"] == ["7", "7"]
+    assert captured["dataset_name"] == "inference_predictions"
+    assert captured["dataset_version"] == "7"
+    assert captured["pushed"].dataset_version == "7"
+
+
+def test_emit_prediction_drift_metrics_uses_recent_rows_for_current_model_version(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+    captured: dict[str, object] = {}
+
+    def append(model_version: str, quality_index: float, hour: int) -> None:
+        prediction_log.append_prediction_log(
+            {
+                "model_version": model_version,
+                "predictions": [
+                    {
+                        "spot_id": "silvaplana",
+                        "spot_name": "Silvaplana",
+                        "forecast": [
+                            {
+                                "time": f"2025-01-01T{hour:02d}:00:00+00:00",
+                                "quality_index": quality_index,
+                            }
+                        ],
+                    }
+                ],
+            },
+            endpoint="predict",
+            path=log_path,
+            max_rows=2,
+            logged_at=datetime(2026, 5, 11, 10, hour, tzinfo=UTC),
+        )
+
+    append("7", 2.1, 0)
+    append("8", 3.1, 1)
+    append("8", 3.2, 2)
+
+    def fake_detect_prediction_drift(predictions_log: pd.DataFrame) -> SimpleNamespace:
+        captured["rows"] = len(predictions_log)
+        captured["versions"] = list(predictions_log["model_version"])
+        captured["quality_index"] = list(predictions_log["quality_index"])
+        return SimpleNamespace(
+            dataset_name=predictions_log.attrs["dataset_name"],
+            dataset_version=predictions_log.attrs["dataset_version"],
+        )
+
+    monkeypatch.setattr(
+        prediction_log,
+        "detect_prediction_drift",
+        fake_detect_prediction_drift,
+    )
+    monkeypatch.setattr(
+        prediction_log,
+        "push_drift_metrics",
+        lambda report: captured.update({"pushed": report}),
+    )
+
+    report = prediction_log.emit_prediction_drift_metrics(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T03:00:00+00:00", "quality_index": 2.2}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        max_rows=2,
+    )
+
+    assert report is not None
+    assert captured["rows"] == 2
+    assert captured["versions"] == ["7", "7"]
+    assert captured["quality_index"] == [2.1, 2.2]
+
+
+def test_emit_prediction_drift_metrics_returns_none_when_no_forecast_rows(
+    tmp_path: Path,
+) -> None:
+    report = prediction_log.emit_prediction_drift_metrics(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=tmp_path / "prediction-log.jsonl",
+    )
+
+    assert report is None

--- a/tests/test_prediction_monitoring_prometheus.py
+++ b/tests/test_prediction_monitoring_prometheus.py
@@ -1,0 +1,86 @@
+"""Tests for Prometheus export of in-process prediction-monitoring state."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from foehncast.monitoring import prediction_monitoring_prometheus
+
+
+def _metric_value(payload: str, metric_prefix: str) -> float:
+    for line in payload.splitlines():
+        if line.startswith(metric_prefix):
+            return float(line.split()[-1])
+    raise AssertionError(f"Metric not found: {metric_prefix}")
+
+
+@pytest.fixture(autouse=True)
+def reset_prediction_monitoring_state() -> None:
+    prediction_monitoring_prometheus._reset_prediction_monitoring_state()
+    yield
+    prediction_monitoring_prometheus._reset_prediction_monitoring_state()
+
+
+def test_render_prediction_monitoring_prometheus_metrics_uses_endpoint_and_result_labels() -> (
+    None
+):
+    prediction_monitoring_prometheus.record_prediction_monitoring_schedule(
+        "predict",
+        "scheduled",
+        when=datetime(2026, 5, 11, 10, 0, tzinfo=UTC),
+    )
+    prediction_monitoring_prometheus.record_prediction_monitoring_schedule(
+        "rank",
+        "failed",
+        when=datetime(2026, 5, 11, 10, 5, tzinfo=UTC),
+    )
+    prediction_monitoring_prometheus.record_prediction_monitoring_execution(
+        "predict",
+        "succeeded",
+        when=datetime(2026, 5, 11, 10, 10, tzinfo=UTC),
+    )
+    prediction_monitoring_prometheus.record_prediction_monitoring_execution(
+        "rank",
+        "failed",
+        when=datetime(2026, 5, 11, 10, 15, tzinfo=UTC),
+    )
+
+    payload = prediction_monitoring_prometheus.render_prediction_monitoring_prometheus_metrics().decode(
+        "utf-8"
+    )
+
+    assert (
+        'foehncast_prediction_monitoring_schedule_total{endpoint="predict",result="scheduled"} 1.0'
+        in payload
+    )
+    assert (
+        'foehncast_prediction_monitoring_schedule_total{endpoint="rank",result="failed"} 1.0'
+        in payload
+    )
+    assert (
+        'foehncast_prediction_monitoring_execution_total{endpoint="predict",result="succeeded"} 1.0'
+        in payload
+    )
+    assert (
+        'foehncast_prediction_monitoring_execution_total{endpoint="rank",result="failed"} 1.0'
+        in payload
+    )
+    assert _metric_value(
+        payload,
+        'foehncast_prediction_monitoring_last_schedule_timestamp_seconds{endpoint="rank",result="failed"}',
+    ) == pytest.approx(1778493900.0)
+    assert _metric_value(
+        payload,
+        'foehncast_prediction_monitoring_last_execution_timestamp_seconds{endpoint="predict",result="succeeded"}',
+    ) == pytest.approx(1778494200.0)
+
+
+def test_render_prediction_monitoring_prometheus_metrics_handles_empty_state() -> None:
+    payload = prediction_monitoring_prometheus.render_prediction_monitoring_prometheus_metrics().decode(
+        "utf-8"
+    )
+
+    assert "foehncast_prediction_monitoring_schedule_total" in payload
+    assert "foehncast_prediction_monitoring_execution_total" in payload

--- a/tests/test_prediction_prometheus.py
+++ b/tests/test_prediction_prometheus.py
@@ -1,0 +1,66 @@
+"""Tests for Prometheus export of retained prediction-log state."""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from foehncast.monitoring import prediction_prometheus
+
+
+def _metric_value(payload: str, metric_prefix: str) -> float:
+    for line in payload.splitlines():
+        if line.startswith(metric_prefix):
+            return float(line.split()[-1])
+    raise AssertionError(f"Metric not found: {metric_prefix}")
+
+
+def test_render_prediction_log_prometheus_metrics_uses_model_labelled_gauges() -> None:
+    predictions_log = pd.DataFrame(
+        {
+            "model_version": ["7", "7", "8"],
+            "prediction_timestamp": pd.to_datetime(
+                [
+                    "2026-05-11T10:00:00+00:00",
+                    "2026-05-11T11:00:00+00:00",
+                    "2026-05-11T12:00:00+00:00",
+                ],
+                utc=True,
+            ),
+            "forecast_time": pd.to_datetime(
+                [
+                    "2025-01-01T00:00:00+00:00",
+                    "2025-01-01T01:00:00+00:00",
+                    "2025-01-01T02:00:00+00:00",
+                ],
+                utc=True,
+            ),
+            "quality_index": [2.1, 2.3, 3.1],
+        }
+    )
+
+    payload = prediction_prometheus.render_prediction_log_prometheus_metrics(
+        predictions_log=predictions_log,
+    ).decode("utf-8")
+
+    assert "foehncast_prediction_log_total_row_count 3.0" in payload
+    assert "foehncast_prediction_log_model_count 2.0" in payload
+    assert 'foehncast_prediction_log_row_count{model_version="7"} 2.0' in payload
+    assert 'foehncast_prediction_log_row_count{model_version="8"} 1.0' in payload
+    assert _metric_value(
+        payload,
+        'foehncast_prediction_log_latest_prediction_timestamp_seconds{model_version="7"}',
+    ) == pytest.approx(1778497200.0)
+    assert _metric_value(
+        payload,
+        'foehncast_prediction_log_latest_forecast_timestamp_seconds{model_version="8"}',
+    ) == pytest.approx(1735696800.0)
+
+
+def test_render_prediction_log_prometheus_metrics_handles_empty_log() -> None:
+    payload = prediction_prometheus.render_prediction_log_prometheus_metrics(
+        predictions_log=pd.DataFrame(),
+    ).decode("utf-8")
+
+    assert "foehncast_prediction_log_total_row_count 0.0" in payload
+    assert "foehncast_prediction_log_model_count 0.0" in payload

--- a/uv.lock
+++ b/uv.lock
@@ -196,6 +196,15 @@ wheels = [
 ]
 
 [[package]]
+name = "appdirs"
+version = "1.4.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41", size = 13470, upload-time = "2020-05-11T07:59:51.037Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3b/00/2344469e2084fb287c2e0b57b72910309874c3245463acd6cf5e3db69324/appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128", size = 9566, upload-time = "2020-05-11T07:59:49.499Z" },
+]
+
+[[package]]
 name = "appnope"
 version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
@@ -780,12 +789,33 @@ wheels = [
 ]
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5a/d3/8ae2869247df154b64c1884d7346d412fed0c49df84db635aab2d1c40e62/deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff", size = 173788, upload-time = "2020-04-20T14:23:38.738Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/02/c3/253a89ee03fc9b9682f1541728eb66db7db22148cd94f89ab22528cd1e1b/deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a", size = 11178, upload-time = "2020-04-20T14:23:36.581Z" },
+]
+
+[[package]]
 name = "dill"
 version = "0.3.9"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/70/43/86fe3f9e130c4137b0f1b50784dd70a5087b911fe07fa81e53e0c4c47fea/dill-0.3.9.tar.gz", hash = "sha256:81aa267dddf68cbfe8029c42ca9ec6a4ab3b22371d1c450abc54422577b4512c", size = 187000, upload-time = "2024-09-29T00:03:20.958Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/46/d1/e73b6ad76f0b1fb7f23c35c6d95dbc506a9c8804f43dda8cb5b0fa6331fd/dill-0.3.9-py3-none-any.whl", hash = "sha256:468dff3b89520b474c0397703366b7b95eebe6303f108adf9b19da1f702be87a", size = 119418, upload-time = "2024-09-29T00:03:19.344Z" },
+]
+
+[[package]]
+name = "distro"
+version = "1.9.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fc/f8/98eea607f65de6527f8a2e8885fc8015d3e6f5775df186e443e0964a11c3/distro-1.9.0.tar.gz", hash = "sha256:2fa77c6fd8940f116ee1d6b94a2f90b13b5ea8d019b98bc8bafdcabcdd9bdbed", size = 60722, upload-time = "2023-12-24T09:54:32.31Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/12/b3/231ffd4ab1fc9d679809f356cebee130ac7daa00d6d6f3206dd4fd137e9e/distro-1.9.0-py3-none-any.whl", hash = "sha256:7bffd925d65168f85027d8da9af6bddab658135b840670a223589bc0c8ef02b2", size = 20277, upload-time = "2023-12-24T09:54:30.421Z" },
 ]
 
 [[package]]
@@ -803,6 +833,15 @@ wheels = [
 ]
 
 [[package]]
+name = "dynaconf"
+version = "3.2.13"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/57/0e/05927cf459e73f8bf9a9277cbea6f2d5b7db8a5cc9dc1e20e7a5fbac1b90/dynaconf-3.2.13.tar.gz", hash = "sha256:d79e0189d97b3f226b8ebb1717e2ce05d1a05cdf6ea05de66d24625fdb5a0cbd", size = 283507, upload-time = "2026-03-17T19:38:47.632Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/43/11d6e5d2c00bf000b5329717c74563bf76a9193f4a41cb0c4ef277dde4fa/dynaconf-3.2.13-py2.py3-none-any.whl", hash = "sha256:4305527aef4834bdba3e39479b23c005186e83fb85f65bcaa4bcea58fa26759b", size = 238041, upload-time = "2026-03-17T19:38:45.337Z" },
+]
+
+[[package]]
 name = "editorconfig"
 version = "0.17.1"
 source = { registry = "https://pypi.org/simple" }
@@ -812,12 +851,61 @@ wheels = [
 ]
 
 [[package]]
+name = "evidently"
+version = "0.7.21"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "cryptography" },
+    { name = "deprecation" },
+    { name = "dynaconf" },
+    { name = "fsspec" },
+    { name = "iterative-telemetry" },
+    { name = "litestar" },
+    { name = "nltk" },
+    { name = "numpy" },
+    { name = "opentelemetry-proto" },
+    { name = "pandas", extra = ["parquet"] },
+    { name = "plotly" },
+    { name = "pydantic" },
+    { name = "pyyaml" },
+    { name = "requests" },
+    { name = "rich" },
+    { name = "scikit-learn" },
+    { name = "scipy" },
+    { name = "statsmodels" },
+    { name = "typer" },
+    { name = "typing-inspect" },
+    { name = "ujson" },
+    { name = "urllib3" },
+    { name = "uuid6" },
+    { name = "uvicorn", extra = ["standard"] },
+    { name = "watchdog" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/da/cbfce40d20d76b2b0edaa258a97aa35a33bd0ad308539fa055872d79a5b5/evidently-0.7.21.tar.gz", hash = "sha256:f13c415d749dd73825bd1ec485136eaf9261b3794d765d2844718b7ffe167998", size = 7678489, upload-time = "2026-03-10T14:15:37.677Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/da/7e/1728a3a1e8fcd6865f3642c260feb5c03b436b62d5b12812f50d4d27e8ed/evidently-0.7.21-py3-none-any.whl", hash = "sha256:04e247de0ce8eabe618687770568ca06162e64a39ebf10e33ef6ea3aeda31187", size = 11744189, upload-time = "2026-03-10T14:15:34.015Z" },
+]
+
+[[package]]
 name = "executing"
 version = "2.2.1"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/cc/28/c14e053b6762b1044f34a13aab6859bbf40456d37d23aa286ac24cfd9a5d/executing-2.2.1.tar.gz", hash = "sha256:3632cc370565f6648cc328b32435bd120a1e4ebb20c77e3fdde9a13cd1e533c4", size = 1129488, upload-time = "2025-09-01T09:48:10.866Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/ea/53f2148663b321f21b5a606bd5f191517cf40b7072c0497d3c92c4a13b1e/executing-2.2.1-py2.py3-none-any.whl", hash = "sha256:760643d3452b4d777d295bb167ccc74c64a81df23fb5e08eff250c425a4b2017", size = 28317, upload-time = "2025-09-01T09:48:08.5Z" },
+]
+
+[[package]]
+name = "faker"
+version = "40.15.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7f/13/6741787bd91c4109c7bed047d68273965cd52ce8a5f773c471b949334b6d/faker-40.15.0.tar.gz", hash = "sha256:20f3a6ec8c266b74d4c554e34118b21c3c2056c0b4a519d15c8decb3a4e6e795", size = 1967447, upload-time = "2026-04-17T20:05:27.555Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a7/a7/a600f8f30d4505e89166de51dd121bd540ab8e560e8cf0901de00a81de8c/faker-40.15.0-py3-none-any.whl", hash = "sha256:71ab3c3370da9d2205ab74ffb0fd51273063ad562b3a3bb69d0026a20923e318", size = 2004447, upload-time = "2026-04-17T20:05:25.437Z" },
 ]
 
 [[package]]
@@ -898,6 +986,15 @@ gcp = [
 ]
 
 [[package]]
+name = "filelock"
+version = "3.29.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
 name = "flask"
 version = "3.1.3"
 source = { registry = "https://pypi.org/simple" }
@@ -933,6 +1030,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "certifi" },
+    { name = "evidently" },
     { name = "fastapi" },
     { name = "google-cloud-bigquery" },
     { name = "matplotlib" },
@@ -967,6 +1065,7 @@ feast = [
 [package.metadata]
 requires-dist = [
     { name = "certifi", specifier = ">=2024.0" },
+    { name = "evidently", specifier = ">=0.7.21" },
     { name = "fastapi", specifier = ">=0.115" },
     { name = "google-cloud-bigquery", specifier = ">=3.30.0" },
     { name = "matplotlib", specifier = ">=3.8" },
@@ -1719,6 +1818,21 @@ wheels = [
 ]
 
 [[package]]
+name = "iterative-telemetry"
+version = "0.0.10"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "appdirs" },
+    { name = "distro" },
+    { name = "filelock" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d2/b6/f17d6e80252b7be6ca4d9463db226ce7863d26287f16f1347e981cd2f3d8/iterative_telemetry-0.0.10.tar.gz", hash = "sha256:7fde6111de6fa4acf5a95a6190cc9cc5d17d835a815f0a18ece201f6031f4ed6", size = 20080, upload-time = "2025-02-11T02:47:53.391Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1a/82/7331bbf84f1ccce7a2dd09a580c7bad38417cf35c84dc0b81bce2cf779b9/iterative_telemetry-0.0.10-py3-none-any.whl", hash = "sha256:e58ffb60d22c3de8dad6a114697cc61f6c14911cae484bf90df394e0d6553603", size = 10644, upload-time = "2025-02-11T02:47:51.273Z" },
+]
+
+[[package]]
 name = "itsdangerous"
 version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2149,6 +2263,39 @@ wheels = [
 ]
 
 [[package]]
+name = "litestar"
+version = "2.21.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "click" },
+    { name = "httpx" },
+    { name = "litestar-htmx" },
+    { name = "msgspec" },
+    { name = "multidict" },
+    { name = "multipart" },
+    { name = "polyfactory" },
+    { name = "pyyaml" },
+    { name = "rich" },
+    { name = "rich-click" },
+    { name = "sniffio" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a1/fc/7ce2057ffd738be4d2abc5b69229f57181bbff8a84a4576004b021085773/litestar-2.21.1.tar.gz", hash = "sha256:28301438de7c5e77bb68a5d8684dff415b9f252b0dd8413b356e8e6794c6863a", size = 376270, upload-time = "2026-03-07T13:49:16.053Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/67/139c0fa6e1dd9e558910c02a383cd0ae12c2a1d6d3f0ea0d42dbeb03d8b2/litestar-2.21.1-py3-none-any.whl", hash = "sha256:6321340195801454aeac4a12e72c28f54714a4c3e8172c33e577c593cc5982c6", size = 568342, upload-time = "2026-03-07T13:49:13.694Z" },
+]
+
+[[package]]
+name = "litestar-htmx"
+version = "0.5.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/3f/b9/7e296aa1adada25cce8e5f89a996b0e38d852d93b1b656a2058226c542a2/litestar_htmx-0.5.0.tar.gz", hash = "sha256:e02d1a3a92172c874835fa3e6749d65ae9fc626d0df46719490a16293e2146fb", size = 119755, upload-time = "2025-06-11T21:19:45.573Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f2/24/8d99982f0aa9c1cd82073c6232b54a0dbe6797c7d63c0583a6c68ee3ddf2/litestar_htmx-0.5.0-py3-none-any.whl", hash = "sha256:92833aa47e0d0e868d2a7dbfab75261f124f4b83d4f9ad12b57b9a68f86c50e6", size = 9970, upload-time = "2025-06-11T21:19:44.465Z" },
+]
+
+[[package]]
 name = "locket"
 version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2176,6 +2323,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/2b/f4/69fa6ed85ae003c2378ffa8f6d2e3234662abd02c10d216c0ba96081a238/markdown-3.10.2.tar.gz", hash = "sha256:994d51325d25ad8aa7ce4ebaec003febcce822c3f8c911e3b17c52f7f589f950", size = 368805, upload-time = "2026-02-09T14:57:26.942Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/de/1f/77fa3081e4f66ca3576c896ae5d31c3002ac6607f9747d2e3aa49227e464/markdown-3.10.2-py3-none-any.whl", hash = "sha256:e91464b71ae3ee7afd3017d9f358ef0baf158fd9a298db92f1d4761133824c36", size = 108180, upload-time = "2026-02-09T14:57:25.787Z" },
+]
+
+[[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
 ]
 
 [[package]]
@@ -2305,6 +2464,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/c7/74/97e72a36efd4ae2bccb3463284300f8953f199b5ffbc04cbbb0ec78f74b1/matplotlib_inline-0.2.1.tar.gz", hash = "sha256:e1ee949c340d771fc39e241ea75683deb94762c8fa5f2927ec57c83c4dffa9fe", size = 8110, upload-time = "2025-10-23T09:00:22.126Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/af/33/ee4519fa02ed11a94aef9559552f3b17bb863f2ecfe1a35dc7f548cde231/matplotlib_inline-0.2.1-py3-none-any.whl", hash = "sha256:d56ce5156ba6085e00a9d54fead6ed29a9c47e215cd1bba2e976ef39f5710a76", size = 9516, upload-time = "2025-10-23T09:00:20.675Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -2574,6 +2742,46 @@ wheels = [
 ]
 
 [[package]]
+name = "msgspec"
+version = "0.21.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e3/60/f79b9b013a16fa3a58350c9295ddc6789f2e335f36ea61ed10a21b215364/msgspec-0.21.1.tar.gz", hash = "sha256:2313508e394b0d208f8f56892ca9b2799e2561329de9763b19619595a6c0f72c", size = 319193, upload-time = "2026-04-12T21:44:50.394Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/6e/cf/317224852c00248c620a9bcf4b26e2e4ab8afd752f18d2a6ef73ebd423b6/msgspec-0.21.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d4248cf0b6129b7d230eacd493c17cc2d4f3989f3bb7f633a928a85b7dcfa251", size = 196188, upload-time = "2026-04-12T21:44:07.181Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/81/074612945c0666078f7366f40000013de9f6ba687491d450df699bceebc9/msgspec-0.21.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:5102c7e9b3acff82178449b85006d96310e690291bb1ea0142f1b24bcb8aabcb", size = 188473, upload-time = "2026-04-12T21:44:08.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/37/655101799590bcc5fddb2bd3fe0e6194e816c2d1da7c361725f5eb89a910/msgspec-0.21.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:846758412e9518252b2ac9bffd6f0e54d9ff614f5f9488df7749f81ff5c80920", size = 218871, upload-time = "2026-04-12T21:44:09.917Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/d1/d4cd9fe89c7d400d7a18f86ccc94daa3f0927f53558846fcb60791dce5d6/msgspec-0.21.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:21995e74b5c598c2e004110ad66ec7f1b8c20bf2bcf3b2de8fd9a3094422d3ff", size = 225025, upload-time = "2026-04-12T21:44:11.191Z" },
+    { url = "https://files.pythonhosted.org/packages/24/bf/e20549e602b9edccadeeff98760345a416f9cce846a657e8b18e3396b212/msgspec-0.21.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:6129f0cca52992e898fd5344187f7c8127b63d810b2fd73e36fca73b4c6475ee", size = 222672, upload-time = "2026-04-12T21:44:12.481Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/68/04d7a8f0f786545cf9b8c280c57aa6befb5977af6e884b8b54191cbe44b3/msgspec-0.21.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ef3ec2296248d1f8b9231acb051b6d471dfde8f21819e86c9adaaa9f42918521", size = 227303, upload-time = "2026-04-12T21:44:13.709Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4d/619866af2840875be408047bf9e70ceafbae6ab50660de7134ed1b25eb86/msgspec-0.21.1-cp312-cp312-win_amd64.whl", hash = "sha256:d4ab834a054c6f0cbeef6df9e7e1b33d5f1bc7b86dea1d2fd7cad003873e783d", size = 190017, upload-time = "2026-04-12T21:44:14.977Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/2e/a8f9eca8fd00e097d7a9e99ba8a4685db994494448e3d4f0b7f6e9a3c0f7/msgspec-0.21.1-cp312-cp312-win_arm64.whl", hash = "sha256:628aaa35c74950a8c59da330d7e98917e1c7188f983745782027748ee4ca573e", size = 175345, upload-time = "2026-04-12T21:44:16.431Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/74/f11ede02839b19ff459f88e3145df5d711626ca84da4e23520cebf819367/msgspec-0.21.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:764173717a01743f007e9f74520ed281f24672c604514f7d76c1c3a10e8edb66", size = 196176, upload-time = "2026-04-12T21:44:17.613Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/40/4476c1bd341418a046c4955aff632ec769315d1e3cb94e6acf86d461f9ed/msgspec-0.21.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:344c7cd0eaed1fb81d7959f99100ef71ec9b536881a376f11b9a6c4803365697", size = 188524, upload-time = "2026-04-12T21:44:18.815Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/d9/9e9d7d7e5061b47540d03d640fab9b3965ba7ae49c1b2154861c8f007518/msgspec-0.21.1-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48943e278b3854c2f89f955ddc6f9f430d3f0784b16e47d10604ee0463cd21f5", size = 218880, upload-time = "2026-04-12T21:44:20.028Z" },
+    { url = "https://files.pythonhosted.org/packages/74/66/2bb344f34abb4b57e60c7c9c761994e0417b9718ec1460bf00c296f2a7ea/msgspec-0.21.1-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a9aa659ebb0101b1cbc31461212b87e341d961f0ab0772aaf068a99e001ec4aa", size = 225050, upload-time = "2026-04-12T21:44:21.577Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/84/7c1e412f76092277bf760cef12b7979d03314d259ab5b5cafde5d0c1722d/msgspec-0.21.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:f7b27d1a8ead2b6f5b0c4f2d07b8be1ccfcc041c8a0e704781edebe3ae13c484", size = 222713, upload-time = "2026-04-12T21:44:22.83Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/27/0bba04b2b4ef05f3d068429410bc71d2cea925f1596a8f41152cccd5edb8/msgspec-0.21.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:38fe93e86b61328fe544cb7fd871fad5a27c8734bfda90f65e5dbe288ae50f61", size = 227259, upload-time = "2026-04-12T21:44:24.11Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/2d/09574b0eea02fed2c2c1383dbaae2c7f79dc16dcd6487a886000afb5d7c4/msgspec-0.21.1-cp313-cp313-win_amd64.whl", hash = "sha256:8bc666331c35fcce05a7cd2d6221adbe0f6058f8e750711413d22793c080ac6a", size = 189857, upload-time = "2026-04-12T21:44:25.359Z" },
+    { url = "https://files.pythonhosted.org/packages/46/34/105b1576ad182879914f0c821f17ee1d13abb165cb060448f96fe2aff078/msgspec-0.21.1-cp313-cp313-win_arm64.whl", hash = "sha256:42bb1241e0750c1a4346f2aa84db26c5ffd99a4eb3a954927d9f149ff2f42898", size = 175403, upload-time = "2026-04-12T21:44:26.608Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/ad/86954e987d1d6a5c579e2c2e7832b65e0fff194179fdac4f581536086024/msgspec-0.21.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:fab48eb45fdbfbdb2c0edfec00ffc53b6b6085beefc6b50b61e01659f9f8757f", size = 196261, upload-time = "2026-04-12T21:44:27.807Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/a1/c5e46c3e42b866199365e35d11dddfd1fbd8bba4fdb3c52f965b1607ce94/msgspec-0.21.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:3cb779ea0c35bc807ff941d415875c1f69ca0be91a2e907ab99a171811d86a9a", size = 188729, upload-time = "2026-04-12T21:44:28.99Z" },
+    { url = "https://files.pythonhosted.org/packages/85/7d/1e29a319d678d6cb962ae5bdf32a6858ebdf38f73bc654c0e9c742a0c2c8/msgspec-0.21.1-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:68604db36b3b4dd9bf160e436e12798a4738848144cea1aca1cb984011eb160f", size = 219866, upload-time = "2026-04-12T21:44:31.104Z" },
+    { url = "https://files.pythonhosted.org/packages/25/1f/cca084ca2572810fff12ea9dbdcbe39eac048f40daf4a9077b49fcbe8cee/msgspec-0.21.1-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3d6b9dc50948eaf65df54d2fd0ff66e6d8c32f116037209ee861810eb9b676cb", size = 224993, upload-time = "2026-04-12T21:44:32.649Z" },
+    { url = "https://files.pythonhosted.org/packages/71/94/d2120fc9d419a89a3a7c13e5b7078798c4b392a96a02a6e2b3ce43a8766c/msgspec-0.21.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:52c5e21930942302394429c5a582ce7e6b62c7f983b3760834c2ce107e0dd6df", size = 223535, upload-time = "2026-04-12T21:44:33.839Z" },
+    { url = "https://files.pythonhosted.org/packages/75/17/42418b66a3ad972a89bab73dd78b79cc6282bb488a25e73c853cee7443b9/msgspec-0.21.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:abbb39d65681fa24ed394e01af3d59d869068324f900c61d06062b7fb9980f2f", size = 227222, upload-time = "2026-04-12T21:44:35.093Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/33/265c894268cca88ff67b144ca2b4c522fc8b9a6f1966a3640c70516e78e1/msgspec-0.21.1-cp314-cp314-win_amd64.whl", hash = "sha256:5666b1b560b97b6ec2eb3fca8a502298ebac56e13bbca1f88523538ce83d01ea", size = 193810, upload-time = "2026-04-12T21:44:36.612Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/8f/a6d35f25bf1fc63c492fdd88fdce01ba0875ead48c2b91f90f33653b4131/msgspec-0.21.1-cp314-cp314-win_arm64.whl", hash = "sha256:d8b8578e4c83b14ceea4cef0d0b747e31d9330fe4b03b2b2ad4063866a178f93", size = 179125, upload-time = "2026-04-12T21:44:38.198Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/39/74839641e64b99d87da55af0fc472854d42b46e2183b9e2a67fe1bb2a512/msgspec-0.21.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:15f523d51c00ebad412213bfe9f06f0a50ec2b93e0c19e824a2d267cabb48ea2", size = 200171, upload-time = "2026-04-12T21:44:39.414Z" },
+    { url = "https://files.pythonhosted.org/packages/70/9b/ce0cca6d2d87fcd4b6ff97600790494e64f26a2c55d61507cd2755c16193/msgspec-0.21.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:4e47390360583ba3d5c6cb44cf0a9f61b0a06a899d3c2c00627cedebb2e2884b", size = 192879, upload-time = "2026-04-12T21:44:40.882Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/08/673a7bb05e5702dc787ddd3011195b509f9867927970da59052211929987/msgspec-0.21.1-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f60800e6299b798142dc40b0644da77ceac5ea0568be58228417eae14135c847", size = 226281, upload-time = "2026-04-12T21:44:42.181Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/45/86508cf57283e9070b3c447e3ab25b792a7a0855a3ea4e0c6d111ac34c97/msgspec-0.21.1-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:5f8e9dfcd98419cf7568808470c4317a3fb30bef0e3715b568730a2b272a20d7", size = 229863, upload-time = "2026-04-12T21:44:43.442Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/62/e7c9367cd08d590559faacd711edbae36840342843e669440363f33c7d36/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:92d89dfad13bd1ea640dc3e37e724ed380da1030b272bdf5ecafb983c3ad7c75", size = 230445, upload-time = "2026-04-12T21:44:44.806Z" },
+    { url = "https://files.pythonhosted.org/packages/42/b4/c0f54632103846b658a10930025f4de41c8724b5e4805a5f3b395586cb7e/msgspec-0.21.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:0d03867786e5d7ba25d666df4b11320c27170f4aeafcb8e3a8b0a50a4fb742ca", size = 231822, upload-time = "2026-04-12T21:44:46.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/1d/0d85cc79d0ccf5508e9c846cc66552a6a16bf92abd1dbd8362617f7b35cd/msgspec-0.21.1-cp314-cp314t-win_amd64.whl", hash = "sha256:740fbf1c9d59992ca3537d6fbe9ebbf9eaf726a65fbf31448e0ecbc710697a63", size = 206650, upload-time = "2026-04-12T21:44:47.601Z" },
+    { url = "https://files.pythonhosted.org/packages/90/91/56c5d560f20e6c20e9e4f55bd0e458f7f162aa689ee350346c04c48eac0b/msgspec-0.21.1-cp314-cp314t-win_arm64.whl", hash = "sha256:0d2cc73df6058d811a126ac3a8ad63a4dfa210c82f9cf5a004802eaf4712de90", size = 183149, upload-time = "2026-04-12T21:44:48.833Z" },
+]
+
+[[package]]
 name = "multidict"
 version = "6.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -2670,6 +2878,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0c/f7/addf1087b860ac60e6f382240f64fb99f8bfb532bb06f7c542b83c29ca61/multidict-6.7.1-cp314-cp314t-win_amd64.whl", hash = "sha256:497bde6223c212ba11d462853cfa4f0ae6ef97465033e7dc9940cdb3ab5b48e5", size = 53542, upload-time = "2026-01-26T02:46:08.809Z" },
     { url = "https://files.pythonhosted.org/packages/4c/81/4629d0aa32302ef7b2ec65c75a728cc5ff4fa410c50096174c1632e70b3e/multidict-6.7.1-cp314-cp314t-win_arm64.whl", hash = "sha256:2bbd113e0d4af5db41d5ebfe9ccaff89de2120578164f86a5d17d5a576d1e5b2", size = 44719, upload-time = "2026-01-26T02:46:11.146Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
+]
+
+[[package]]
+name = "multipart"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/8e/d6/9c4f366d6f9bb8f8fb5eae3acac471335c39510c42b537fd515213d7d8c3/multipart-1.3.1.tar.gz", hash = "sha256:211d7cfc1a7a43e75c4d24ee0e8e0f4f61d522f1a21575303ae85333dea687bf", size = 38929, upload-time = "2026-02-27T10:17:13.7Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/ed/e1f03200ee1f0bf4a2b9b72709afefbf5319b68df654e0b84b35c65613ee/multipart-1.3.1-py3-none-any.whl", hash = "sha256:a82b59e1befe74d3d30b3d3f70efd5a2eba4d938f845dcff9faace968888ff29", size = 15061, upload-time = "2026-02-27T10:17:11.943Z" },
 ]
 
 [[package]]
@@ -2786,6 +3003,21 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/83/f8/51569ac65d696c8ecbee95938f89d4abf00f47d58d48f6fbabfe8f0baefe/nest_asyncio-1.6.0.tar.gz", hash = "sha256:6f172d5449aca15afd6c646851f4e31e02c598d553a667e38cafa997cfec55fe", size = 7418, upload-time = "2024-01-21T14:25:19.227Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a0/c4/c2971a3ba4c6103a3d10c4b0f24f461ddc027f0f09763220cf35ca1401b3/nest_asyncio-1.6.0-py3-none-any.whl", hash = "sha256:87af6efd6b5e897c81050477ef65c62e2b2f35d51703cae01aff2905b1852e1c", size = 5195, upload-time = "2024-01-21T14:25:17.223Z" },
+]
+
+[[package]]
+name = "nltk"
+version = "3.9.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "joblib" },
+    { name = "regex" },
+    { name = "tqdm" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/74/a1/b3b4adf15585a5bc4c357adde150c01ebeeb642173ded4d871e89468767c/nltk-3.9.4.tar.gz", hash = "sha256:ed03bc098a40481310320808b2db712d95d13ca65b27372f8a403949c8b523d0", size = 2946864, upload-time = "2026-03-24T06:13:40.641Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/91/04e965f8e717ba0ab4bdca5c112deeab11c9e750d94c4d4602f050295d39/nltk-3.9.4-py3-none-any.whl", hash = "sha256:f2fa301c3a12718ce4a0e9305c5675299da5ad9e26068218b69d692fda84828f", size = 1552087, upload-time = "2026-03-24T06:13:38.47Z" },
 ]
 
 [[package]]
@@ -2987,6 +3219,11 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/70/44/5191d2e4026f86a2a109053e194d3ba7a31a2d10a9c2348368c63ed4e85a/pandas-2.3.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:3869faf4bd07b3b66a9f462417d0ca3a9df29a9f6abd5d0d0dbab15dac7abe87", size = 13202175, upload-time = "2025-09-29T23:31:59.173Z" },
 ]
 
+[package.optional-dependencies]
+parquet = [
+    { name = "pyarrow" },
+]
+
 [[package]]
 name = "pandas-gbq"
 version = "0.35.0"
@@ -3048,6 +3285,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/5a/82/42f767fc1c1143d6fd36efb827202a2d997a375e160a71eb2888a925aac1/pathspec-1.1.1.tar.gz", hash = "sha256:17db5ecd524104a120e173814c90367a96a98d07c45b2e10c2f3919fff91bf5a", size = 135180, upload-time = "2026-04-27T01:46:08.907Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/d9/7fb5aa316bc299258e68c73ba3bddbc499654a07f151cba08f6153988714/pathspec-1.1.1-py3-none-any.whl", hash = "sha256:a00ce642f577bf7f473932318056212bc4f8bfdf53128c78bbd5af0b9b20b189", size = 57328, upload-time = "2026-04-27T01:46:07.06Z" },
+]
+
+[[package]]
+name = "patsy"
+version = "1.0.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/be/44/ed13eccdd0519eff265f44b670d46fbb0ec813e2274932dc1c0e48520f7d/patsy-1.0.2.tar.gz", hash = "sha256:cdc995455f6233e90e22de72c37fcadb344e7586fb83f06696f54d92f8ce74c0", size = 399942, upload-time = "2025-10-20T16:17:37.535Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f1/70/ba4b949bdc0490ab78d545459acd7702b211dfccf7eb89bbc1060f52818d/patsy-1.0.2-py2.py3-none-any.whl", hash = "sha256:37bfddbc58fcf0362febb5f54f10743f8b21dd2aa73dec7e7ef59d1b02ae668a", size = 233301, upload-time = "2025-10-20T16:17:36.563Z" },
 ]
 
 [[package]]
@@ -3141,12 +3390,38 @@ wheels = [
 ]
 
 [[package]]
+name = "plotly"
+version = "5.24.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "packaging" },
+    { name = "tenacity" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/79/4f/428f6d959818d7425a94c190a6b26fbc58035cbef40bf249be0b62a9aedd/plotly-5.24.1.tar.gz", hash = "sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae", size = 9479398, upload-time = "2024-09-12T15:36:31.068Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e5/ae/580600f441f6fc05218bd6c9d5794f4aef072a7d9093b291f1c50a9db8bc/plotly-5.24.1-py3-none-any.whl", hash = "sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089", size = 19054220, upload-time = "2024-09-12T15:36:24.08Z" },
+]
+
+[[package]]
 name = "pluggy"
 version = "1.6.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "polyfactory"
+version = "3.3.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "faker" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/85/68/7717bd9e63ed254617a7d3dc9260904fb736d6ea203e58ffddcb186c64e4/polyfactory-3.3.0.tar.gz", hash = "sha256:237258b6ff43edf362ffd1f68086bb796466f786adfa002b0ac256dbf2246e9a", size = 348668, upload-time = "2026-02-22T09:46:28.01Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dd/34/b6f19941adcdaf415b5e8a8d577499f5b6a76b59cbae37f9b125a9ffe9f2/polyfactory-3.3.0-py3-none-any.whl", hash = "sha256:686abcaa761930d3df87b91e95b26b8d8cb9fdbbbe0b03d5f918acff5c72606e", size = 62707, upload-time = "2026-02-22T09:46:25.985Z" },
 ]
 
 [[package]]
@@ -3773,6 +4048,94 @@ wheels = [
 ]
 
 [[package]]
+name = "regex"
+version = "2026.5.9"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/dc/0e/49aee608ad09480e7fd276898c99ec6192985fa331abe4eb3a986094490b/regex-2026.5.9.tar.gz", hash = "sha256:a8234aa23ec39894bfe4a3f1b85616a7032481964a13ac6fc9f10de4f6fca270", size = 416074, upload-time = "2026-05-09T23:15:19.37Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/50/9b/6550044bc44e17c84d312c031c2ec42fbdb6a4ec4e29093be3a172d08772/regex-2026.5.9-cp312-cp312-macosx_10_13_universal2.whl", hash = "sha256:57eeeb05db7979413dec5438f2db21d7ecbba787cde7a711df1a6f6df672aa06", size = 490451, upload-time = "2026-05-09T23:12:34.72Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/95/fc7ba4303b5a0f92446a12ee6778ef2c6c799233f5060042a31bf390cfe9/regex-2026.5.9-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:398c521292f4c7fb807001dcd54694d3a1fcafc179a36ad9cc56f98df85930b6", size = 292112, upload-time = "2026-05-09T23:12:36.285Z" },
+    { url = "https://files.pythonhosted.org/packages/54/4b/ee27938d1b2c443e89a9a10e00d2d19aa5ee300cd3d61140644e93bb083e/regex-2026.5.9-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f7a7c26137296beba7784de6eba69c6a93a63ccebc385e4962fe67e267a91225", size = 289599, upload-time = "2026-05-09T23:12:38.089Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/dd/ba103dc19614e25f3880800ca67ce093d6e21b325d72b8383c7bf906e9fa/regex-2026.5.9-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:6441cc660d76107934a09c22167200839a0e89604a6297f78a974e66e931d2c0", size = 796732, upload-time = "2026-05-09T23:12:40.062Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/e7/f035b4fd858b050b0080bf302968dc0f59ba34e391872d54936758e6844e/regex-2026.5.9-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:91328f1c23d47595ca3ef0a7557fa129c5a23404b775c770697d2f35b33e0107", size = 865440, upload-time = "2026-05-09T23:12:42.059Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/51/8cd301ecc899aea28124357f729f4272f44de7806fc7ca02490bfbe253e8/regex-2026.5.9-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:93a7860539414dddaefba2b40f8771765ae17949d4c7182b876ce429e11a8309", size = 912329, upload-time = "2026-05-09T23:12:44.373Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/1e/3fbe2fa1e8cebd62f3bb7d3321cff1640aca2e240b51d9bd624aad949260/regex-2026.5.9-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:dd2810d22146b6d838acc5ec15602cb6b47920aa4e33015df3868eedfd20bab8", size = 801239, upload-time = "2026-05-09T23:12:46.268Z" },
+    { url = "https://files.pythonhosted.org/packages/17/2f/6f6008682bf2cf98040a0d3153a8e557b6ab728d7713d045cee4ce544ab8/regex-2026.5.9-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:daff2bdbaf1d23e52fdff7c0b7bc2048b68f978df6a4d107ac981f94caef2e66", size = 777054, upload-time = "2026-05-09T23:12:48.051Z" },
+    { url = "https://files.pythonhosted.org/packages/19/2b/eee0d20a6842ba04df4b8847a920b57ef56853f14ef85405473e586b605a/regex-2026.5.9-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:4eeb011098fcb77af513dcef521a3dbecbf8849b1e38940759d293b7a93f5026", size = 785098, upload-time = "2026-05-09T23:12:49.851Z" },
+    { url = "https://files.pythonhosted.org/packages/4a/98/6fc1e6410feefb92159edaed5041992bfe390e8d26c721865434acbca558/regex-2026.5.9-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:ea9c8ecfa1b73c73b626534d6626e5340d429630943672b8480724f44e84b962", size = 860095, upload-time = "2026-05-09T23:12:51.666Z" },
+    { url = "https://files.pythonhosted.org/packages/18/a3/bd855e0f2cb1a978ecf6fa6bb69632dd9c3f6ea3b81cde62fde14c9daec7/regex-2026.5.9-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:cd2846168eb9ee3c513902bc8225409cb1caab31d04728b145171fa1625d9621", size = 765762, upload-time = "2026-05-09T23:12:53.413Z" },
+    { url = "https://files.pythonhosted.org/packages/dc/66/0ae8c092e60b14c79d24f8e0b7f0aea5bfbffdcab00b5483d13404d3c3a5/regex-2026.5.9-cp312-cp312-musllinux_1_2_s390x.whl", hash = "sha256:39617fb0cde9c0e6306dc70e3bfc096f3da793219879f7ae7aa341a69fbdcf6d", size = 852100, upload-time = "2026-05-09T23:12:55.256Z" },
+    { url = "https://files.pythonhosted.org/packages/21/de/8dfde60fc1b21c946a893ba273403b72617edb261370cb1087099a83f088/regex-2026.5.9-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:fd03c4f0e33280d15cae17159b899245d6b7c53d21def19b263b39655061f5ce", size = 789479, upload-time = "2026-05-09T23:12:57.573Z" },
+    { url = "https://files.pythonhosted.org/packages/c3/1c/bdcc98f9a4af4fdd166c74941174619ccff4726d3ce32faa8e9a2ecd38dd/regex-2026.5.9-cp312-cp312-win32.whl", hash = "sha256:164eba9b755ea6f244b0d881196fbc1fac09714e9782c9e2732b813142033c8e", size = 266699, upload-time = "2026-05-09T23:12:59.14Z" },
+    { url = "https://files.pythonhosted.org/packages/78/87/240d36864f9e48ace85f72e79ced97ceb7f27ce87739a947dcb834b4e6bc/regex-2026.5.9-cp312-cp312-win_amd64.whl", hash = "sha256:86f40a5d6444db30a125c9c9177e6b25dad981cbc37451fd838f145e6edac92e", size = 277783, upload-time = "2026-05-09T23:13:00.789Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/b5/7b30f312b0669dff5beebe5b0989dc2d1a312b1a44fab852199c387a5b96/regex-2026.5.9-cp312-cp312-win_arm64.whl", hash = "sha256:96f5f58b54a063d7ea9dca08e1cf57bfe10499c4d579ee672da284f57f5f0070", size = 270513, upload-time = "2026-05-09T23:13:02.426Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/da/797e91ecec6f84135da778ddce78c20e0af5d2a15c26f87a81bc3eadb6db/regex-2026.5.9-cp313-cp313-macosx_10_13_universal2.whl", hash = "sha256:d626b84406444b165fc0ba981604edea39f0588ff1f92baa23fe50799ea9afdb", size = 490303, upload-time = "2026-05-09T23:13:04.382Z" },
+    { url = "https://files.pythonhosted.org/packages/44/da/bf30abaaa737b58f4a4b8c4a03659e02fd92092c822e0197ed9e0daab917/regex-2026.5.9-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:d7bdc0ab8f3dd7e1b4f9ab88634e13374669db86bb3c72e8292f07ae313f539f", size = 292019, upload-time = "2026-05-09T23:13:06.022Z" },
+    { url = "https://files.pythonhosted.org/packages/2d/e7/d0eaf5713828417b9e5648cf81fa9bacd4961f6ab98c380c2034f8716e35/regex-2026.5.9-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:a8820737949116ffff55fe18f9fc644530063ba6ebfcb8314239416e78f1347c", size = 289468, upload-time = "2026-05-09T23:13:08.214Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9b/b3fdd62b003baa1a9b593cd8c8699c9651c2e80cc21a5c715707983c42d7/regex-2026.5.9-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:aa0fbdbac82cb3e4450d0ccde7d7a35607f4cb2dd9fba4b8b69bfaf8c9fa6aed", size = 796749, upload-time = "2026-05-09T23:13:10.573Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/30/66ab84588765f5b4b271a9ca09ef7ce2b87caa95176ec3d2ad65d7bc4902/regex-2026.5.9-cp313-cp313-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:57e8915c7986aa33d25e4d3629cef711cd2863f2961b10409f0c04cb8b7d9020", size = 865445, upload-time = "2026-05-09T23:13:12.523Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/89/f05169e8588aac365f35ffc7f3bc3184f095ef4cfded7cfaa3c7fd5dbd89/regex-2026.5.9-cp313-cp313-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:508f56a89ba9cb26e4168cbc37dbd60a28d82430a9e18ad1d25fe0883c314ca2", size = 912322, upload-time = "2026-05-09T23:13:14.281Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/c93444052cf41581f3c884ab3fb5823daf0992f11cd4388d4275ca610558/regex-2026.5.9-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b6d189041f15691cfa2b6c4290448ec221244d225b3f5fe9e7771b34ffcdf6e2", size = 801269, upload-time = "2026-05-09T23:13:16.569Z" },
+    { url = "https://files.pythonhosted.org/packages/50/fe/0cf96b882f540e62e8b9956599798203d599c44cf4c77917ca27400ff69b/regex-2026.5.9-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e82db382b44d0111b22601c509c89f64434816c9e0eef9d1989cda8cc6ff1c04", size = 777085, upload-time = "2026-05-09T23:13:18.675Z" },
+    { url = "https://files.pythonhosted.org/packages/23/5c/d78d4924e7fc875557b9e9b768423925fdfaac5549d06da7810019a9bd26/regex-2026.5.9-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:2acfb48634f64996b57f90f39afa692ff362162722581921fe92239a59960f3c", size = 785153, upload-time = "2026-05-09T23:13:20.525Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e0/5214774090e7b4524dcea3e3c4aa74141d43043f8beb49c1599db1c8b53a/regex-2026.5.9-cp313-cp313-musllinux_1_2_ppc64le.whl", hash = "sha256:d29eebfc9525db68cad3c97eedd7f754fa265aa5cd0cf4f863b2421e1b48fc9f", size = 860164, upload-time = "2026-05-09T23:13:22.263Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/e1/4a57a83350319b1271f0d7a249b8672513ed928b237a741631270de6caea/regex-2026.5.9-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:debb893095e944091c16e641a6e33c1b0f4cb61ab945ec5afbf53ce7068834d8", size = 765731, upload-time = "2026-05-09T23:13:24.277Z" },
+    { url = "https://files.pythonhosted.org/packages/12/f4/499e74a20c156fc75836ee04a72a38d1a063978f600937f9760467beb1b0/regex-2026.5.9-cp313-cp313-musllinux_1_2_s390x.whl", hash = "sha256:d659eee77986549c9ea45b861c7567e44d6287c3dc9a4565478853f7b9fe2ff6", size = 852062, upload-time = "2026-05-09T23:13:26.125Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/92/7eebc0d0a01e78629695f342ba17e0deaff8fb45e79cc0d7b98287da6e3e/regex-2026.5.9-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:2efa205e6d98b24d1f3ab395c11aa15cdf10935bca283d0285e0499c284fba21", size = 789577, upload-time = "2026-05-09T23:13:27.814Z" },
+    { url = "https://files.pythonhosted.org/packages/05/a4/018e71f7d2ad48c1ebe6d3ae0026f9b7cb4802fd15c7cc02fdf724355102/regex-2026.5.9-cp313-cp313-win32.whl", hash = "sha256:f3844f134e834076677dd369976e9f5068679fcb8e50102fdf6b7ac96a3ec127", size = 266691, upload-time = "2026-05-09T23:13:29.549Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/1d/861a93719fb9ee7dbfc3761b3797b7a3e112a5d42c6129459d2d741be9b5/regex-2026.5.9-cp313-cp313-win_amd64.whl", hash = "sha256:3527bb4942d2c14552155406cdedd906567456821848aed1cb4933a391bf5eca", size = 277747, upload-time = "2026-05-09T23:13:31.859Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/c6/0a2436ae4da1ba76e51cb98943c6838a9a721faa40ebe2dce07694ae34e3/regex-2026.5.9-cp313-cp313-win_arm64.whl", hash = "sha256:56a33f191f17d8c417f99945ebdc1e691d3af9605d86ec68c7e54a57e3e17af6", size = 270500, upload-time = "2026-05-09T23:13:33.525Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e9/d21346f7b60ed58789371358ed66b09d00f832e1bd7c06e55d9da5679882/regex-2026.5.9-cp313-cp313t-macosx_10_13_universal2.whl", hash = "sha256:01f28d868834624c934b8d2e0aa1c8341337e37831f4a012f18a5afcba4cbaf3", size = 494172, upload-time = "2026-05-09T23:13:35.935Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/43/fd1177a2032037c681baecdb3422ee4e1424aec4e4f470ef47793d325274/regex-2026.5.9-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:48036f6374aaa79eb3b754ec29c61d1c6b1606749d705a13f8854fa2539671f6", size = 293952, upload-time = "2026-05-09T23:13:38.307Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/7d/9fbf919768368d3f8a4f6c692cf2aa61e482b2b81ec6a298ace4cbf02480/regex-2026.5.9-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b96350aa424e79d4fd6b567b344dcbe2b2d6bfc48dfe7717587e1fa6d43da6ff", size = 292314, upload-time = "2026-05-09T23:13:40.353Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/6c/e41bfeecb589716843e7c4df09ba46ff2a42961457afece19059d85caeef/regex-2026.5.9-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8f3af7a4903c5c04a11a196a5aa75cdd7dd3f8508132f9fb3259d9f5908e3b88", size = 811681, upload-time = "2026-05-09T23:13:42.543Z" },
+    { url = "https://files.pythonhosted.org/packages/87/83/a5c1c525fba0aa656e88ad0face0b1829788ef4c2fb6b26df58aa1151b84/regex-2026.5.9-cp313-cp313t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:7e87577720152d2caae19fe2baaf1f8d5ca12091e9e229f03915c37d1e4b9178", size = 871135, upload-time = "2026-05-09T23:13:44.326Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/80882e799e440dd878b0979cbebf8fa4d54624a332c83037c7a701649e3f/regex-2026.5.9-cp313-cp313t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:c8b9b9d294cfea3cd19c718ade7cc93492b2c4991abd9a68d0b3477ae6d8e100", size = 917265, upload-time = "2026-05-09T23:13:47.295Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/ff/8db60211e2286e396aad7dc7725356c502bff0901ea05bd6cdc2e1a042b9/regex-2026.5.9-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:728d8bfd28a8845c8b6bc5dc7ce010453d206396786c0765c2740cb65f37791e", size = 816311, upload-time = "2026-05-09T23:13:49.885Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/47/742ef579c61730f8d268e5cf1f9ce0e37e2ea041ad0f5644724f2378e463/regex-2026.5.9-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:7e30b874d341fac767d7df5a0870540541c2c054b80cfaac116e8d367a8a7ff2", size = 785498, upload-time = "2026-05-09T23:13:52.25Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/ab/cb0999802dcb0fb95b1ab005e8d4163d8afdd67efc2cb6b6630ac13f8cb1/regex-2026.5.9-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:fd190e88a895a8901325fad284a3f74ea52b1da8525b76cc811fa9b1edf0ce2b", size = 801348, upload-time = "2026-05-09T23:13:54.127Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/62/8ca59a24c55bc34d166eefaf3717bd77772f329fdbf984d86581e0a3571c/regex-2026.5.9-cp313-cp313t-musllinux_1_2_ppc64le.whl", hash = "sha256:8e76e8161ad00694cfce6767d5dea860c6391ac5b83e5c3a39661e696f11fc7e", size = 866493, upload-time = "2026-05-09T23:13:56.067Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/3d/30f2ae62cef3278bb5bb821f467277a55fb73f01032cf85997e15e8289a8/regex-2026.5.9-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:ddda5340e6c01a293027dd46232fa79eaff1b48058ce7a98f572b6445b088041", size = 772811, upload-time = "2026-05-09T23:13:57.867Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/ae/7d2089bcd78ad0c0161bc684339df50032acb438a7bd3305e7ddb1193cec/regex-2026.5.9-cp313-cp313t-musllinux_1_2_s390x.whl", hash = "sha256:205109e96b3cf5adf8f4cd62bedde9487feb282b9497a3535451e5a24cd706a0", size = 856584, upload-time = "2026-05-09T23:13:59.679Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/29/92ff47f75990131ea4f24ba17819e5a9d141e10819807e09addd73409af6/regex-2026.5.9-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:dfbe4579b9f08036aa7d101d1835437a20783574ac66327e6b29b4018a138081", size = 803453, upload-time = "2026-05-09T23:14:01.978Z" },
+    { url = "https://files.pythonhosted.org/packages/04/99/eff29f1037dcab36702c9ee5d6858cf1ce2336ea8ea2987f64245b99ea5e/regex-2026.5.9-cp313-cp313t-win32.whl", hash = "sha256:ed2c9e8068b614c574d8d30e543d617cf5379b0535d46f97ef00e904745a08b5", size = 269951, upload-time = "2026-05-09T23:14:03.661Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/9d/8870b8981d27b22cda77bb26a5ac7ebfa9c7d9e0dea195a834a82380e748/regex-2026.5.9-cp313-cp313t-win_amd64.whl", hash = "sha256:b46b0f094dc1d3b90356c85a0bd2c9bafc4a6a190b9d6f8ddd5a033b6e088ed4", size = 281240, upload-time = "2026-05-09T23:14:05.56Z" },
+    { url = "https://files.pythonhosted.org/packages/72/b1/3379415e8f135c13ac551353397cc4fe97b4978f3cac73c5fcbcded548b8/regex-2026.5.9-cp313-cp313t-win_arm64.whl", hash = "sha256:872acc074bd29ffc9913ecdfedf6ea77502312ca44a4aa0d3779089c6069d8de", size = 272383, upload-time = "2026-05-09T23:14:07.843Z" },
+    { url = "https://files.pythonhosted.org/packages/13/3e/9c3cd292d8808b3645a2ce517e200179b6d0e903f176300bd8b542e14de5/regex-2026.5.9-cp314-cp314-macosx_10_13_universal2.whl", hash = "sha256:1bd7587a2948b4085195d5a3374eaf4a425dc3e55784c038175355ecf3bbbf8a", size = 490376, upload-time = "2026-05-09T23:14:09.64Z" },
+    { url = "https://files.pythonhosted.org/packages/60/70/d43ee8a2ca0a8b68d167f21658b85520ac0574617c7f320367c5047f7556/regex-2026.5.9-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:dea2e88e1cce4522496cce630e11e67b98b7076620bc4336c3f674bc21a375f4", size = 291964, upload-time = "2026-05-09T23:14:11.424Z" },
+    { url = "https://files.pythonhosted.org/packages/21/91/9d50b433828d8e74196904e168a43abf1e6e88b2a15d47ed742456720c37/regex-2026.5.9-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:2099f7e7ff7b6aa3192312650a56e91cc091e49d50b04e4f6f8b6e28b3b27f1c", size = 289682, upload-time = "2026-05-09T23:14:13.123Z" },
+    { url = "https://files.pythonhosted.org/packages/3e/d2/b835e3cafbb9d977736912436259ff551d60919f7d7b3d37d46659c63564/regex-2026.5.9-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:ecd353045824e4477562a2ac718c25799cdaaa41f7aa925a806a8a3e6848a5b9", size = 796996, upload-time = "2026-05-09T23:14:14.923Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/a6/9f992d00019166b9de01c546dd4549bc679f2a68df11b877740b0760b7c2/regex-2026.5.9-cp314-cp314-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:65c8c8c37377794bd5b2f3ebe51919042bf17aec802e23c833d89782ed0c78af", size = 866089, upload-time = "2026-05-09T23:14:17.757Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/08/4d32af657e049b19cb62b02e46e38fe1518797bfb2203ee93a510b21b0dc/regex-2026.5.9-cp314-cp314-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:5b73ab8afcf66c622db143d1c6fda4e58e4d537ee4f125229ad47b1ab80f34c0", size = 911530, upload-time = "2026-05-09T23:14:20.353Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/27/2af43dd1dc201d1fecefda64a45f4ad0995855b92724f795a777b402ee69/regex-2026.5.9-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0de5cf193997384ed2ca6f1cd4f78055b255d93d82d5a8cd6ba0d11c10b167e4", size = 800643, upload-time = "2026-05-09T23:14:22.265Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/dd/23a249047013b5321d4a60c4d2437462086f601b061776a525e5fba2a59f/regex-2026.5.9-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d641a8c9a61618047796d572a39a79b26167b0411d2c3031937b2fe2d081e2cf", size = 777223, upload-time = "2026-05-09T23:14:24.179Z" },
+    { url = "https://files.pythonhosted.org/packages/94/6a/e85ed9538cd19586d0465076a4578a12e093ce776d15f3f8ce92733a8dd6/regex-2026.5.9-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:24b2355ef5cc9aa5b8f07d17704face1c166fdcc2290fa7bd6e6c925655a8346", size = 785760, upload-time = "2026-05-09T23:14:26.065Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/c4/f25473209438638e947c55f9156fd8f236f74169229028cc99116380868e/regex-2026.5.9-cp314-cp314-musllinux_1_2_ppc64le.whl", hash = "sha256:a24852d3c29ad9e47593593d8a247c44ccc3d0548ef12c822d6ed0810affe676", size = 860891, upload-time = "2026-05-09T23:14:28.17Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/f7/f4f86e3c74419c37370e91f150ae0c2ef7d34b2e0e4cdd5da046a02e4022/regex-2026.5.9-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:916714069da19329ef7de197dcbc77bb3104145c7c2c864dbfbe318f46b88b14", size = 765891, upload-time = "2026-05-09T23:14:30.06Z" },
+    { url = "https://files.pythonhosted.org/packages/26/70/704d8e13765939146b1cd0ef4e2feb71d7929727d2290f026eed10095955/regex-2026.5.9-cp314-cp314-musllinux_1_2_s390x.whl", hash = "sha256:fa411799ca8da32a8d38d020a88faa5b6f91657d284761352940ecf9f7c3bbdd", size = 851380, upload-time = "2026-05-09T23:14:32.123Z" },
+    { url = "https://files.pythonhosted.org/packages/26/29/1a13582a8460038edc38e49f64ceb0dd7c60f5caba77571f4bf6601965d9/regex-2026.5.9-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:1e6da47d679b7010ef27556b6e0f99771b744936db1792a10ceac6547ae1503e", size = 789350, upload-time = "2026-05-09T23:14:34.799Z" },
+    { url = "https://files.pythonhosted.org/packages/73/56/3dcafe34fc72e271d62ad9a291801e88a1457bb251c132f15fcc2e5aad1a/regex-2026.5.9-cp314-cp314-win32.whl", hash = "sha256:98bd73080e8756255137e1bd3f3f00295bbc5aa383c0e0f973920e9134d7c4ad", size = 272130, upload-time = "2026-05-09T23:14:36.729Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9c/02eebf0be95efe416c664db7fb8b6b05b7a0b06a7544f2884f2558b0526f/regex-2026.5.9-cp314-cp314-win_amd64.whl", hash = "sha256:ff8d372ac2acdc048d1c19916f27ee61bc5722728458ba6ca5052f2c72d51763", size = 280999, upload-time = "2026-05-09T23:14:39.126Z" },
+    { url = "https://files.pythonhosted.org/packages/70/5a/1dd1abee76cb7a846a0bcf42fdc87e5720c3c33c24f3e37814310a513d9f/regex-2026.5.9-cp314-cp314-win_arm64.whl", hash = "sha256:e1d93bf647916292e8edcec150c07ddf3dc50179ccaf770c04a7f9e452155372", size = 273500, upload-time = "2026-05-09T23:14:41.059Z" },
+    { url = "https://files.pythonhosted.org/packages/86/c1/c5f619b0057a7965cb78ec559c1d7a45ce8c99a35bea95483d64959a93d9/regex-2026.5.9-cp314-cp314t-macosx_10_13_universal2.whl", hash = "sha256:83d0ee4a57d1c87cb549e195ec300b8f0ec3a82eba66d835e4e2ed8634fe4499", size = 494269, upload-time = "2026-05-09T23:14:42.869Z" },
+    { url = "https://files.pythonhosted.org/packages/05/2c/5d01f1aee33de4bbe60c8452945bfc8477ca7c5ae4450f6bfe711036cb36/regex-2026.5.9-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:d3d7eb5c9a7f6df82ed3cfac9beb93882a5cbcb5b8b157b56cb2b3b276574ac1", size = 293954, upload-time = "2026-05-09T23:14:44.822Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/fe/e8988b2ae2108c6ef71bd4aa8d87fbe257976dd0810e826cd75f701c68b6/regex-2026.5.9-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:075160bf16658e16d35233300b8453aac25de4cbea808d22348b6979668e924d", size = 292405, upload-time = "2026-05-09T23:14:47.211Z" },
+    { url = "https://files.pythonhosted.org/packages/79/34/d2b0937faa7859263f7f0a3c6b103a1296306be6952dc173d0154e9a2f49/regex-2026.5.9-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:45375819235558a4ff1c4971dc32881f022613abdb180128f5cb4768c1765a1c", size = 811855, upload-time = "2026-05-09T23:14:49.21Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fe/daf53a47457a8486db66c66c01ceb9c2303eecee3f87197f1e77eb1a736d/regex-2026.5.9-cp314-cp314t-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:ead4b163ac30a29574510cd4b3e2e985ac5290c05fc7095557d6a5f403fc31b5", size = 871189, upload-time = "2026-05-09T23:14:51.555Z" },
+    { url = "https://files.pythonhosted.org/packages/1c/75/058fc4470cbfbf57d800aff1a0022b929a3f9fa553ee10a0cdf2070eb31f/regex-2026.5.9-cp314-cp314t-manylinux2014_s390x.manylinux_2_17_s390x.manylinux_2_28_s390x.whl", hash = "sha256:8c6e4218fbdfbcd4f6c19efca40930d24a621bf4b48cb76bc6640543bd28ef20", size = 917485, upload-time = "2026-05-09T23:14:53.633Z" },
+    { url = "https://files.pythonhosted.org/packages/88/e7/179cfda3a28bc843b5c6cfe7f79f23489c791ed95f151083803660878432/regex-2026.5.9-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:6351571c8a42b505eb555c0dc47d740d0fb66977dc142919eea6f4325b7c56a0", size = 816369, upload-time = "2026-05-09T23:14:56.198Z" },
+    { url = "https://files.pythonhosted.org/packages/41/90/6f0cc422071688266d344fca8462d787cba0a2c144acb25721f9a61ec265/regex-2026.5.9-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:002205cafd2a9e78c6290c7d1df277bf3277b3b7a30e0b4bb0dac2e2e3f7cb2d", size = 785869, upload-time = "2026-05-09T23:14:58.602Z" },
+    { url = "https://files.pythonhosted.org/packages/02/67/a31f1760f09c27b251ef39e9beb541f462cf977381d067faa764c2c0e393/regex-2026.5.9-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:8abd33fef90b2a9efac5557d6033ca82d1195ed3a15fea5af15ba7b463c6a63b", size = 801427, upload-time = "2026-05-09T23:15:00.642Z" },
+    { url = "https://files.pythonhosted.org/packages/e3/c4/1a80654597b6bc1e1ea0494824c31200e8a956abe290afae9b19a166a148/regex-2026.5.9-cp314-cp314t-musllinux_1_2_ppc64le.whl", hash = "sha256:31037c82eccb44b7ea2e9e221d7c01429430e989a1f4b91ea5a855f6017b509a", size = 866482, upload-time = "2026-05-09T23:15:03.384Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/11/960724e06482c08466ff5611e242e86f80062949cdf6b4b9cc317b9dd93d/regex-2026.5.9-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:5604dfd046dc37eca90250fc3be938b076c8059fa772ac0ed6f499b0f0fb0415", size = 773022, upload-time = "2026-05-09T23:15:05.625Z" },
+    { url = "https://files.pythonhosted.org/packages/50/a8/a9979c3e7918280e93159ebcab5ef1a65116dd4f3bd6091be0eae4a126e8/regex-2026.5.9-cp314-cp314t-musllinux_1_2_s390x.whl", hash = "sha256:0e1b1b4e496afbb24f4a62aba855ee4f88f25578927697b340702e48c9ee6bc2", size = 856642, upload-time = "2026-05-09T23:15:07.966Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/d4/a9b732f2f0072c0ab12227483abb24fffcb9f73f8a2b203df0a6d0434735/regex-2026.5.9-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:be3372b9df6ddecff6486d37e19095a7b4973137caf5512407a89f4455361f41", size = 803552, upload-time = "2026-05-09T23:15:10.215Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/fe/1b3113817447a1d4155e4ac76d2e072f42c0bcba2f43fa8a0e756ea2cd91/regex-2026.5.9-cp314-cp314t-win32.whl", hash = "sha256:3ddd90103f9e5c471c49c7852ecc1fe27c7e45eb99e977aefe7caa4e779f4f58", size = 275746, upload-time = "2026-05-09T23:15:12.609Z" },
+    { url = "https://files.pythonhosted.org/packages/92/73/93d42045302636c91f2e5ef588b65b84b01428f28ec77de256b1dfdfbe5c/regex-2026.5.9-cp314-cp314t-win_amd64.whl", hash = "sha256:ca518ed29c46eecba6010b15f1b9a479314d2de409536e71b6a13aa04e3b8a77", size = 285685, upload-time = "2026-05-09T23:15:15.086Z" },
+    { url = "https://files.pythonhosted.org/packages/da/80/35b4c33c804a165a7f55289afda3ea9e3eb6d15800341a2d66455c0f1f30/regex-2026.5.9-cp314-cp314t-win_arm64.whl", hash = "sha256:5e41809d2683fcde7d5a8c87a6567ba1fb1ce0de9f31bff578de00a4b2d76daa", size = 275713, upload-time = "2026-05-09T23:15:16.98Z" },
+]
+
+[[package]]
 name = "requests"
 version = "2.33.1"
 source = { registry = "https://pypi.org/simple" }
@@ -3831,6 +4194,33 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/2c/06/37c1a5557acf449e8e406a830a05bf885ac47d33270aec454ef78675008d/rfc3987_syntax-1.1.0.tar.gz", hash = "sha256:717a62cbf33cffdd16dfa3a497d81ce48a660ea691b1ddd7be710c22f00b4a0d", size = 14239, upload-time = "2025-07-18T01:05:05.015Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/7e/71/44ce230e1b7fadd372515a97e32a83011f906ddded8d03e3c6aafbdedbb7/rfc3987_syntax-1.1.0-py3-none-any.whl", hash = "sha256:6c3d97604e4c5ce9f714898e05401a0445a641cfa276432b0a648c80856f6a3f", size = 8046, upload-time = "2025-07-18T01:05:03.843Z" },
+]
+
+[[package]]
+name = "rich"
+version = "15.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markdown-it-py" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13a6a0c696dacf35430f72e0ec571c4275d2371fca3e9/rich-15.0.0.tar.gz", hash = "sha256:edd07a4824c6b40189fb7ac9bc4c52536e9780fbbfbddf6f1e2502c31b068c36", size = 230680, upload-time = "2026-04-12T08:24:00.75Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
+]
+
+[[package]]
+name = "rich-click"
+version = "1.9.7"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "click" },
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "rich" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/04/27/091e140ea834272188e63f8dd6faac1f5c687582b687197b3e0ec3c78ebf/rich_click-1.9.7.tar.gz", hash = "sha256:022997c1e30731995bdbc8ec2f82819340d42543237f033a003c7b1f843fc5dc", size = 74838, upload-time = "2026-01-31T04:29:27.707Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ca/e5/d708d262b600a352abe01c2ae360d8ff75b0af819b78e9af293191d928e6/rich_click-1.9.7-py3-none-any.whl", hash = "sha256:2f99120fca78f536e07b114d3b60333bc4bb2a0969053b1250869bcdc1b5351b", size = 71491, upload-time = "2026-01-31T04:29:26.777Z" },
 ]
 
 [[package]]
@@ -4077,6 +4467,15 @@ wheels = [
 ]
 
 [[package]]
+name = "shellingham"
+version = "1.5.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/58/15/8b3609fd3830ef7b27b655beb4b4e9c62313a4e8da8c676e142cc210d58e/shellingham-1.5.4.tar.gz", hash = "sha256:8dbca0739d487e5bd35ab3ca4b36e11c4078f3a234bfce294b0a0291363404de", size = 10310, upload-time = "2023-10-24T04:13:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e0/f9/0595336914c5619e5f28a1fb793285925a8cd4b432c9da0a987836c7f822/shellingham-1.5.4-py2.py3-none-any.whl", hash = "sha256:7ecfff8f2fd72616f7481040475a65b2bf8af90a56c89140852d1120324e8686", size = 9755, upload-time = "2023-10-24T04:13:38.866Z" },
+]
+
+[[package]]
 name = "six"
 version = "1.17.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4108,6 +4507,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/1f/ea/49c993d6dfdd7338c9b1000a0f36817ed7ec84577ae2e52f890d1a4ff909/smmap-5.0.3.tar.gz", hash = "sha256:4d9debb8b99007ae47165abc08670bd74cb74b5227dda7f643eccc4e9eb5642c", size = 22506, upload-time = "2026-03-09T03:43:26.1Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c1/d4/59e74daffcb57a07668852eeeb6035af9f32cbfd7a1d2511f17d2fe6a738/smmap-5.0.3-py3-none-any.whl", hash = "sha256:c106e05d5a61449cf6ba9a1e650227ecfb141590d2a98412103ff35d89fc7b2f", size = 24390, upload-time = "2026-03-09T03:43:24.361Z" },
+]
+
+[[package]]
+name = "sniffio"
+version = "1.3.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e041b6ae58d80074f81b7d5121207425c964ddf5cfdbd/sniffio-1.3.1.tar.gz", hash = "sha256:f4324edc670a0f49750a81b895f35c3adb843cca46f0530f79fc1babb23789dc", size = 20372, upload-time = "2024-02-25T23:20:04.057Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
 
 [[package]]
@@ -4204,6 +4612,39 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
+]
+
+[[package]]
+name = "statsmodels"
+version = "0.14.6"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "patsy" },
+    { name = "scipy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/0d/81/e8d74b34f85285f7335d30c5e3c2d7c0346997af9f3debf9a0a9a63de184/statsmodels-0.14.6.tar.gz", hash = "sha256:4d17873d3e607d398b85126cd4ed7aad89e4e9d89fc744cdab1af3189a996c2a", size = 20689085, upload-time = "2025-12-05T23:08:39.522Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/25/ce/308e5e5da57515dd7cab3ec37ea2d5b8ff50bef1fcc8e6d31456f9fae08e/statsmodels-0.14.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:fe76140ae7adc5ff0e60a3f0d56f4fffef484efa803c3efebf2fcd734d72ecb5", size = 10091932, upload-time = "2025-12-05T19:28:55.446Z" },
+    { url = "https://files.pythonhosted.org/packages/05/30/affbabf3c27fb501ec7b5808230c619d4d1a4525c07301074eb4bda92fa9/statsmodels-0.14.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:26d4f0ed3b31f3c86f83a92f5c1f5cbe63fc992cd8915daf28ca49be14463a1c", size = 9997345, upload-time = "2025-12-05T19:29:10.278Z" },
+    { url = "https://files.pythonhosted.org/packages/48/f5/3a73b51e6450c31652c53a8e12e24eac64e3824be816c0c2316e7dbdcb7d/statsmodels-0.14.6-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:d8c00a42863e4f4733ac9d078bbfad816249c01451740e6f5053ecc7db6d6368", size = 10058649, upload-time = "2025-12-05T23:10:12.775Z" },
+    { url = "https://files.pythonhosted.org/packages/81/68/dddd76117df2ef14c943c6bbb6618be5c9401280046f4ddfc9fb4596a1b8/statsmodels-0.14.6-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:19b58cf7474aa9e7e3b0771a66537148b2df9b5884fbf156096c0e6c1ff0469d", size = 10339446, upload-time = "2025-12-05T23:10:28.503Z" },
+    { url = "https://files.pythonhosted.org/packages/56/4a/dce451c74c4050535fac1ec0c14b80706d8fc134c9da22db3c8a0ec62c33/statsmodels-0.14.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:81e7dcc5e9587f2567e52deaff5220b175bf2f648951549eae5fc9383b62bc37", size = 10368705, upload-time = "2025-12-05T23:10:44.339Z" },
+    { url = "https://files.pythonhosted.org/packages/60/15/3daba2df40be8b8a9a027d7f54c8dedf24f0d81b96e54b52293f5f7e3418/statsmodels-0.14.6-cp312-cp312-win_amd64.whl", hash = "sha256:b5eb07acd115aa6208b4058211138393a7e6c2cf12b6f213ede10f658f6a714f", size = 9543991, upload-time = "2025-12-05T23:10:58.536Z" },
+    { url = "https://files.pythonhosted.org/packages/81/59/a5aad5b0cc266f5be013db8cde563ac5d2a025e7efc0c328d83b50c72992/statsmodels-0.14.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:47ee7af083623d2091954fa71c7549b8443168f41b7c5dce66510274c50fd73e", size = 10072009, upload-time = "2025-12-05T23:11:14.021Z" },
+    { url = "https://files.pythonhosted.org/packages/53/dd/d8cfa7922fc6dc3c56fa6c59b348ea7de829a94cd73208c6f8202dd33f17/statsmodels-0.14.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:aa60d82e29fcd0a736e86feb63a11d2380322d77a9369a54be8b0965a3985f71", size = 9980018, upload-time = "2025-12-05T23:11:30.907Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/77/0ec96803eba444efd75dba32f2ef88765ae3e8f567d276805391ec2c98c6/statsmodels-0.14.6-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:89ee7d595f5939cc20bf946faedcb5137d975f03ae080f300ebb4398f16a5bd4", size = 10060269, upload-time = "2025-12-05T23:11:46.338Z" },
+    { url = "https://files.pythonhosted.org/packages/10/b9/fd41f1f6af13a1a1212a06bb377b17762feaa6d656947bf666f76300fc05/statsmodels-0.14.6-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:730f3297b26749b216a06e4327fe0be59b8d05f7d594fb6caff4287b69654589", size = 10324155, upload-time = "2025-12-05T23:12:01.805Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/0f/a6900e220abd2c69cd0a07e3ad26c71984be6061415a60e0f17b152ecf08/statsmodels-0.14.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:f1c08befa85e93acc992b72a390ddb7bd876190f1360e61d10cf43833463bc9c", size = 10349765, upload-time = "2025-12-05T23:12:18.018Z" },
+    { url = "https://files.pythonhosted.org/packages/98/08/b79f0c614f38e566eebbdcff90c0bcacf3c6ba7a5bbb12183c09c29ca400/statsmodels-0.14.6-cp313-cp313-win_amd64.whl", hash = "sha256:8021271a79f35b842c02a1794465a651a9d06ec2080f76ebc3b7adce77d08233", size = 9540043, upload-time = "2025-12-05T23:12:33.887Z" },
+    { url = "https://files.pythonhosted.org/packages/71/de/09540e870318e0c7b58316561d417be45eff731263b4234fdd2eee3511a8/statsmodels-0.14.6-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:00781869991f8f02ad3610da6627fd26ebe262210287beb59761982a8fa88cae", size = 10069403, upload-time = "2025-12-05T23:12:48.424Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/f0/63c1bfda75dc53cee858006e1f46bd6d6f883853bea1b97949d0087766ca/statsmodels-0.14.6-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:73f305fbf31607b35ce919fae636ab8b80d175328ed38fdc6f354e813b86ee37", size = 9989253, upload-time = "2025-12-05T23:13:05.274Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/98/b0dfb4f542b2033a3341aa5f1bdd97024230a4ad3670c5b0839d54e3dcab/statsmodels-0.14.6-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:e443e7077a6e2d3faeea72f5a92c9f12c63722686eb80bb40a0f04e4a7e267ad", size = 10090802, upload-time = "2025-12-05T23:13:20.653Z" },
+    { url = "https://files.pythonhosted.org/packages/34/0e/2408735aca9e764643196212f9069912100151414dd617d39ffc72d77eee/statsmodels-0.14.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3414e40c073d725007a6603a18247ab7af3467e1af4a5e5a24e4c27bc26673b4", size = 10337587, upload-time = "2025-12-05T23:13:37.597Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/36/4d44f7035ab3c0b2b6a4c4ebb98dedf36246ccbc1b3e2f51ebcd7ac83abb/statsmodels-0.14.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a518d3f9889ef920116f9fa56d0338069e110f823926356946dae83bc9e33e19", size = 10363350, upload-time = "2025-12-05T23:13:53.08Z" },
+    { url = "https://files.pythonhosted.org/packages/26/33/f1652d0c59fa51de18492ee2345b65372550501ad061daa38f950be390b6/statsmodels-0.14.6-cp314-cp314-win_amd64.whl", hash = "sha256:151b73e29f01fe619dbce7f66d61a356e9d1fe5e906529b78807df9189c37721", size = 9588010, upload-time = "2025-12-05T23:14:07.28Z" },
 ]
 
 [[package]]
@@ -4328,12 +4769,40 @@ wheels = [
 ]
 
 [[package]]
+name = "typer"
+version = "0.25.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-doc" },
+    { name = "click" },
+    { name = "rich" },
+    { name = "shellingham" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e4/51/9aed62104cea109b820bbd6c14245af756112017d309da813ef107d42e7e/typer-0.25.1.tar.gz", hash = "sha256:9616eb8853a09ffeabab1698952f33c6f29ffdbceb4eaeecf571880e8d7664cc", size = 122276, upload-time = "2026-04-30T19:32:16.964Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/f9/2b3ff4e56e5fa7debfaf9eb135d0da96f3e9a1d5b27222223c7296336e5f/typer-0.25.1-py3-none-any.whl", hash = "sha256:75caa44ed46a03fb2dab8808753ffacdbfea88495e74c85a28c5eefcf5f39c89", size = 58409, upload-time = "2026-04-30T19:32:18.271Z" },
+]
+
+[[package]]
 name = "typing-extensions"
 version = "4.15.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspect"
+version = "0.9.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mypy-extensions" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dc/74/1789779d91f1961fa9438e9a8710cdae6bd138c80d7303996933d117264a/typing_inspect-0.9.0.tar.gz", hash = "sha256:b23fc42ff6f6ef6954e4852c1fb512cdd18dbea03134f91f856a95ccc9461f78", size = 13825, upload-time = "2023-05-24T20:25:47.612Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/f3/107a22063bf27bdccf2024833d3445f4eea42b2e598abfbd46f6a63b6cb0/typing_inspect-0.9.0-py3-none-any.whl", hash = "sha256:9ee6fc59062311ef8547596ab6b955e1b8aa46242d854bfc78f4f6b0eff35f9f", size = 8827, upload-time = "2023-05-24T20:25:45.287Z" },
 ]
 
 [[package]]
@@ -4358,6 +4827,61 @@ wheels = [
 ]
 
 [[package]]
+name = "ujson"
+version = "5.12.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/bc/78/937198ea8708182dd1edbf0237bf255a96feab3f511691ad08b84da98e5d/ujson-5.12.1.tar.gz", hash = "sha256:5b7e96406c301a1366534479a7352ec40ec68bb327c0c119091635acd5925e35", size = 7164538, upload-time = "2026-05-05T22:05:01.354Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/40/dbb8e2fe6ee33769602fba203dacaa3963b6599f0d0aefdf2b8811af5f70/ujson-5.12.1-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:10f44bd08ae52ee23ca6e8b472692e5da1768af2d53ff1bad6f40b532e0bc7ee", size = 57951, upload-time = "2026-05-05T22:03:31.606Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/db/627472e6b4ac34148ea52e6d3d15f6f366fc21c72fe7d6c7d3729d4b3ac5/ujson-5.12.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:6cc6ea753b7303fa5629fa9ac9257ea4b001c4d72583b2bb36ff1855a07db49f", size = 55562, upload-time = "2026-05-05T22:03:32.853Z" },
+    { url = "https://files.pythonhosted.org/packages/be/59/1248c966da197ae7d2673542444a2d9a1ff7c46e3ec2a302c3caf902b922/ujson-5.12.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:289f13095764d03734adfa10107da9b530ceb64dc1b02a5f507588d978d5b7df", size = 59448, upload-time = "2026-05-05T22:03:34.143Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/d7/60c1ca71a09c0654c3edca1192a18fc55e6cc06107be86d7d3f2b39fb29b/ujson-5.12.1-cp312-cp312-manylinux_2_24_i686.manylinux_2_28_i686.whl", hash = "sha256:427893168d074e59214b0ee058337c57f5bb80175cdd5b4799a9c931aae22022", size = 61608, upload-time = "2026-05-05T22:03:35.386Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/0a/c619525576219bfc50084100117481b1a732a16716a3878355570995de4e/ujson-5.12.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7a81724d5d90a2da7155d15d8b156ce57eaed7cdd622df813f36a8e612fd4c8", size = 59113, upload-time = "2026-05-05T22:03:37.555Z" },
+    { url = "https://files.pythonhosted.org/packages/18/4d/79c1674036085e8dfdb77f8d87c1fd2896e97e6affd117c5e8ecc40f0ae4/ujson-5.12.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3a6efff7dc6515416366819de4a1bc449b77107c5b48508b101fd40f7f8bec08", size = 1038914, upload-time = "2026-05-05T22:03:38.954Z" },
+    { url = "https://files.pythonhosted.org/packages/94/b1/9409bba17189ee282b6314cdf0ecdcc72e3d38cd565c870c0227d0494569/ujson-5.12.1-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:77a71fe53427a0cf49d56eafd801d9f7e203b784b7f99cc717783fd6f6f7b732", size = 1198408, upload-time = "2026-05-05T22:03:40.943Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/ad/fafbce7ac59f1a10a83892d0a34add23cc06492308e1330493aab707dc20/ujson-5.12.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:ea3bed53d2ea8e5642e814a9e41f3e29420a8067874ba03ace8c0462e160490c", size = 1091451, upload-time = "2026-05-05T22:03:42.739Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/1f/76fc9d5b1dcb9eb73ed45fd56e5114391bd30808eb1cea7f8bc5c9a64324/ujson-5.12.1-cp312-cp312-win32.whl", hash = "sha256:758e5c8fbe4e6d483041e03b307b01fb5d2f2dd4452d4d4b927ab902e188939e", size = 41049, upload-time = "2026-05-05T22:03:44.341Z" },
+    { url = "https://files.pythonhosted.org/packages/35/2a/7ce3b6fda10d05b79a245db03405734b521ba3da6c377f173b018dce6d4e/ujson-5.12.1-cp312-cp312-win_amd64.whl", hash = "sha256:f6074d3d3267ba1914c624b6e1fa3d8152648ff36b0ab77ddf83b92db488c30d", size = 45330, upload-time = "2026-05-05T22:03:45.828Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/66/5a37bba7a2e2ab36ae467521c4511e6593ad74c869f62ec4ba6330f3f71e/ujson-5.12.1-cp312-cp312-win_arm64.whl", hash = "sha256:7642a41520ac1b2bc25ea282b66b8da522cc43424442e6fb5e039be4d4f96530", size = 39828, upload-time = "2026-05-05T22:03:47.123Z" },
+    { url = "https://files.pythonhosted.org/packages/b9/f0/985b351771ebf095e2c1aaad18f4d251831226a767a32593310e4f181f19/ujson-5.12.1-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:c4bdc052a5d097f0a2e56d93aed97355f9f7a62ef9baa4f8517e43245434af9c", size = 57959, upload-time = "2026-05-05T22:03:48.348Z" },
+    { url = "https://files.pythonhosted.org/packages/61/73/03c7473372e1a538206fc655e474fa15f8bf9c46bb7c73c5fec9a544e429/ujson-5.12.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:5dc91fa06ea35920b704fd9d70871897680145998071cfbf5ee3e19f2c9fc242", size = 55564, upload-time = "2026-05-05T22:03:49.869Z" },
+    { url = "https://files.pythonhosted.org/packages/04/e6/104ebc35fa8dbaca66bf027c53c0c9c572271c2984576f4fd7d349d1a2e4/ujson-5.12.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b5db0849c0e3da54822a5834f2dc51d7c51072d7f7d665014ee34600dc10889b", size = 59448, upload-time = "2026-05-05T22:03:51.224Z" },
+    { url = "https://files.pythonhosted.org/packages/11/d2/55274e80fe1806cdb5cb97483be16cd6163337ab11c3bd7e28ff8a8aad26/ujson-5.12.1-cp313-cp313-manylinux_2_24_i686.manylinux_2_28_i686.whl", hash = "sha256:949cb4863a5d4847edeb47c5364b334e8cadf23a7cbdaa547d86098a4b093106", size = 61611, upload-time = "2026-05-05T22:03:52.731Z" },
+    { url = "https://files.pythonhosted.org/packages/6c/15/ec46b1757c8f7770d8c101b8a463bec67c19e89c46c608d01e4b193cc64a/ujson-5.12.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8aa731138d6dfca4ab84501b72384e6c544bfb48cb87a0dd4d304df3246cac25", size = 59120, upload-time = "2026-05-05T22:03:54.064Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/27/ec73bc8908c33eb1f5be29d696084e531cbcfbd5c7b89ce54c025f66c682/ujson-5.12.1-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:727e983ef27892d86ee2d28fd517eeb02b2c1165aafcbe929dce988aeee81bfe", size = 1038913, upload-time = "2026-05-05T22:03:55.792Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/30/907e47569bed5f5eb258fef5e587c6759a7a062048796e40024497137e28/ujson-5.12.1-cp313-cp313-musllinux_1_2_i686.whl", hash = "sha256:d57d731ecf492d3d011e65369f8330654f0875b19f646be5270d478e843d3b81", size = 1198409, upload-time = "2026-05-05T22:03:57.947Z" },
+    { url = "https://files.pythonhosted.org/packages/46/aa/f135f4b741baf14d5350be5511076408e7540353d3d850a430cb89d585a6/ujson-5.12.1-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:1a09636220f26c66f80c6c6283023cb53120e843825f890be92696cd1aa43f39", size = 1091456, upload-time = "2026-05-05T22:04:00.355Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/81/5e6ef1115c0f700a74a150857c66cb22245f0e43f79667af9bf2b88f9452/ujson-5.12.1-cp313-cp313-win32.whl", hash = "sha256:ee83fbac03a0896faf190177c938f94eb610b798d495a19d50997242c4eca685", size = 41055, upload-time = "2026-05-05T22:04:02.372Z" },
+    { url = "https://files.pythonhosted.org/packages/98/76/8b423bc72a02f3fcf90f911a16382f360442c1a8887955c023d517f5d4ba/ujson-5.12.1-cp313-cp313-win_amd64.whl", hash = "sha256:e08d9e096c416ddc34519241f97c201258b42639f2012d9547d8ae32921800dd", size = 45331, upload-time = "2026-05-05T22:04:03.946Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/f2/c839a923da49384d4a319ddd5ce666e50e45a5c8417cec742c65667a1864/ujson-5.12.1-cp313-cp313-win_arm64.whl", hash = "sha256:963287e4b1bc463735c4056968a2dfa59bb831b6daba68bddd14f451191fe9e5", size = 39828, upload-time = "2026-05-05T22:04:05.52Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/ca/d88d86f90f8f237985f3e347b9a4f9fa24e8d30d19ec7d477ed18aa58393/ujson-5.12.1-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:6f19e9a407a24230df0cc1ec1c0f5999872ba526b14a780f80ad6479f5eed9bc", size = 58099, upload-time = "2026-05-05T22:04:06.688Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/2d/a0a88407cee3550f7ed1e49b41157ee2d410f51905ed51fb134844255280/ujson-5.12.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:8b657e870c77aaacdeea86cfad3e6d2ef9b52517e45988c9c367f7ee764fe4dd", size = 55631, upload-time = "2026-05-05T22:04:07.925Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/6d/12a3b8e72132db244ae048075e71a0079b3c5f61ff45b7ca81d5193ab3e7/ujson-5.12.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:984b5a99d1e0a037c2046c3c4b34cec832565d62d5017be0a035bf3cbfab72dc", size = 59469, upload-time = "2026-05-05T22:04:09.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/72/310f8c21737554f2d2b4f1883e1a71e8a6ab0d8f92f0feb8aaa85e0f4b66/ujson-5.12.1-cp314-cp314-manylinux_2_24_i686.manylinux_2_28_i686.whl", hash = "sha256:f48ef8a16f1d85bd7982beac7adfd3fb704058631db84c1c61c8a1b7072b1508", size = 61611, upload-time = "2026-05-05T22:04:10.836Z" },
+    { url = "https://files.pythonhosted.org/packages/50/50/ab4b2f7bab6c7a67298c8f2aca80e2082eaf6f332cf2d099762647b5301e/ujson-5.12.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:4f39ba3b65cc637b59731532f7e7c807786bff1d0332ab2d5b96a04d2584d78f", size = 59122, upload-time = "2026-05-05T22:04:12.137Z" },
+    { url = "https://files.pythonhosted.org/packages/21/48/5d81cbe76fc2aa9e071aa489a3041cf0712f5e0663d60d501641f92b7bb4/ujson-5.12.1-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:07f307780f85b49cba93f291718421b6f5f3b627a323b431fad937a18f6587cb", size = 1038938, upload-time = "2026-05-05T22:04:13.548Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a7/abe1acb0e5d8b8d724b35533a44c89684c88100a5fd9f2fee7f7155528d5/ujson-5.12.1-cp314-cp314-musllinux_1_2_i686.whl", hash = "sha256:1c335caea51c31494e514b82d50763b9792d3960d2c7d9fdb6b6fb8ed50ebdd0", size = 1198416, upload-time = "2026-05-05T22:04:15.609Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6e/087067d6ee22bd01bfba9fb1f32ce98c24ae2bcbab53bd2fbf8f7a80fe9e/ujson-5.12.1-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:19ea07e29a45d199f926aadf93a9974128438c01b83141fba32477c0ee604b33", size = 1091425, upload-time = "2026-05-05T22:04:17.909Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/d2/28938574b766980f873b68962abb4c68a944d939446768982934ad3bcd93/ujson-5.12.1-cp314-cp314-win32.whl", hash = "sha256:c8e626b6bc9bdd2e8f7393b7d99f3daa2ca4022e6203662e70de7bb3604b21b9", size = 42334, upload-time = "2026-05-05T22:04:19.85Z" },
+    { url = "https://files.pythonhosted.org/packages/49/b0/0af30bf65d96b73c28054b344ebbe24bc96780ae8a7f2973f5dad979510a/ujson-5.12.1-cp314-cp314-win_amd64.whl", hash = "sha256:c6d3bdd020333688ee60559437021ed68a98a28fdd609b5af16de5dd58f90cba", size = 46586, upload-time = "2026-05-05T22:04:21.298Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/3b/0ee2555823724e60cc847c715c299f5792aa444bdde69c51d4aa42d885c2/ujson-5.12.1-cp314-cp314-win_arm64.whl", hash = "sha256:e3c9c894971f4ada3ded16a804ed4640e1f2b3e5239beaeec7c48296f39f4232", size = 41178, upload-time = "2026-05-05T22:04:22.597Z" },
+    { url = "https://files.pythonhosted.org/packages/3f/3d/7547835cd0b7fa22eb1122702f81b2403c38a0027a2cc0d75acc449a4a66/ujson-5.12.1-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:49dd9c378e1c8e676785ff2b62cb490074229f15ab54abf45b623713cb2c36b5", size = 58565, upload-time = "2026-05-05T22:04:23.75Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/6a/1784e0b24aab50623eb47b2f7a8dc22c9d809d798854d2568a9cb7c3560f/ujson-5.12.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:6d8827904358d7da59ccf2e1fd8de59e78248036d17fecc0462e62c6721f1102", size = 56157, upload-time = "2026-05-05T22:04:25.028Z" },
+    { url = "https://files.pythonhosted.org/packages/91/2d/2c1b24df24eee309047d81460c3a1acf0d047207327edc6f3cab8a614985/ujson-5.12.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:dc26caebea90425662ef0b979f945f6ac832651881107d6ec9a3c4d4a4ba929c", size = 60288, upload-time = "2026-05-05T22:04:26.273Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/14/c0c603e3dff2ef98f7deee2df7795e6055abbc5825c6ef530024b3b06a15/ujson-5.12.1-cp314-cp314t-manylinux_2_24_i686.manylinux_2_28_i686.whl", hash = "sha256:45022aae09ac3d45bda6fbfc631088d1aff9a0465542d40bd6d295ced378c430", size = 62302, upload-time = "2026-05-05T22:04:27.516Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/0d/889bbc044561d9adc9bf413620fbd9878f352c9fd36da829d319bca2f5ad/ujson-5.12.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:b22aa0f644516d3d5b29464949e4b23fe784f84b4a1030ab9ac3cb42aaedabb1", size = 59784, upload-time = "2026-05-05T22:04:28.776Z" },
+    { url = "https://files.pythonhosted.org/packages/18/35/3b1d8ff8cd6dc048f5c495af6ee6ded43055562610a7e9b78b438dc6421e/ujson-5.12.1-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:7dc5cf44ea42365cd1b66e6ed3fc6ca040c86587b024a6659b98e99d31cff2cd", size = 1039759, upload-time = "2026-05-05T22:04:30.291Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/d8/3c66cdf839420a6da2d6140a54a882c15efd135bcced103bd4473d577636/ujson-5.12.1-cp314-cp314t-musllinux_1_2_i686.whl", hash = "sha256:8df5d984ff4ac1ef292d70f30da03417038a7e1e0bc272d28ca9d34f02f41682", size = 1199121, upload-time = "2026-05-05T22:04:31.961Z" },
+    { url = "https://files.pythonhosted.org/packages/54/51/c3d1b94a4ad27dc7532e9f7d00b869463157cede2295ba6d57566afeb8cd/ujson-5.12.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:485f0182a0c0b54c304061cdc826d8343ce595c4055f7a24e72772a8520e5f7b", size = 1092085, upload-time = "2026-05-05T22:04:33.697Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/52/4d4a6e78290a5eef3f576f6d281e6355535db903a08483fd1bb393bf8cb9/ujson-5.12.1-cp314-cp314t-win32.whl", hash = "sha256:4e12ca368b397aed7fa1eec534ea1ba8d94977b376f9df3e93ae1acfd004ec40", size = 43243, upload-time = "2026-05-05T22:04:35.486Z" },
+    { url = "https://files.pythonhosted.org/packages/3d/c8/849366785de52b513e5fc89d7aea0b531e71bb5641407cbdfdf47a99ede8/ujson-5.12.1-cp314-cp314t-win_amd64.whl", hash = "sha256:cec6b9b539539affc1f01a795c99574592a635ce22331b64f2b42e0af570659e", size = 47662, upload-time = "2026-05-05T22:04:37.07Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/46/36a67f5a531a15308124786f3e2b7b96414b9d23dbcdc2a182dd3ffa2e1d/ujson-5.12.1-cp314-cp314t-win_arm64.whl", hash = "sha256:696224d4cfb8883fa5c0285dff31e5ce924704dd9ccd38e9ea8b5bf4a42b12fc", size = 41680, upload-time = "2026-05-05T22:04:39.083Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/26/c9d0479236b3f5690d6a8bb45f708aabc2c91ca80d275eba24b1e9e464ab/ujson-5.12.1-graalpy312-graalpy250_312_native-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:b2c419bf42ae40963fc27f70c59e24e9a97f5cf168dbce2c572f3c0ce3595912", size = 56153, upload-time = "2026-05-05T22:04:40.326Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/c8/785f4e132500aff2f1fd2bd4a4b86fe396a5519f830a098358c90ebb92ee/ujson-5.12.1-graalpy312-graalpy250_312_native-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0be2b4f2f547b9f0f3d902640e410e5a2fc851576cbe033c88445a23e3e7aef1", size = 57352, upload-time = "2026-05-05T22:04:42.005Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/13/b688a905653871b10b4ff0403c2ff562c17a0bd50be0d44324f3c85ca48f/ujson-5.12.1-graalpy312-graalpy250_312_native-win_amd64.whl", hash = "sha256:4ea0c490c702c20495e97345acfcf0c2f3153e658ef537ff111929c48b89e10a", size = 45988, upload-time = "2026-05-05T22:04:43.36Z" },
+]
+
+[[package]]
 name = "uri-template"
 version = "1.3.0"
 source = { registry = "https://pypi.org/simple" }
@@ -4373,6 +4897,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c7/24/5f1b3bdffd70275f6661c76461e25f024d5a38a46f04aaca912426a2b1d3/urllib3-2.6.3.tar.gz", hash = "sha256:1b62b6884944a57dbe321509ab94fd4d3b307075e0c2eae991ac71ee15ad38ed", size = 435556, upload-time = "2026-01-07T16:24:43.925Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/39/08/aaaad47bc4e9dc8c725e68f9d04865dbcb2052843ff09c97b08904852d84/urllib3-2.6.3-py3-none-any.whl", hash = "sha256:bf272323e553dfb2e87d9bfd225ca7b0f467b919d7bbd355436d3fd37cb0acd4", size = 131584, upload-time = "2026-01-07T16:24:42.685Z" },
+]
+
+[[package]]
+name = "uuid6"
+version = "2025.0.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ca/b7/4c0f736ca824b3a25b15e8213d1bcfc15f8ac2ae48d1b445b310892dc4da/uuid6-2025.0.1.tar.gz", hash = "sha256:cd0af94fa428675a44e32c5319ec5a3485225ba2179eefcf4c3f205ae30a81bd", size = 13932, upload-time = "2025-07-04T18:30:35.186Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/b2/93faaab7962e2aa8d6e174afb6f76be2ca0ce89fde14d3af835acebcaa59/uuid6-2025.0.1-py3-none-any.whl", hash = "sha256:80530ce4d02a93cdf82e7122ca0da3ebbbc269790ec1cb902481fa3e9cc9ff99", size = 6979, upload-time = "2025-07-04T18:30:34.001Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
What changed:
- add Evidently-backed feature and prediction drift helpers plus StatsD emission
- log prediction requests locally and expose prediction-monitoring Prometheus metrics
- wire the serving and orchestration paths into the new monitoring helpers and document the local prediction log

Why:
- make feature drift, inference drift, and local prediction-monitoring state observable

Verification:
- uv run ruff check src/foehncast/inference_pipeline/serve.py src/foehncast/monitoring/__init__.py src/foehncast/monitoring/drift.py src/foehncast/monitoring/prediction_log.py src/foehncast/monitoring/prediction_monitoring_prometheus.py src/foehncast/monitoring/prediction_prometheus.py src/foehncast/orchestration.py tests/test_drift.py tests/test_orchestration.py tests/test_predict.py tests/test_prediction_log.py tests/test_prediction_monitoring_prometheus.py tests/test_prediction_prometheus.py
- uv run pytest tests/test_drift.py tests/test_prediction_log.py tests/test_prediction_monitoring_prometheus.py tests/test_prediction_prometheus.py tests/test_predict.py tests/test_orchestration.py -q

Closes: #17