### PR TITLE
chore(runtime): modernize airflow and mlflow stack

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -40,9 +40,9 @@ MLFLOW_BIND_HOST=127.0.0.1
 # Airflow
 AIRFLOW_HOME=./airflow
 AIRFLOW__CORE__LOAD_EXAMPLES=false
-AIRFLOW_CREATE_ADMIN_USER=false
 AIRFLOW_BIND_HOST=127.0.0.1
-AIRFLOW__WEBSERVER__CONFIG_FILE=/opt/airflow/webserver_config.py
+AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS=true
+AIRFLOW__API_AUTH__JWT_SECRET=foehncast-local-jwt-secret
 # Airflow owns feature-pipeline orchestration inside the stack.
 # Leave AIRFLOW_FEATURE_SCHEDULE empty, manual, or off to disable recurring refreshes.
 AIRFLOW_FEATURE_DATASET=train

--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ mlartifacts/
 # Airflow
 airflow/logs/
 airflow/airflow.db
+airflow/airflow.db-*
 airflow/.init-complete
 airflow/*.pid
 airflow/airflow.cfg

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,7 @@ DATASET ?= train
 JUPYTER_TOKEN ?= foehncast-local
 TF_REMOTE_ARGS ?= plan
 SMOKE_BOOTSTRAP_ARGS ?=
+LOCAL_ONLY_COMPOSE := COMPOSE_PROFILES=local-only docker compose
 
 help:  ## Show this help
 	@grep -E '^[a-zA-Z0-9_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "%-24s %s\n", $$1, $$2}'
@@ -53,7 +54,7 @@ terraform-remote:  ## Trigger the remote Terraform workflow with TF_REMOTE_ARGS=
 smoke-bootstrap-only:  ## Run the disposable bootstrap-only smoke driver with SMOKE_BOOTSTRAP_ARGS='--repo owner/repo'
 	cd $(ROOT_DIR) && ./scripts/smoke-bootstrap-only.sh $(SMOKE_BOOTSTRAP_ARGS)
 
-compose-up:  ## Start the local compose stack
+compose-up:  ## Start the default local runtime stack
 	cd $(ROOT_DIR) && docker compose up -d
 
 compose-down:  ## Stop and remove the local compose stack
@@ -65,20 +66,20 @@ compose-ps:  ## List compose services
 compose-logs:  ## Tail compose logs
 	cd $(ROOT_DIR) && docker compose logs -f
 
-dev-build:  ## Rebuild the development_env image
-	cd $(ROOT_DIR) && docker compose build development_env
+dev-build:  ## Rebuild the opt-in development_env image
+	cd $(ROOT_DIR) && $(LOCAL_ONLY_COMPOSE) build development_env
 
-dev-rebuild:  ## Rebuild and recreate the development_env container
-	cd $(ROOT_DIR) && docker compose up -d --build --force-recreate development_env
+dev-rebuild:  ## Rebuild and recreate the opt-in development_env container
+	cd $(ROOT_DIR) && $(LOCAL_ONLY_COMPOSE) up -d --build --force-recreate development_env
 
-dev-shell:  ## Open a shell in development_env
-	cd $(ROOT_DIR) && docker compose exec development_env /bin/bash
+dev-shell:  ## Open a shell in the opt-in development_env container
+	cd $(ROOT_DIR) && $(LOCAL_ONLY_COMPOSE) up -d development_env && $(LOCAL_ONLY_COMPOSE) exec development_env /bin/bash
 
-notebook-server:  ## Restart development_env and start localhost-only Jupyter Lab
-	cd $(ROOT_DIR) && docker compose up -d development_env && docker compose restart development_env && docker compose exec -d development_env env JUPYTER_TOKEN="$(JUPYTER_TOKEN)" start-jupyter-server.sh && printf 'VS Code Jupyter URL: http://127.0.0.1:8888/?token=%s\n' "$(JUPYTER_TOKEN)"
+notebook-server:  ## Start the opt-in development_env container and localhost-only Jupyter Lab
+	cd $(ROOT_DIR) && $(LOCAL_ONLY_COMPOSE) up -d development_env && $(LOCAL_ONLY_COMPOSE) restart development_env && $(LOCAL_ONLY_COMPOSE) exec -d development_env env JUPYTER_TOKEN="$(JUPYTER_TOKEN)" start-jupyter-server.sh && printf 'VS Code Jupyter URL: http://127.0.0.1:8888/?token=%s\n' "$(JUPYTER_TOKEN)"
 
 notebook-stop:  ## Stop the container-backed notebook server by restarting development_env
-	cd $(ROOT_DIR) && docker compose restart development_env
+	cd $(ROOT_DIR) && $(LOCAL_ONLY_COMPOSE) up -d development_env && $(LOCAL_ONLY_COMPOSE) restart development_env
 
 feast-prepare:  ## Export stored features and apply the local Feast repo for DATASET=$(DATASET)
 	cd $(ROOT_DIR) && ./scripts/prepare-feast-local.sh $(DATASET)

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ This is the default path for a fresh machine.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 The local bootstrap uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, and it prepares Feast against the bundled Datastore-mode emulator before declaring the stack ready. If the preferred host ports are already busy, the helper moves the local bindings to the next free ports and prints the resolved endpoints.
+On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically; the `training_pipeline` DAG remains manual.
+The optional `development_env` notebook container stays out of the default runtime path and starts only when you explicitly target the notebook or dev-shell Makefile commands.
 
 After bootstrap completes, the main local endpoints are:
 

--- a/containers/README.md
+++ b/containers/README.md
@@ -12,7 +12,7 @@ flowchart LR
 		API[FastAPI app]
 	end
 	subgraph LocalOnly[Local-only services]
-		Dev[development_env]
+		Dev[optional development_env]
 		Objectstore[MinIO]
 		Emulator[Feast Datastore emulator]
 	end
@@ -42,7 +42,7 @@ flowchart LR
 
 | Surface group | Local evaluator | Hosted full-stack target | Hosted inference target |
 |---------------|-----------------|--------------------------|-------------------------|
-| `development_env`, MinIO, Feast emulator | yes | no | no |
+| optional `development_env`, MinIO, Feast emulator | yes | no | no |
 | Airflow, MLflow, app | yes | yes | app only |
 
 ## Main Components
@@ -54,14 +54,15 @@ flowchart LR
 
 ### `airflow/`
 
-- `airflow-init`: sets up the metadata database, log directories, and health marker, and can create an admin user when local auth is enabled.
-- `airflow-webserver`: serves the UI and API.
+- `airflow-init`: sets up the metadata database, log directories, a clean Airflow 3 config state, and can seed the simple-auth password file when login is enabled.
+- `airflow-webserver`: runs the Airflow 3 API server and UI on port 8080 under the repo's legacy service name.
+- `airflow-dag-processor`: parses DAG files into the metadata database for the scheduler and UI.
 - `airflow-scheduler`: schedules DAG runs.
 - `airflow-triggerer`: handles deferred task triggers.
 
 ### `development_env/`
 
-- `development_env`: keeps a local development container ready with the project environment synced by `uv`. It is part of the local baseline, not a hosted runtime target.
+- `development_env`: keeps a local development container ready with the project environment synced by `uv`. It is opt-in local tooling for notebooks, ad hoc shells, and container-side checks, not part of the default Airflow runtime path or any hosted target.
 
 ### `app/`
 
@@ -79,6 +80,7 @@ For the shortest evaluator path, run `./scripts/bootstrap-local.sh` from the rep
 This path is intentionally GCP-free. You do not need `gcloud`, Terraform, GitHub Actions variables, or Cloud Shell to run it.
 
 The default local path uses the bundled MinIO service for curated feature storage and MLflow artifacts, starts Airflow and MLflow without a login, prepares Feast against the bundled Datastore-mode emulator, and resets Docker volumes plus disposable local runtime artifacts for a clean run each time. The helper keeps the container-side endpoints on `objectstore:9000` and `feast-online-store:8080`, and can shift the host-exposed ports when the preferred defaults are already occupied.
+The optional `development_env` container now stays off unless you explicitly target it through the dedicated Makefile notebook and dev-shell commands.
 The app image itself is Feast-capable, and the local bootstrap prepares Feast state and verifies the online-feature route before declaring the stack ready.
 
 The initialized local runtime file is `.env`. The bootstrap script creates it from `.env.example` on first run if it does not exist yet.
@@ -87,7 +89,7 @@ Run these checks before deployment work:
 
 1. `./scripts/bootstrap-local.sh`
 2. `docker compose -f docker-compose.yml -f docker-compose.objectstore.yml ps -a`
-3. `curl -fsS http://127.0.0.1:8080/health`
+3. `curl -fsS http://127.0.0.1:8080/api/v2/monitor/health`
 4. `curl -fsS http://127.0.0.1:8000/health`
 5. `docker compose -f docker-compose.yml -f docker-compose.objectstore.yml exec -T airflow-scheduler airflow dags list`
 

--- a/containers/airflow/Dockerfile
+++ b/containers/airflow/Dockerfile
@@ -1,19 +1,19 @@
-FROM apache/airflow:2.10.5-python3.12
+FROM apache/airflow:3.2.1-python3.12
 
 USER root
 
 COPY --from=ghcr.io/astral-sh/uv:0.11.8 /uv /uvx /usr/local/bin/
 COPY containers/airflow/init-airflow.sh /usr/local/bin/init-airflow.sh
 COPY containers/airflow/start-airflow-webserver.sh /usr/local/bin/start-airflow-webserver.sh
+COPY containers/airflow/start-airflow-dag-processor.sh /usr/local/bin/start-airflow-dag-processor.sh
 COPY containers/airflow/start-airflow-scheduler.sh /usr/local/bin/start-airflow-scheduler.sh
 COPY containers/airflow/start-airflow-triggerer.sh /usr/local/bin/start-airflow-triggerer.sh
-COPY containers/airflow/webserver_config.py /opt/airflow/webserver_config.py
-COPY containers/airflow/webserver_config_cloud.py /opt/airflow/webserver_config_cloud.py
 
 RUN apt-get update \
     && apt-get install -y --no-install-recommends git tini \
     && chmod 755 /usr/local/bin/init-airflow.sh \
     /usr/local/bin/start-airflow-webserver.sh \
+    /usr/local/bin/start-airflow-dag-processor.sh \
     /usr/local/bin/start-airflow-scheduler.sh \
     /usr/local/bin/start-airflow-triggerer.sh \
     && rm -rf /var/lib/apt/lists/*
@@ -25,9 +25,14 @@ COPY src ./src
 
 USER airflow
 
-ENV UV_LINK_MODE=copy
+ENV UV_LINK_MODE=copy \
+    PATH=/usr/local/bin:$PATH
 
-RUN uv pip install --python /home/airflow/.local/bin/python -e .
+RUN /usr/local/bin/uv pip install --python /home/airflow/.local/bin/python \
+    "apache-airflow-providers-standard==1.12.3" \
+    -e . \
+    && ln -sf /usr/local/bin/uv /home/airflow/.local/bin/uv \
+    && ln -sf /usr/local/bin/uvx /home/airflow/.local/bin/uvx
 
 ENV PYTHONUNBUFFERED=1 \
     AIRFLOW_HOME=/workspace/airflow \

--- a/containers/airflow/docker-compose.yml
+++ b/containers/airflow/docker-compose.yml
@@ -1,13 +1,21 @@
 x-airflow-runtime-env: &airflow-runtime-env
   AIRFLOW_HOME: /workspace/airflow
-  AIRFLOW__CORE__EXECUTOR: SequentialExecutor
+  AIRFLOW__CORE__AUTH_MANAGER: ${AIRFLOW__CORE__AUTH_MANAGER:-airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager}
+  AIRFLOW__CORE__EXECUTOR: LocalExecutor
   AIRFLOW__CORE__LOAD_EXAMPLES: ${AIRFLOW__CORE__LOAD_EXAMPLES:-false}
   AIRFLOW__CORE__DAGS_FOLDER: /workspace/dags
+  AIRFLOW__CORE__EXECUTION_API_SERVER_URL: http://airflow-webserver:8080/execution/
+  AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS: ${AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS:-true}
+  AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS: ${AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_USERS:-admin:admin}
+  AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE: ${AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE:-/workspace/airflow/simple_auth_manager_passwords.json}
   AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: sqlite:////workspace/airflow/airflow.db
-  AIRFLOW__WEBSERVER__CONFIG_FILE: ${AIRFLOW__WEBSERVER__CONFIG_FILE:-/opt/airflow/webserver_config.py}
-  AIRFLOW__WEBSERVER__WARN_DEPLOYMENT_EXPOSURE: false
+  AIRFLOW__DATABASE__SQL_ALCHEMY_CONN_ASYNC: sqlite+aiosqlite:////workspace/airflow/airflow.db
+  AIRFLOW__API_AUTH__JWT_SECRET: ${AIRFLOW__API_AUTH__JWT_SECRET:-foehncast-local-jwt-secret}
   MLFLOW_TRACKING_URI: http://model-registry:5001
   GOOGLE_CLOUD_PROJECT: ${GCP_PROJECT_ID:-}
+  FOEHNCAST_STATSD_HOST: statsd
+  FOEHNCAST_STATSD_PORT: 8125
+  FOEHNCAST_STATSD_PREFIX: ${FOEHNCAST_STATSD_PREFIX:-drift_metrics}
   PYTHONPATH: /workspace/src
 
 x-airflow-common: &airflow-common
@@ -36,13 +44,9 @@ services:
     container_name: airflow-init
     environment:
       <<: *airflow-runtime-env
-      AIRFLOW_CREATE_ADMIN_USER: ${AIRFLOW_CREATE_ADMIN_USER:-false}
       AIRFLOW_ADMIN_USERNAME: ${AIRFLOW_ADMIN_USERNAME:-admin}
-      AIRFLOW_ADMIN_FIRSTNAME: ${AIRFLOW_ADMIN_FIRSTNAME:-Admin}
-      AIRFLOW_ADMIN_LASTNAME: ${AIRFLOW_ADMIN_LASTNAME:-User}
-      AIRFLOW_ADMIN_ROLE: ${AIRFLOW_ADMIN_ROLE:-Admin}
-      AIRFLOW_ADMIN_EMAIL: ${AIRFLOW_ADMIN_EMAIL:-admin@example.com}
       AIRFLOW_ADMIN_PASSWORD: ${AIRFLOW_ADMIN_PASSWORD:-admin}
+      AIRFLOW_ADMIN_PASSWORD_FILE: ${AIRFLOW_ADMIN_PASSWORD_FILE:-}
     command: ["/usr/local/bin/init-airflow.sh"]
     healthcheck:
       test: ["CMD-SHELL", "test -f /workspace/airflow/.init-complete"]
@@ -59,6 +63,14 @@ services:
     command: ["/usr/local/bin/start-airflow-webserver.sh"]
     ports:
       - ${AIRFLOW_BIND_HOST:-127.0.0.1}:8080:8080
+
+  airflow-dag-processor:
+    <<: *airflow-common
+    container_name: airflow-dag-processor
+    depends_on:
+      airflow-init:
+        condition: service_healthy
+    command: ["/usr/local/bin/start-airflow-dag-processor.sh"]
 
   airflow-scheduler:
     <<: *airflow-common

--- a/containers/airflow/init-airflow.sh
+++ b/containers/airflow/init-airflow.sh
@@ -8,13 +8,10 @@ set -eu
 airflow_home="/workspace/airflow"
 marker_file="${AIRFLOW_INIT_MARKER:-$airflow_home/.init-complete}"
 admin_username="${AIRFLOW_ADMIN_USERNAME:-admin}"
-admin_firstname="${AIRFLOW_ADMIN_FIRSTNAME:-Admin}"
-admin_lastname="${AIRFLOW_ADMIN_LASTNAME:-User}"
-admin_role="${AIRFLOW_ADMIN_ROLE:-Admin}"
-admin_email="${AIRFLOW_ADMIN_EMAIL:-admin@example.com}"
 admin_password_file="${AIRFLOW_ADMIN_PASSWORD_FILE:-}"
 admin_password="${AIRFLOW_ADMIN_PASSWORD:-admin}"
-create_admin_user="${AIRFLOW_CREATE_ADMIN_USER:-false}"
+simple_auth_manager_all_admins="${AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS:-false}"
+simple_auth_manager_passwords_file="${AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_PASSWORDS_FILE:-$airflow_home/simple_auth_manager_passwords.json.generated}"
 
 if [ -n "$admin_password_file" ] && [ -f "$admin_password_file" ]; then
   admin_password="$(cat "$admin_password_file")"
@@ -23,20 +20,22 @@ fi
 rm -f "$marker_file"
 mkdir -p "$airflow_home/logs" "$airflow_home/reports"
 rm -f "$airflow_home"/*.pid
+rm -f "$airflow_home/airflow.cfg" "$airflow_home/webserver_config.py"
 
-airflow db migrate
-
-case "$create_admin_user" in
+simple_auth_manager_all_admins_enabled=false
+case "$simple_auth_manager_all_admins" in
   1|true|TRUE|True|yes|YES|Yes)
-    airflow users create \
-      --username "$admin_username" \
-      --firstname "$admin_firstname" \
-      --lastname "$admin_lastname" \
-      --role "$admin_role" \
-      --email "$admin_email" \
-      --password "$admin_password" || true
+    simple_auth_manager_all_admins_enabled=true
     ;;
 esac
+
+if [ "$simple_auth_manager_all_admins_enabled" != true ] && [ -n "$admin_username" ] && [ -n "$admin_password" ]; then
+  mkdir -p "$(dirname "$simple_auth_manager_passwords_file")"
+  printf '{"%s":"%s"}\n' "$admin_username" "$admin_password" > "$simple_auth_manager_passwords_file"
+  chmod 600 "$simple_auth_manager_passwords_file"
+fi
+
+airflow db migrate
 
 touch "$marker_file"
 exec tail -f /dev/null

--- a/containers/airflow/start-airflow-dag-processor.sh
+++ b/containers/airflow/start-airflow-dag-processor.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Start the Airflow DAG processor in its own container.
+
+set -eu
+
+exec airflow dag-processor

--- a/containers/airflow/start-airflow-webserver.sh
+++ b/containers/airflow/start-airflow-webserver.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
-# Remove an old pid file, then start the Airflow webserver.
+# Remove stale pid files, then start the Airflow API server.
 
 set -eu
 
 airflow_home="/workspace/airflow"
 
-rm -f "$airflow_home/airflow-webserver.pid"
-exec airflow webserver
+rm -f "$airflow_home/airflow-webserver.pid" "$airflow_home/airflow-api-server.pid"
+exec airflow api-server

--- a/containers/airflow/webserver_config.py
+++ b/containers/airflow/webserver_config.py
@@ -1,9 +1,0 @@
-"""Local-only Airflow webserver settings."""
-
-from flask_appbuilder.const import AUTH_DB
-
-
-# Give anonymous localhost users full access to the local Airflow UI.
-# Do not reuse this config for shared or public deployments.
-AUTH_TYPE = AUTH_DB
-AUTH_ROLE_PUBLIC = "Admin"

--- a/containers/airflow/webserver_config_cloud.py
+++ b/containers/airflow/webserver_config_cloud.py
@@ -1,7 +1,0 @@
-"""Shared Airflow webserver settings for the online stack."""
-
-from flask_appbuilder.const import AUTH_DB
-
-
-AUTH_TYPE = AUTH_DB
-AUTH_ROLE_PUBLIC = "Public"

--- a/containers/development_env/docker-compose.yml
+++ b/containers/development_env/docker-compose.yml
@@ -1,6 +1,8 @@
 services:
   development_env:
     container_name: development_env
+    profiles:
+      - local-only
     build:
       context: ../..
       dockerfile: containers/development_env/Dockerfile

--- a/containers/mlflow/Dockerfile
+++ b/containers/mlflow/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/mlflow/mlflow:v3.7.0
+FROM ghcr.io/mlflow/mlflow:v3.12.0
 
 COPY start-model-registry.sh /usr/local/bin/start-model-registry.sh
 

--- a/dags/feature_dag.py
+++ b/dags/feature_dag.py
@@ -6,8 +6,8 @@ from datetime import datetime
 import os
 
 try:
-    from airflow import DAG
-    from airflow.operators.python import PythonOperator
+    from airflow.providers.standard.operators.python import PythonOperator
+    from airflow.sdk import DAG
 except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
     dag = None
 else:
@@ -28,6 +28,7 @@ else:
         start_date=datetime(2024, 1, 1),
         schedule=feature_schedule,
         catchup=False,
+        is_paused_upon_creation=False,
         tags=["foehncast", "feature"],
     ) as dag:
         PythonOperator(

--- a/dags/training_dag.py
+++ b/dags/training_dag.py
@@ -5,8 +5,8 @@ from __future__ import annotations
 from datetime import datetime
 
 try:
-    from airflow import DAG
-    from airflow.operators.python import PythonOperator
+    from airflow.providers.standard.operators.python import PythonOperator
+    from airflow.sdk import DAG
 except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
     dag = None
 else:
@@ -19,6 +19,7 @@ else:
         start_date=datetime(2024, 1, 1),
         schedule=None,
         catchup=False,
+        is_paused_upon_creation=True,
         tags=["foehncast", "training"],
     ) as dag:
         train_model = PythonOperator(

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -20,6 +20,10 @@ services:
     volumes:
       - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro
 
+  airflow-dag-processor:
+    volumes:
+      - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro
+
   airflow-scheduler:
     volumes:
       - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro

--- a/docker-compose.objectstore.yml
+++ b/docker-compose.objectstore.yml
@@ -34,6 +34,10 @@ services:
     environment:
       <<: [*objectstore-runtime-env, *feast-runtime-env]
 
+  airflow-dag-processor:
+    environment:
+      <<: [*objectstore-runtime-env, *feast-runtime-env]
+
   airflow-scheduler:
     environment:
       <<: [*objectstore-runtime-env, *feast-runtime-env]

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -13,6 +13,7 @@ This is the default path for a fresh machine.
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 
 The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
+The optional `development_env` notebook container stays off by default and only starts when you explicitly target the notebook or dev-shell Makefile commands.
 
 After bootstrap completes, the main local endpoints are:
 

--- a/docs/site/milestones/ms2.md
+++ b/docs/site/milestones/ms2.md
@@ -44,7 +44,7 @@ flowchart LR
 | `airflow dags test training_pipeline 2024-01-01` | the training DAG can execute through Airflow |
 | `curl -fsS http://127.0.0.1:8000/health` | the API starts with a serving model version |
 | `curl -fsS -X POST http://127.0.0.1:8000/predict ...` | the app returns live per-spot predictions |
-| `docker compose exec -T development_env uv run pytest` | the local stack still passes the regression suite after initialization |
+| `COMPOSE_PROFILES=local-only docker compose up -d development_env && COMPOSE_PROFILES=local-only docker compose exec -T development_env uv run pytest` | the opt-in notebook container still passes the regression suite after initialization |
 
 ## What Changed From MS1
 

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -62,7 +62,7 @@ flowchart LR
 
 | Target | Deploys | Leaves out | Primary use |
 |------|---------|------------|-------------|
-| Local evaluator target | Airflow, MLflow, FastAPI, `development_env`, MinIO, and the Feast Datastore emulator | shared GCP baseline | default development and course evaluation |
+| Local evaluator target | Airflow, MLflow, FastAPI, MinIO, the Feast Datastore emulator, and optional `development_env` tooling | shared GCP baseline | default development and course evaluation |
 | Hosted full-stack target | Airflow, MLflow, and FastAPI on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | keep the whole stack online |
 | Hosted inference target | FastAPI only, backed by shared GCP services | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | publish the inference API as a smaller hosted surface |
 | GitHub automation | image publishing and Terraform workflows | runtime services | repeatable delivery, not a runtime target |
@@ -73,7 +73,6 @@ The hosted targets deploy only runtime surfaces. Development assets, notebooks, 
 
 <div class="mermaid">
 flowchart TD
-    DEV[development_env] --> FEAT[Feature DAG]
     OME[Open-Meteo] --> FEAT
     FEAT --> PAR[(MinIO curated features)]
     PAR --> TRAIN[Training DAG]
@@ -86,7 +85,6 @@ flowchart TD
     PAR --> OFF[Feast offline export]
     OFF --> FEAST[(Datastore-mode emulator)]
     FEAST --> APP
-    DEV --> APP
 </div>
 
 ## Hosted Runtime Detail

--- a/scripts/bootstrap-local.sh
+++ b/scripts/bootstrap-local.sh
@@ -7,7 +7,7 @@ DEFAULT_ENV_FILE="${ROOT_DIR}/.env"
 EXAMPLE_ENV_FILE="${ROOT_DIR}/.env.example"
 FEATURE_DATE="${FEATURE_DATE:-2024-01-01}"
 TRAINING_DATE="${TRAINING_DATE:-2024-01-02}"
-AIRFLOW_HEALTH_URL="${AIRFLOW_HEALTH_URL:-http://127.0.0.1:8080/health}"
+AIRFLOW_HEALTH_URL="${AIRFLOW_HEALTH_URL:-http://127.0.0.1:8080/api/v2/monitor/health}"
 APP_HEALTH_URL="${APP_HEALTH_URL:-http://127.0.0.1:8000/health}"
 ONLINE_FEATURES_URL="${ONLINE_FEATURES_URL:-http://127.0.0.1:8000/features/online}"
 # shellcheck disable=SC1091
@@ -15,6 +15,60 @@ source "${ROOT_DIR}/scripts/cli-common.sh"
 
 usage() {
   echo "Usage: $0 [env-file]" >&2
+}
+
+TEMP_DOCKER_CONFIG=""
+
+cleanup_temporary_docker_config() {
+  if [[ -n "$TEMP_DOCKER_CONFIG" && -d "$TEMP_DOCKER_CONFIG" ]]; then
+    rm -rf "$TEMP_DOCKER_CONFIG"
+  fi
+}
+
+
+configure_docker_client_for_bootstrap() {
+  local source_docker_config="${HOME}/.docker"
+  local config_file="${DOCKER_CONFIG:-${source_docker_config}}/config.json"
+  local current_context="desktop-linux"
+
+  if [[ -n "${DOCKER_CONFIG:-}" ]]; then
+    return
+  fi
+
+  if [[ ! -f "$config_file" ]]; then
+    return
+  fi
+
+  if ! grep -Eq '"credsStore"[[:space:]]*:[[:space:]]*"desktop"' "$config_file"; then
+    return
+  fi
+
+  if command -v docker-credential-desktop >/dev/null 2>&1; then
+    return
+  fi
+
+  current_context="$(sed -nE 's/.*"currentContext"[[:space:]]*:[[:space:]]*"([^"]+)".*/\1/p' "$config_file" | head -n 1)"
+  current_context="${current_context:-desktop-linux}"
+  TEMP_DOCKER_CONFIG="$(mktemp -d "${TMPDIR:-/tmp}/foehncast-docker-config.XXXXXX")"
+
+  if [[ -d "$source_docker_config/cli-plugins" ]]; then
+    ln -s "$source_docker_config/cli-plugins" "$TEMP_DOCKER_CONFIG/cli-plugins"
+  fi
+  if [[ -d "$source_docker_config/contexts" ]]; then
+    ln -s "$source_docker_config/contexts" "$TEMP_DOCKER_CONFIG/contexts"
+  fi
+  if [[ -d "$source_docker_config/buildx" ]]; then
+    ln -s "$source_docker_config/buildx" "$TEMP_DOCKER_CONFIG/buildx"
+  fi
+  if [[ -d "$source_docker_config/desktop-build" ]]; then
+    ln -s "$source_docker_config/desktop-build" "$TEMP_DOCKER_CONFIG/desktop-build"
+  fi
+
+  printf '{\n  "currentContext": "%s",\n  "features": {\n    "hooks": "true"\n  }\n}\n' \
+    "$current_context" > "$TEMP_DOCKER_CONFIG/config.json"
+
+  export DOCKER_CONFIG="$TEMP_DOCKER_CONFIG"
+  echo "Docker credential helper 'docker-credential-desktop' is unavailable; using a temporary Docker client config for this bootstrap run."
 }
 
 ENV_FILE="$DEFAULT_ENV_FILE"
@@ -42,6 +96,9 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+trap cleanup_temporary_docker_config EXIT
+configure_docker_client_for_bootstrap
+
 require_docker_compose
 require_command curl
 
@@ -58,6 +115,15 @@ fi
 cd "$ROOT_DIR"
 
 COMPOSE_FILES=(-f docker-compose.yml -f docker-compose.objectstore.yml)
+BOOTSTRAP_SERVICES=(
+  objectstore-init
+  feast-online-store
+  airflow-webserver
+  airflow-dag-processor
+  airflow-scheduler
+  airflow-triggerer
+  app
+)
 
 compose() {
   docker compose --env-file "$ENV_FILE" "${COMPOSE_FILES[@]}" "$@"
@@ -115,8 +181,13 @@ next_available_port() {
 cleanup_local_runtime_state() {
   local dataset="$1"
 
+  rm -f "$ROOT_DIR/airflow/airflow.cfg"
+  rm -f "$ROOT_DIR/airflow/simple_auth_manager_passwords.json"
+  rm -f "$ROOT_DIR/airflow/simple_auth_manager_passwords.json.generated"
+  rm -f "$ROOT_DIR/airflow/webserver_config.py"
   rm -rf "$ROOT_DIR/airflow/reports"
   rm -rf "$ROOT_DIR/.state/feast"
+  rm -rf "$ROOT_DIR/.state/monitoring"
   rm -rf "$ROOT_DIR/data/$dataset"
   rm -f "$ROOT_DIR/data/feast/$dataset.parquet"
 }
@@ -210,13 +281,13 @@ echo "Removing disposable local runtime artifacts..."
 cleanup_local_runtime_state "$FEAST_DATASET"
 
 echo "Starting local stack..."
-compose up --build -d --remove-orphans
+compose up --build -d --remove-orphans "${BOOTSTRAP_SERVICES[@]}"
 
 echo "Waiting for Feast Datastore emulator..."
 wait_for_service_health feast-online-store 90 2
 curl --retry 30 --retry-all-errors --retry-delay 2 -fsS -X POST "$FEAST_DATASTORE_EMULATOR_RESET_URL" >/dev/null
 
-echo "Waiting for Airflow webserver health..."
+echo "Waiting for Airflow API server health..."
 curl --retry 60 --retry-all-errors --retry-delay 2 -fsS "$AIRFLOW_HEALTH_URL" >/dev/null
 
 echo "Running feature pipeline for ${FEATURE_DATE}..."
@@ -244,7 +315,7 @@ echo "App:      http://127.0.0.1:8000"
 echo "Airflow:  http://127.0.0.1:8080"
 echo "MLflow:   http://127.0.0.1:5001"
 echo "Feast:    /features/online verified"
-echo "Airflow and MLflow open directly in local mode."
+echo "Airflow UI/API and MLflow open directly in local mode."
 echo "This bootstrap path resets local Docker volumes and disposable local runtime artifacts so each run starts clean."
 echo "Curated features and MLflow artifacts are using the MinIO-backed local objectstore baseline for this run."
 echo "This keeps the local object-access layer aligned with the hosted GCS-facing architecture while Feast uses the local Datastore-mode emulator for online serving."

--- a/src/foehncast/training_pipeline/register.py
+++ b/src/foehncast/training_pipeline/register.py
@@ -24,12 +24,35 @@ def _registry_alias(stage: str, mlflow_config: dict[str, Any]) -> str:
     return normalized_stage
 
 
+def _logged_model_uri_for_run(run_id: str, client: Any) -> str | None:
+    if not hasattr(client, "get_run") or not hasattr(client, "search_logged_models"):
+        return None
+
+    run = client.get_run(run_id)
+    experiment_id = run.info.experiment_id
+    logged_models = client.search_logged_models(
+        experiment_ids=[experiment_id],
+        filter_string=f"source_run_id = '{run_id}'",
+        max_results=20,
+    )
+    if not logged_models:
+        return None
+
+    for logged_model in logged_models:
+        if getattr(logged_model, "name", None) == "model":
+            return logged_model.model_uri
+
+    return logged_models[0].model_uri
+
+
 def register_model(run_id: str, model_name: str | None = None) -> "ModelVersion":
     """Register the trained model artifact from a run and return its version."""
     mlflow_config = get_mlflow_config()
     resolved_model_name = _resolved_model_name(model_name, mlflow_config)
     mlflow.set_tracking_uri(get_mlflow_tracking_uri())
-    return mlflow.register_model(f"runs:/{run_id}/model", resolved_model_name)
+    client = mlflow.MlflowClient()
+    model_uri = _logged_model_uri_for_run(run_id, client) or f"runs:/{run_id}/model"
+    return mlflow.register_model(model_uri, resolved_model_name)
 
 
 def promote_model(

--- a/src/foehncast/training_pipeline/train.py
+++ b/src/foehncast/training_pipeline/train.py
@@ -107,6 +107,10 @@ def _log_feature_importance_plot(model: Any, feature_columns: list[str]) -> None
     plt.close(figure)
 
 
+def _model_pip_requirements() -> list[str]:
+    return mlflow.sklearn.get_default_pip_requirements(include_cloudpickle=True)
+
+
 def run_training_pipeline(model_config: dict[str, Any] | None = None) -> str:
     """Train the configured model, log the run to MLflow, and return the run id."""
     resolved_model_config = model_config or get_model_config()
@@ -142,6 +146,10 @@ def run_training_pipeline(model_config: dict[str, Any] | None = None) -> str:
             }
         )
         mlflow.log_metrics(metrics)
-        mlflow.sklearn.log_model(model, artifact_path="model")
+        mlflow.sklearn.log_model(
+            model,
+            name="model",
+            pip_requirements=_model_pip_requirements(),
+        )
         _log_feature_importance_plot(model, resolved_model_config["features"])
         return run.info.run_id

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -41,14 +41,28 @@ def _load_dag_module(
             return other
 
     airflow_module = types.ModuleType("airflow")
-    airflow_module.DAG = FakeDAG
-    operators_module = types.ModuleType("airflow.operators")
-    python_module = types.ModuleType("airflow.operators.python")
+    airflow_module.__path__ = []
+    sdk_module = types.ModuleType("airflow.sdk")
+    sdk_module.DAG = FakeDAG
+    providers_module = types.ModuleType("airflow.providers")
+    providers_module.__path__ = []
+    standard_module = types.ModuleType("airflow.providers.standard")
+    standard_module.__path__ = []
+    operators_module = types.ModuleType("airflow.providers.standard.operators")
+    operators_module.__path__ = []
+    python_module = types.ModuleType("airflow.providers.standard.operators.python")
     python_module.PythonOperator = FakePythonOperator
 
     monkeypatch.setitem(sys.modules, "airflow", airflow_module)
-    monkeypatch.setitem(sys.modules, "airflow.operators", operators_module)
-    monkeypatch.setitem(sys.modules, "airflow.operators.python", python_module)
+    monkeypatch.setitem(sys.modules, "airflow.sdk", sdk_module)
+    monkeypatch.setitem(sys.modules, "airflow.providers", providers_module)
+    monkeypatch.setitem(sys.modules, "airflow.providers.standard", standard_module)
+    monkeypatch.setitem(
+        sys.modules, "airflow.providers.standard.operators", operators_module
+    )
+    monkeypatch.setitem(
+        sys.modules, "airflow.providers.standard.operators.python", python_module
+    )
 
     for name in (
         "AIRFLOW_FEATURE_DATASET",
@@ -79,6 +93,7 @@ def test_feature_dag_defaults_to_airflow_schedule(
 
     assert module.dag.kwargs["schedule"] == "0 */6 * * *"
     assert module.dag.kwargs["catchup"] is False
+    assert module.dag.kwargs["is_paused_upon_creation"] is False
     assert len(operators) == 1
     assert operators[0].kwargs["task_id"] == "run_feature_pipeline"
     assert operators[0].kwargs["op_kwargs"] == {"dataset": "train"}
@@ -98,3 +113,18 @@ def test_feature_dag_supports_manual_override_and_dataset(
 
     assert module.dag.kwargs["schedule"] is None
     assert operators[0].kwargs["op_kwargs"] == {"dataset": "validation"}
+
+
+def test_training_dag_stays_manual_and_paused_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, operators = _load_dag_module(monkeypatch, "dags/training_dag.py")
+
+    assert module.dag.kwargs["schedule"] is None
+    assert module.dag.kwargs["catchup"] is False
+    assert module.dag.kwargs["is_paused_upon_creation"] is True
+    assert [operator.kwargs["task_id"] for operator in operators] == [
+        "train_model",
+        "evaluate_model",
+        "register_model",
+    ]

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -23,15 +23,32 @@ def mlflow_config() -> dict[str, str]:
     }
 
 
-def test_register_model_registers_run_artifact(
+def test_register_model_registers_logged_model_uri_when_available(
     monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
 ) -> None:
     logged: dict[str, object] = {}
     expected_version = SimpleNamespace(name="foehncast-quality", version="3")
 
+    class FakeClient:
+        def get_run(self, run_id: str) -> object:
+            logged["run_id"] = run_id
+            return SimpleNamespace(info=SimpleNamespace(experiment_id="exp-123"))
+
+        def search_logged_models(
+            self,
+            experiment_ids: list[str],
+            filter_string: str | None = None,
+            max_results: int | None = None,
+        ) -> list[object]:
+            logged["search"] = (experiment_ids, filter_string, max_results)
+            return [SimpleNamespace(name="model", model_uri="models:/m-123")]
+
     class FakeMlflow:
         def set_tracking_uri(self, tracking_uri: str) -> None:
             logged["tracking_uri"] = tracking_uri
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
 
         def register_model(self, model_uri: str, model_name: str) -> object:
             logged["registration"] = (model_uri, model_name)
@@ -47,8 +64,14 @@ def test_register_model_registers_run_artifact(
 
     assert model_version is expected_version
     assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["run_id"] == "run-123"
+    assert logged["search"] == (
+        ["exp-123"],
+        "source_run_id = 'run-123'",
+        20,
+    )
     assert logged["registration"] == (
-        "runs:/run-123/model",
+        "models:/m-123",
         "foehncast-quality",
     )
 
@@ -58,9 +81,24 @@ def test_register_model_allows_model_name_override(
 ) -> None:
     logged: dict[str, tuple[str, str]] = {}
 
+    class FakeClient:
+        def get_run(self, run_id: str) -> object:
+            return SimpleNamespace(info=SimpleNamespace(experiment_id="exp-123"))
+
+        def search_logged_models(
+            self,
+            experiment_ids: list[str],
+            filter_string: str | None = None,
+            max_results: int | None = None,
+        ) -> list[object]:
+            return [SimpleNamespace(name="model", model_uri="models:/m-456")]
+
     class FakeMlflow:
         def set_tracking_uri(self, tracking_uri: str) -> None:
             return None
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
 
         def register_model(self, model_uri: str, model_name: str) -> object:
             logged["registration"] = (model_uri, model_name)
@@ -75,8 +113,41 @@ def test_register_model_allows_model_name_override(
     register.register_model("run-456", model_name="foehncast-experiment")
 
     assert logged["registration"] == (
-        "runs:/run-456/model",
+        "models:/m-456",
         "foehncast-experiment",
+    )
+
+
+def test_register_model_falls_back_to_run_artifact_when_logged_model_lookup_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, tuple[str, str]] = {}
+
+    class FakeClient:
+        pass
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            return None
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
+
+        def register_model(self, model_uri: str, model_name: str) -> object:
+            logged["registration"] = (model_uri, model_name)
+            return object()
+
+    monkeypatch.setattr(register, "mlflow", FakeMlflow())
+    monkeypatch.setattr(register, "get_mlflow_config", lambda: mlflow_config)
+    monkeypatch.setattr(
+        register, "get_mlflow_tracking_uri", lambda: "http://localhost:5001"
+    )
+
+    register.register_model("run-789")
+
+    assert logged["registration"] == (
+        "runs:/run-789/model",
+        "foehncast-quality",
     )
 
 

--- a/tests/test_runtime_stack.py
+++ b/tests/test_runtime_stack.py
@@ -1,0 +1,101 @@
+"""Contract tests for the modernized local runtime stack."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read_text(relative_path: str) -> str:
+    return (REPO_ROOT / relative_path).read_text()
+
+
+def _read_yaml(relative_path: str) -> dict:
+    return yaml.safe_load(_read_text(relative_path))
+
+
+def test_env_example_uses_airflow3_simple_auth_contract() -> None:
+    env_example = _read_text(".env.example")
+
+    assert "AIRFLOW__CORE__SIMPLE_AUTH_MANAGER_ALL_ADMINS=true" in env_example
+    assert "AIRFLOW__API_AUTH__JWT_SECRET=foehncast-local-jwt-secret" in env_example
+    assert "AIRFLOW_CREATE_ADMIN_USER" not in env_example
+    assert "AIRFLOW__WEBSERVER__CONFIG_FILE" not in env_example
+
+
+def test_airflow_compose_uses_airflow3_runtime_contract() -> None:
+    compose = _read_yaml("containers/airflow/docker-compose.yml")
+    runtime_env = compose["x-airflow-runtime-env"]
+    services = compose["services"]
+
+    assert runtime_env["AIRFLOW__CORE__EXECUTOR"] == "LocalExecutor"
+    assert (
+        runtime_env["AIRFLOW__CORE__EXECUTION_API_SERVER_URL"]
+        == "http://airflow-webserver:8080/execution/"
+    )
+    assert (
+        runtime_env["AIRFLOW__CORE__AUTH_MANAGER"]
+        == "${AIRFLOW__CORE__AUTH_MANAGER:-airflow.api_fastapi.auth.managers.simple.simple_auth_manager.SimpleAuthManager}"
+    )
+    assert (
+        runtime_env["AIRFLOW__API_AUTH__JWT_SECRET"]
+        == "${AIRFLOW__API_AUTH__JWT_SECRET:-foehncast-local-jwt-secret}"
+    )
+    assert "airflow-dag-processor" in services
+
+
+def test_local_bootstrap_uses_runtime_service_subset_and_api_health() -> None:
+    bootstrap = _read_text("scripts/bootstrap-local.sh")
+    services = bootstrap.split("BOOTSTRAP_SERVICES=(", 1)[1].split(")", 1)[0]
+
+    assert "http://127.0.0.1:8080/api/v2/monitor/health" in bootstrap
+    assert "Waiting for Airflow API server health" in bootstrap
+    assert (
+        'compose up --build -d --remove-orphans "${BOOTSTRAP_SERVICES[@]}"' in bootstrap
+    )
+    assert "airflow-dag-processor" in services
+    assert "development_env" not in services
+
+
+def test_local_bootstrap_handles_missing_docker_desktop_helper() -> None:
+    bootstrap = _read_text("scripts/bootstrap-local.sh")
+
+    assert "configure_docker_client_for_bootstrap" in bootstrap
+    assert "docker-credential-desktop" in bootstrap
+    assert '"credsStore"[[:space:]]*:[[:space:]]*"desktop"' in bootstrap
+    assert 'ln -s "$source_docker_config/cli-plugins"' in bootstrap
+    assert 'export DOCKER_CONFIG="$TEMP_DOCKER_CONFIG"' in bootstrap
+
+
+def test_airflow_init_uses_simple_auth_password_file() -> None:
+    init_script = _read_text("containers/airflow/init-airflow.sh")
+
+    assert "simple_auth_manager_passwords_file" in init_script
+    assert 'printf \'{"%s":"%s"}\\n\'' in init_script
+    assert "airflow db migrate" in init_script
+    assert "airflow users create" not in init_script
+
+
+def test_dag_processor_command_script_runs_airflow_dag_processor() -> None:
+    dag_processor = _read_text("containers/airflow/start-airflow-dag-processor.sh")
+
+    assert "exec airflow dag-processor" in dag_processor
+
+
+def test_development_env_is_opt_in_via_local_only_profile() -> None:
+    compose = _read_yaml("containers/development_env/docker-compose.yml")
+
+    assert compose["services"]["development_env"]["profiles"] == ["local-only"]
+
+
+def test_runtime_images_use_validated_airflow_and_mlflow_versions() -> None:
+    airflow_dockerfile = _read_text("containers/airflow/Dockerfile")
+    mlflow_dockerfile = _read_text("containers/mlflow/Dockerfile")
+
+    assert "FROM apache/airflow:3.2.1-python3.12" in airflow_dockerfile
+    assert "apache-airflow-providers-standard==1.12.3" in airflow_dockerfile
+    assert "FROM ghcr.io/mlflow/mlflow:v3.12.0" in mlflow_dockerfile

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -218,10 +218,11 @@ def test_run_training_pipeline_logs_mlflow_artifacts(
     class FakeMlflow:
         def __init__(self) -> None:
             self.sklearn = SimpleNamespace(
-                log_model=lambda model, artifact_path: logged.update(
+                log_model=lambda model, name, pip_requirements: logged.update(
                     {
                         "logged_model": model,
-                        "artifact_path": artifact_path,
+                        "model_name": name,
+                        "pip_requirements": pip_requirements,
                     }
                 )
             )
@@ -280,6 +281,11 @@ def test_run_training_pipeline_logs_mlflow_artifacts(
             {"feature_plot": list(feature_columns)}
         ),
     )
+    monkeypatch.setattr(
+        train,
+        "_model_pip_requirements",
+        lambda: ["scikit-learn==1.8.0", "cloudpickle==3.1.1"],
+    )
 
     run_id = train.run_training_pipeline(model_config)
 
@@ -294,5 +300,9 @@ def test_run_training_pipeline_logs_mlflow_artifacts(
         "r2",
         "overall_class_accuracy",
     }
-    assert logged["artifact_path"] == "model"
+    assert logged["model_name"] == "model"
+    assert logged["pip_requirements"] == [
+        "scikit-learn==1.8.0",
+        "cloudpickle==3.1.1",
+    ]
     assert logged["feature_plot"] == model_config["features"]


### PR DESCRIPTION
What changed:
- upgrade the local Airflow runtime to 3.2.1 and the MLflow image to 3.12.0
- switch Airflow to the API server plus dag-processor topology with the simple auth manager contract
- update bootstrap, docs, and runtime contract tests for the modern local stack path

Why:
- keep the local runtime on supported versions without regressing the clean bootstrap path

Verification:
- uv run ruff check dags/feature_dag.py dags/training_dag.py src/foehncast/training_pipeline/register.py src/foehncast/training_pipeline/train.py tests/test_dags.py tests/test_register.py tests/test_train.py tests/test_runtime_stack.py
- uv run pytest tests/test_dags.py tests/test_register.py tests/test_train.py tests/test_runtime_stack.py -q
- docker compose -f docker-compose.yml -f docker-compose.objectstore.yml config >/dev/null

Closes: #99