### PR TITLE
chore(ci): update workflow actions for Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
   workflow_dispatch:
 
 permissions:
@@ -16,7 +16,7 @@ jobs:
       'pull_request' || github.triggering_actor == github.repository_owner) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: docker compose -f docker-compose.yml config
       - run: docker compose -f docker-compose.yml -f docker-compose.cloud.yml config
       - run: docker compose -f docker-compose.yml build model-registry app
@@ -27,7 +27,7 @@ jobs:
       'pull_request' || github.triggering_actor == github.repository_owner) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
       - run: bash -n scripts/*.sh
       - run: bash scripts/terraform-remote.sh --help >/dev/null
       - run: bash scripts/smoke-bootstrap-only.sh --repo example/foehncast --project-id fcast-smoke-ci --dry-run >/dev/null
@@ -39,8 +39,8 @@ jobs:
       'pull_request' || github.triggering_actor == github.repository_owner) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v6.0.2
+      - uses: hashicorp/setup-terraform@v4.0.0
       - run: terraform -chdir=terraform init -backend=false
       - run: terraform -chdir=terraform fmt -check
       - run: terraform -chdir=terraform validate
@@ -50,8 +50,8 @@ jobs:
       'pull_request' || github.triggering_actor == github.repository_owner) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync --frozen
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -61,8 +61,8 @@ jobs:
       'pull_request' || github.triggering_actor == github.repository_owner) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync --frozen
       - run: uv run pytest tests/ -v
 
@@ -71,7 +71,7 @@ jobs:
       'pull_request' || github.triggering_actor == github.repository_owner) }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v5
+      - uses: actions/checkout@v6.0.2
+      - uses: astral-sh/setup-uv@v8.1.0
       - run: uv sync --frozen --only-group docs --no-default-groups
       - run: uv run mkdocs build -f docs/mkdocs.yml --strict

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,7 +2,7 @@ name: Deploy Docs
 
 on:
     push:
-        branches: [ main ]
+        branches: [main]
         paths:
             - "docs/site/**"
             - "docs/mkdocs.yml"
@@ -22,8 +22,8 @@ jobs:
         permissions:
             contents: read
         steps:
-            - uses: actions/checkout@v4
-            - uses: astral-sh/setup-uv@v5
+            - uses: actions/checkout@v6.0.2
+            - uses: astral-sh/setup-uv@v8.1.0
             - uses: actions/configure-pages@v5
             - run: uv sync --frozen --only-group docs --no-default-groups
             - run: uv run mkdocs build -f docs/mkdocs.yml --strict

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -2,7 +2,7 @@ name: Publish App Image
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - .github/workflows/publish-app-image.yml
       - containers/app/**
@@ -34,7 +34,7 @@ jobs:
     env:
       IMAGE_NAME: foehncast-app
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - id: flags
         env:
@@ -106,7 +106,7 @@ jobs:
       IMAGE_NAME: foehncast-app
       IMAGE_REPOSITORY: ${{ needs.config.outputs.image_repository }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/publish-runtime-images.yml
+++ b/.github/workflows/publish-runtime-images.yml
@@ -2,7 +2,7 @@ name: Publish Runtime Images
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
     paths:
       - .github/workflows/publish-runtime-images.yml
       - containers/app/**
@@ -36,7 +36,7 @@ jobs:
             context: containers/mlflow
             dockerfile: containers/mlflow/Dockerfile
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
       - uses: docker/setup-buildx-action@v3
 

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -143,8 +143,8 @@ jobs:
       github.repository_owner }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: hashicorp/setup-terraform@v3
+      - uses: actions/checkout@v6.0.2
+      - uses: hashicorp/setup-terraform@v4.0.0
       - run: terraform -chdir=terraform init -backend=false
       - run: terraform -chdir=terraform fmt -check
       - run: terraform -chdir=terraform validate
@@ -162,9 +162,9 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6.0.2
 
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4.0.0
 
       - name: Load repository configuration
         id: repo_config


### PR DESCRIPTION
- What changed: upgraded workflow action references that still ran on Node 20 to Node 24-compatible releases across CI, docs, Terraform, and image-publish workflows.\n- Why: GitHub runners now warn on Node 20-based JavaScript actions and will switch the default runtime to Node 24.\n- Verification: parsed the edited workflow YAML locally, ran git diff --check, and verified the deprecated action references are gone.\n- Closes: #105