### PR TITLE
fix(infra): restore shared cloud deployment workflow

### DIFF
--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -186,7 +186,8 @@ jobs:
             --image "$IMAGE_URI" \
             --quiet
 
-          echo "service_url=$(gcloud run services describe \"$CLOUD_RUN_SERVICE\" --project \"$GCP_PROJECT_ID\" --region \"$GCP_LOCATION\" --format='value(status.url)')" >> "$GITHUB_OUTPUT"
+          service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
+          echo "service_url=${service_url}" >> "$GITHUB_OUTPUT"
 
       - name: Summarize Cloud Run deployment
         run: |

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -89,10 +89,6 @@ on:
         description: Cloud Run service name (leave blank to use repo vars)
         required: false
         type: string
-      cloud_run_container_port:
-        description: Cloud Run container port (leave blank to use repo vars)
-        required: false
-        type: string
       cloud_run_allow_unauthenticated:
         description: Allow unauthenticated Cloud Run access (`true` or `false`; leave blank to use repo vars)
         required: false
@@ -103,14 +99,6 @@ on:
         type: string
       cloud_run_max_instance_count:
         description: Maximum Cloud Run instance count (leave blank to use repo vars)
-        required: false
-        type: string
-      cloud_run_cpu:
-        description: Cloud Run CPU limit (leave blank to use repo vars)
-        required: false
-        type: string
-      cloud_run_memory:
-        description: Cloud Run memory limit (leave blank to use repo vars)
         required: false
         type: string
       provision_online_compose_host:
@@ -422,10 +410,7 @@ jobs:
             cloud_run_service_name='foehncast-serve'
           fi
 
-          cloud_run_container_port="${{ inputs.cloud_run_container_port }}"
-          if [[ -z "$cloud_run_container_port" ]]; then
-            cloud_run_container_port="$REPO_GCP_CLOUD_RUN_CONTAINER_PORT"
-          fi
+          cloud_run_container_port="$REPO_GCP_CLOUD_RUN_CONTAINER_PORT"
           if [[ -z "$cloud_run_container_port" ]]; then
             cloud_run_container_port='8080'
           fi
@@ -462,18 +447,12 @@ jobs:
             exit 1
           fi
 
-          cloud_run_cpu="${{ inputs.cloud_run_cpu }}"
-          if [[ -z "$cloud_run_cpu" ]]; then
-            cloud_run_cpu="$REPO_GCP_CLOUD_RUN_CPU"
-          fi
+          cloud_run_cpu="$REPO_GCP_CLOUD_RUN_CPU"
           if [[ -z "$cloud_run_cpu" ]]; then
             cloud_run_cpu='1'
           fi
 
-          cloud_run_memory="${{ inputs.cloud_run_memory }}"
-          if [[ -z "$cloud_run_memory" ]]; then
-            cloud_run_memory="$REPO_GCP_CLOUD_RUN_MEMORY"
-          fi
+          cloud_run_memory="$REPO_GCP_CLOUD_RUN_MEMORY"
           if [[ -z "$cloud_run_memory" ]]; then
             cloud_run_memory='512Mi'
           fi

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ flowchart LR
 | Feature pipeline | Working | Airflow ingests, engineers, validates, and stores curated weather features |
 | Training pipeline | Working | Airflow labels data, trains the model, evaluates it, and registers versions in MLflow |
 | Inference pipeline | Working | FastAPI serves `/health`, `/spots`, `/predict`, `/rank`, and online-feature routes |
-| Hosted runtime | Working | Terraform can provision either a hosted full-stack target on one GCP host or an inference-only Cloud Run service |
+| Hosted runtime | Working | The shared environment currently runs the hosted full-stack target on one GCP host; the inference-only Cloud Run target remains provisionable but is not enabled there |
 | Automation | Working | GitHub Actions publishes images, validates infrastructure, and drives remote Terraform workflows |
 | Monitoring | Working | Docker Compose provisions Prometheus, a StatsD exporter, and Grafana; the app exposes `/metrics`; and Grafana loads starter dashboards plus alert rules from checked-in config |
 
@@ -37,7 +37,9 @@ FoehnCast has one supported contributor setup path: run everything locally with 
 ```mermaid
 flowchart TB
     Local[Local setup] --> Compose[Airflow + MLflow + FastAPI]
-    Main[Push to main] --> Cloud[GitHub-managed shared cloud automation]
+  Main[Push to main] --> Cloud[GitHub-managed shared cloud automation]
+  Cloud --> Host[Hosted full-stack target today]
+  Cloud -. optional .-> Run[Inference-only Cloud Run target]
 ```
 
 ## Quick Start
@@ -89,6 +91,8 @@ The shared hosted environment is not part of normal contributor setup.
 - Contributors only need Docker and the local bootstrap path.
 - The shared cloud environment is maintained through GitHub Actions after a one-time maintainer bootstrap.
 - Contributors do not need local Terraform, `gcloud`, or `gh` for normal work.
+
+The current shared environment uses the hosted full-stack target so Airflow, MLflow, and the API stay online together. The Cloud Run path remains available as an inference-only option, but it is not the active shared deployment surface today.
 
 Maintainer-only cloud bootstrap and operator details live in `terraform/README.md`.
 

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -6,6 +6,7 @@ FoehnCast has two hosted targets: a hosted full-stack target on one GCP host and
 
     The shared GCP baseline and the hosted entry points exist today.
     Not every longer-term managed service is finished yet, so this page distinguishes between what is implemented now and what remains a transition target.
+    The current shared environment uses the hosted full-stack target. The inference-only Cloud Run path is implemented, but it is not the active shared deployment surface today.
 
 ## Cloud Paths In One View
 
@@ -45,10 +46,12 @@ FoehnCast has two hosted targets: a hosted full-stack target on one GCP host and
 flowchart LR
     TF[Terraform baseline] --> GCP[Shared GCP resources]
     GCP --> HOST[Hosted full-stack target]
-    GCP --> RUN[Hosted inference target]
+    GCP -. optional .-> RUN[Hosted inference target]
     TF --> GH[GitHub OIDC delivery]
     HOST --> STACK[Airflow + MLflow + API]
     RUN --> API[Inference API only]
+    GH --> HOST
+    GH -. app image publish .-> RUN
 </div>
 
 ## What Exists Today
@@ -56,12 +59,14 @@ flowchart LR
 | Surface | Deploys | Leaves out | Current state |
 |--------|---------|------------|---------------|
 | Shared GCP baseline | APIs, Artifact Registry, GCS, BigQuery, Datastore, and OIDC identities | app containers | implemented as Terraform inputs and resources |
-| Hosted full-stack target | Airflow, MLflow, and the API on one Compute Engine host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented as a Terraform path |
-| Hosted inference target | the FastAPI inference API on Cloud Run | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented as a Terraform path |
-| GitHub delivery | image publishing and remote Terraform runs | runtime services | implemented |
+| Hosted full-stack target | Airflow, MLflow, and the API on one Compute Engine host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented as a Terraform path and active in the shared environment |
+| Hosted inference target | the FastAPI inference API on Cloud Run | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented as a Terraform and image-delivery path, currently disabled in the shared environment |
+| GitHub delivery | image publishing and remote Terraform runs | runtime services | implemented and bootstrapped for the shared environment |
 
 The hosted paths deploy runtime services only. Development assets stay local or CI-only.
 | BigQuery backend support | implemented in the application | local and hosted runtimes can point the storage backend at BigQuery |
+
+Today the shared environment uses the hosted full-stack target because it keeps Airflow and MLflow co-located with the API. The Cloud Run path remains the smaller optional API-only surface for a later or separate deployment slice.
 
 ## Honest Mapping From Local To Cloud
 

--- a/scripts/terraform-remote.sh
+++ b/scripts/terraform-remote.sh
@@ -220,6 +220,10 @@ record_input() {
       INPUT_FEAST_ONLINE_STORE_DATABASE_NAME="$value"
       EXTRA_INPUTS+=("$input")
       ;;
+    cloud_run_container_port|cloud_run_cpu|cloud_run_memory)
+      echo "${key} is not exposed as a workflow_dispatch input. Update the synced repository variable or Terraform configuration instead." >&2
+      exit 1
+      ;;
     cleanup_clear_github_actions)
       CLEANUP_CLEAR_GITHUB_ACTIONS="$(normalize_bool "$value")"
       ;;

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -67,6 +67,7 @@ When `provision_cloud_run_service = true`, provide:
 - any extra runtime configuration in `cloud_run_env_vars`
 
 Terraform already injects the default BigQuery storage environment for the Cloud Run service using the managed dataset and table IDs. Cloud Run should rely on its runtime service account for auth, not on mounted key files.
+That runtime service account includes both BigQuery job access and BigQuery Storage API read-session access so pandas-backed BigQuery reads can succeed without falling back to mounted credentials.
 Terraform also injects the Feast runtime env contract for the hosted app path: the service gets `FOEHNCAST_FEAST_SOURCE=bigquery`, the managed bucket-backed registry and staging paths, the fully-qualified curated BigQuery table reference used by the rendered Feast runtime config, and the named Datastore-mode database used for Feast online serving.
 
 ## Hosted Full-Stack Target Inputs
@@ -84,7 +85,7 @@ The same generated `.env` also points the hosted MLflow service at `gs://<artifa
 
 The hosted baseline also provisions a Firestore Datastore-mode database dedicated to Feast online serving. Using a named database avoids coupling the repo to whatever default Firestore state a reused GCP project may already have.
 
-The host uses a dedicated runtime service account with BigQuery job access, BigQuery dataset edit access, and Datastore user access, so the Airflow, training, Feast, app, and MLflow containers can rely on Application Default Credentials instead of mounted key files.
+The host uses a dedicated runtime service account with BigQuery job access, BigQuery Storage API read-session access, BigQuery dataset edit access, bucket object-admin access for MLflow and Feast artifacts, and Datastore user access, so the Airflow, training, Feast, app, and MLflow containers can rely on Application Default Credentials instead of mounted key files.
 
 After curated BigQuery rows are available, run `./scripts/prepare-feast-cloud.sh` on the host or from another shell with ADC to apply the Feast repo and materialize the hosted online store.
 
@@ -180,6 +181,8 @@ When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow
 Use `.github/workflows/terraform.yml` to run validate, plan, apply, destroy, or cleanup from GitHub Actions without requiring local Terraform. After the one-time bootstrap has established OIDC and the remote backend, pushes to `main` automatically run the shared remote apply path for Terraform-managed cloud changes. Successful applies resync the repository variables automatically.
 
 Manual workflow dispatch is still available for plan, destroy, cleanup, and explicit overrides. `./scripts/terraform-remote.sh` remains optional maintainer convenience for people who already use `gh`, but the GitHub Actions workflow is the primary operator surface.
+
+GitHub limits `workflow_dispatch` to 25 inputs. The manual workflow therefore keeps the higher-value environment and topology overrides exposed there, while lower-level Cloud Run sizing defaults such as container port, CPU, and memory stay repo-variable-backed through the Terraform sync contract.
 
 For `command=destroy`, the workflow does not create a missing backend bucket. Instead it fails fast unless the remote state backend already exists, and it requires `destroy_confirmation` to match the resolved GCP project id. That keeps remote teardown explicit and tied to the same state that created the environment.
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -382,6 +382,12 @@ resource "google_project_iam_member" "cloud_run_bigquery_job_user" {
   member  = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
 }
 
+resource "google_project_iam_member" "cloud_run_bigquery_read_session_user" {
+  project = var.project_id
+  role    = "roles/bigquery.readSessionUser"
+  member  = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
+}
+
 resource "google_project_iam_member" "cloud_run_datastore_user" {
   project = var.project_id
   role    = "roles/datastore.user"
@@ -402,12 +408,28 @@ resource "google_project_iam_member" "online_compose_bigquery_job_user" {
   member  = "serviceAccount:${google_service_account.online_compose_runtime[0].email}"
 }
 
+resource "google_project_iam_member" "online_compose_bigquery_read_session_user" {
+  count = var.provision_online_compose_host ? 1 : 0
+
+  project = var.project_id
+  role    = "roles/bigquery.readSessionUser"
+  member  = "serviceAccount:${google_service_account.online_compose_runtime[0].email}"
+}
+
 resource "google_project_iam_member" "online_compose_datastore_user" {
   count = var.provision_online_compose_host ? 1 : 0
 
   project = var.project_id
   role    = "roles/datastore.user"
   member  = "serviceAccount:${google_service_account.online_compose_runtime[0].email}"
+}
+
+resource "google_storage_bucket_iam_member" "online_compose_bucket_admin" {
+  count = var.provision_online_compose_host ? 1 : 0
+
+  bucket = google_storage_bucket.artifacts.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.online_compose_runtime[0].email}"
 }
 
 resource "google_bigquery_dataset_iam_member" "online_compose_bigquery_editor" {
@@ -469,6 +491,7 @@ resource "google_cloud_run_v2_service" "app" {
     google_artifact_registry_repository_iam_member.cloud_run_reader,
     google_storage_bucket_iam_member.cloud_run_bucket_reader,
     google_project_iam_member.cloud_run_bigquery_job_user,
+    google_project_iam_member.cloud_run_bigquery_read_session_user,
     google_project_iam_member.cloud_run_datastore_user,
     google_bigquery_dataset_iam_member.cloud_run_bigquery_reader,
   ]
@@ -558,7 +581,9 @@ resource "google_compute_instance" "online_compose" {
     google_firestore_database.feast_online_store,
     google_compute_firewall.online_compose_public,
     google_project_iam_member.online_compose_bigquery_job_user,
+    google_project_iam_member.online_compose_bigquery_read_session_user,
     google_project_iam_member.online_compose_datastore_user,
+    google_storage_bucket_iam_member.online_compose_bucket_admin,
     google_bigquery_dataset_iam_member.online_compose_bigquery_editor,
   ]
 }

--- a/terraform/templates/online-compose-host.sh.tftpl
+++ b/terraform/templates/online-compose-host.sh.tftpl
@@ -38,15 +38,15 @@ install -d -m 0775 /opt/foehncast/airflow /opt/foehncast/airflow/logs /opt/foehn
 install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast
 install -d -m 0755 /opt/foehncast/grafana_work/data
 
-chown -R ${airflow_uid}:0 /opt/foehncast/airflow
-chown -R ${app_uid}:${app_uid} /opt/foehncast/.state
-chown -R ${grafana_uid}:${grafana_uid} /opt/foehncast/grafana_work/data
+chown -R $${airflow_uid}:0 /opt/foehncast/airflow
+chown -R $${app_uid}:$${app_uid} /opt/foehncast/.state
+chown -R $${grafana_uid}:$${grafana_uid} /opt/foehncast/grafana_work/data
 
 if [[ ! -s /opt/foehncast/airflow/.admin-password ]]; then
   head -c 32 /dev/urandom | base64 | tr -d '\n' > /opt/foehncast/airflow/.admin-password
   printf '\n' >> /opt/foehncast/airflow/.admin-password
 fi
-chown ${airflow_uid}:0 /opt/foehncast/airflow/.admin-password
+chown $${airflow_uid}:0 /opt/foehncast/airflow/.admin-password
 chmod 600 /opt/foehncast/airflow/.admin-password
 
 cat > /opt/foehncast/.env <<'EOF'

--- a/terraform/templates/online-compose-host.sh.tftpl
+++ b/terraform/templates/online-compose-host.sh.tftpl
@@ -23,6 +23,10 @@ systemctl enable docker --now
 
 install -d -m 0755 /opt/foehncast
 
+airflow_uid=50000
+app_uid=1000
+grafana_uid=472
+
 if [[ ! -d /opt/foehncast/.git ]]; then
   git clone "https://github.com/${github_repository_path}.git" /opt/foehncast
 fi
@@ -30,12 +34,20 @@ fi
 git -C /opt/foehncast fetch --depth 1 origin "${git_ref}"
 git -C /opt/foehncast checkout --force FETCH_HEAD
 
-install -d -m 0700 /opt/foehncast/airflow
+install -d -m 0775 /opt/foehncast/airflow /opt/foehncast/airflow/logs /opt/foehncast/airflow/reports
+install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast
+install -d -m 0755 /opt/foehncast/grafana_work/data
+
+chown -R ${airflow_uid}:0 /opt/foehncast/airflow
+chown -R ${app_uid}:${app_uid} /opt/foehncast/.state
+chown -R ${grafana_uid}:${grafana_uid} /opt/foehncast/grafana_work/data
+
 if [[ ! -s /opt/foehncast/airflow/.admin-password ]]; then
   head -c 32 /dev/urandom | base64 | tr -d '\n' > /opt/foehncast/airflow/.admin-password
   printf '\n' >> /opt/foehncast/airflow/.admin-password
-  chmod 600 /opt/foehncast/airflow/.admin-password
 fi
+chown ${airflow_uid}:0 /opt/foehncast/airflow/.admin-password
+chmod 600 /opt/foehncast/airflow/.admin-password
 
 cat > /opt/foehncast/.env <<'EOF'
 %{ for key, value in stack_env ~}

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -83,12 +83,9 @@ REPO_BACKED_WORKFLOW_INPUTS = {
     "provision_cloud_run_service",
     "mlflow_tracking_uri",
     "cloud_run_service_name",
-    "cloud_run_container_port",
     "cloud_run_allow_unauthenticated",
     "cloud_run_min_instance_count",
     "cloud_run_max_instance_count",
-    "cloud_run_cpu",
-    "cloud_run_memory",
     "provision_online_compose_host",
     "online_compose_host_name",
     "online_compose_host_zone",
@@ -187,10 +184,15 @@ def test_remote_terraform_workflow_consumes_repo_backed_contract() -> None:
     assert "github.event_name == 'workflow_dispatch' ||" in remote_job["if"]
     assert "github.event_name == 'push'" in remote_job["if"]
     assert "environment" not in remote_job
+    assert len(inputs) <= 25
 
     for input_name in REPO_BACKED_WORKFLOW_INPUTS:
         assert input_name in inputs
         assert "default" not in inputs[input_name]
+
+    assert "cloud_run_container_port" not in inputs
+    assert "cloud_run_cpu" not in inputs
+    assert "cloud_run_memory" not in inputs
 
     assert inputs["provision_cloud_run_service"]["type"] == "string"
     assert inputs["provision_online_compose_host"]["type"] == "string"
@@ -212,10 +214,6 @@ def test_remote_terraform_workflow_consumes_repo_backed_contract() -> None:
     assert (
         'provision_online_compose_host="$(normalize_bool '
         'provision_online_compose_host "$provision_online_compose_host")"' in run_script
-    )
-    assert (
-        'cloud_run_container_port="${{ inputs.cloud_run_container_port }}"'
-        in run_script
     )
     assert 'cloud_run_container_port="$REPO_GCP_CLOUD_RUN_CONTAINER_PORT"' in run_script
     assert "cloud_run_container_port='8080'" in run_script
@@ -266,10 +264,8 @@ def test_remote_terraform_workflow_consumes_repo_backed_contract() -> None:
         'echo "cloud_run_max_instance_count must be greater than or equal to cloud_run_min_instance_count." >&2'
         in run_script
     )
-    assert 'cloud_run_cpu="${{ inputs.cloud_run_cpu }}"' in run_script
     assert 'cloud_run_cpu="$REPO_GCP_CLOUD_RUN_CPU"' in run_script
     assert "cloud_run_cpu='1'" in run_script
-    assert 'cloud_run_memory="${{ inputs.cloud_run_memory }}"' in run_script
     assert 'cloud_run_memory="$REPO_GCP_CLOUD_RUN_MEMORY"' in run_script
     assert "cloud_run_memory='512Mi'" in run_script
     assert (
@@ -437,6 +433,113 @@ def test_terraform_injects_feast_runtime_contract_into_both_hosted_targets() -> 
         assert key in online_compose_block.group("body")
 
 
+def test_terraform_grants_hosted_runtime_identities_bigquery_storage_and_bucket_access() -> (
+    None
+):
+    terraform = _read_text("terraform/main.tf")
+
+    assert (
+        'resource "google_project_iam_member" "cloud_run_bigquery_read_session_user"'
+        in terraform
+    )
+    assert (
+        'resource "google_project_iam_member" "online_compose_bigquery_read_session_user"'
+        in terraform
+    )
+    assert (
+        'resource "google_storage_bucket_iam_member" "online_compose_bucket_admin"'
+        in terraform
+    )
+    assert 'role    = "roles/bigquery.readSessionUser"' in terraform
+    assert 'role   = "roles/storage.objectAdmin"' in terraform
+    assert (
+        "google_project_iam_member.cloud_run_bigquery_read_session_user," in terraform
+    )
+    assert (
+        "google_project_iam_member.online_compose_bigquery_read_session_user,"
+        in terraform
+    )
+    assert "google_storage_bucket_iam_member.online_compose_bucket_admin," in terraform
+
+
+def test_online_compose_startup_template_prepares_writable_runtime_dirs() -> None:
+    template = _read_text("terraform/templates/online-compose-host.sh.tftpl")
+
+    assert "airflow_uid=50000" in template
+    assert "app_uid=1000" in template
+    assert "grafana_uid=472" in template
+    assert (
+        "install -d -m 0775 /opt/foehncast/airflow /opt/foehncast/airflow/logs /opt/foehncast/airflow/reports"
+        in template
+    )
+    assert (
+        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast"
+        in template
+    )
+    assert "install -d -m 0755 /opt/foehncast/grafana_work/data" in template
+    assert "chown -R ${airflow_uid}:0 /opt/foehncast/airflow" in template
+    assert "chown -R ${app_uid}:${app_uid} /opt/foehncast/.state" in template
+    assert (
+        "chown -R ${grafana_uid}:${grafana_uid} /opt/foehncast/grafana_work/data"
+        in template
+    )
+    assert "chown ${airflow_uid}:0 /opt/foehncast/airflow/.admin-password" in template
+
+
+def test_online_compose_startup_template_prepares_writable_runtime_directories() -> (
+    None
+):
+    template = _read_text("terraform/templates/online-compose-host.sh.tftpl")
+
+    assert "airflow_uid=50000" in template
+    assert "app_uid=1000" in template
+    assert "grafana_uid=472" in template
+    assert (
+        "install -d -m 0775 /opt/foehncast/airflow /opt/foehncast/airflow/logs /opt/foehncast/airflow/reports"
+        in template
+    )
+    assert (
+        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast"
+        in template
+    )
+    assert "install -d -m 0755 /opt/foehncast/grafana_work/data" in template
+    assert "chown -R ${airflow_uid}:0 /opt/foehncast/airflow" in template
+    assert "chown -R ${app_uid}:${app_uid} /opt/foehncast/.state" in template
+    assert (
+        "chown -R ${grafana_uid}:${grafana_uid} /opt/foehncast/grafana_work/data"
+        in template
+    )
+    assert "chown ${airflow_uid}:0 /opt/foehncast/airflow/.admin-password" in template
+    assert "chmod 600 /opt/foehncast/airflow/.admin-password" in template
+
+
+def test_terraform_runtime_iam_includes_bigquery_storage_api_and_bucket_access() -> (
+    None
+):
+    terraform = _read_text("terraform/main.tf")
+
+    assert (
+        'resource "google_project_iam_member" "cloud_run_bigquery_read_session_user"'
+        in terraform
+    )
+    assert 'role    = "roles/bigquery.readSessionUser"' in terraform
+    assert (
+        'resource "google_project_iam_member" "online_compose_bigquery_read_session_user"'
+        in terraform
+    )
+    assert (
+        'resource "google_storage_bucket_iam_member" "online_compose_bucket_admin"'
+        in terraform
+    )
+    assert 'role   = "roles/storage.objectAdmin"' in terraform
+    assert "google_project_iam_member.cloud_run_bigquery_read_session_user" in terraform
+    assert (
+        "google_project_iam_member.online_compose_bigquery_read_session_user"
+        in terraform
+    )
+    assert "google_storage_bucket_iam_member.online_compose_bucket_admin" in terraform
+
+
 def test_bootstrap_gcp_reports_hosted_feast_follow_up_step() -> None:
     bootstrap = _read_text("scripts/bootstrap-gcp.sh")
 
@@ -577,6 +680,11 @@ def test_terraform_remote_reports_hosted_feast_follow_up_for_apply() -> None:
     assert 'INPUT_BIGQUERY_FEATURE_TABLE_ID="$value"' in script
     assert "feast_online_store_database_name)" in script
     assert 'INPUT_FEAST_ONLINE_STORE_DATABASE_NAME="$value"' in script
+    assert "cloud_run_container_port|cloud_run_cpu|cloud_run_memory)" in script
+    assert (
+        'echo "${key} is not exposed as a workflow_dispatch input. Update the synced repository variable or Terraform configuration instead." >&2'
+        in script
+    )
     assert 'echo "Hosted Feast runtime source: bigquery"' in script
     assert (
         'echo "Hosted Feast offline source table: $(remote_feast_bigquery_table)"'

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -477,13 +477,13 @@ def test_online_compose_startup_template_prepares_writable_runtime_dirs() -> Non
         in template
     )
     assert "install -d -m 0755 /opt/foehncast/grafana_work/data" in template
-    assert "chown -R ${airflow_uid}:0 /opt/foehncast/airflow" in template
-    assert "chown -R ${app_uid}:${app_uid} /opt/foehncast/.state" in template
+    assert "chown -R $${airflow_uid}:0 /opt/foehncast/airflow" in template
+    assert "chown -R $${app_uid}:$${app_uid} /opt/foehncast/.state" in template
     assert (
-        "chown -R ${grafana_uid}:${grafana_uid} /opt/foehncast/grafana_work/data"
+        "chown -R $${grafana_uid}:$${grafana_uid} /opt/foehncast/grafana_work/data"
         in template
     )
-    assert "chown ${airflow_uid}:0 /opt/foehncast/airflow/.admin-password" in template
+    assert "chown $${airflow_uid}:0 /opt/foehncast/airflow/.admin-password" in template
 
 
 def test_online_compose_startup_template_prepares_writable_runtime_directories() -> (
@@ -503,13 +503,13 @@ def test_online_compose_startup_template_prepares_writable_runtime_directories()
         in template
     )
     assert "install -d -m 0755 /opt/foehncast/grafana_work/data" in template
-    assert "chown -R ${airflow_uid}:0 /opt/foehncast/airflow" in template
-    assert "chown -R ${app_uid}:${app_uid} /opt/foehncast/.state" in template
+    assert "chown -R $${airflow_uid}:0 /opt/foehncast/airflow" in template
+    assert "chown -R $${app_uid}:$${app_uid} /opt/foehncast/.state" in template
     assert (
-        "chown -R ${grafana_uid}:${grafana_uid} /opt/foehncast/grafana_work/data"
+        "chown -R $${grafana_uid}:$${grafana_uid} /opt/foehncast/grafana_work/data"
         in template
     )
-    assert "chown ${airflow_uid}:0 /opt/foehncast/airflow/.admin-password" in template
+    assert "chown $${airflow_uid}:0 /opt/foehncast/airflow/.admin-password" in template
     assert "chmod 600 /opt/foehncast/airflow/.admin-password" in template
 
 


### PR DESCRIPTION
- What changed: repaired the remote Terraform workflow contract, added the hosted-runtime IAM and writable-state fixes, and aligned the public docs with the active shared hosted topology.
- Why: the shared deployment path had drifted between GitHub automation, Terraform, and the actual hosted runtime, which blocked reliable cloud bring-up.
- Verification: `uv run pytest tests/test_cloud_operator_contract.py -q`, `actionlint .github/workflows/terraform.yml .github/workflows/publish-app-image.yml`, `uv run mkdocs build -f docs/mkdocs.yml --strict`, and the hosted app health check.
- Closes: #107