### PR TITLE
fix(terraform): grant deployer datastore admin

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -315,6 +315,7 @@ resource "google_project_iam_member" "github_project_admin" {
     "roles/artifactregistry.admin",
     "roles/bigquery.admin",
     "roles/compute.admin",
+    "roles/datastore.owner",
     "roles/iam.serviceAccountAdmin",
     "roles/iam.workloadIdentityPoolAdmin",
     "roles/resourcemanager.projectIamAdmin",

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -531,6 +531,13 @@ def test_terraform_runtime_iam_includes_bigquery_storage_api_and_bucket_access()
         'resource "google_storage_bucket_iam_member" "online_compose_bucket_admin"'
         in terraform
     )
+
+
+def test_terraform_grants_github_deployer_firestore_admin() -> None:
+    terraform = _read_text("terraform/main.tf")
+
+    assert 'resource "google_project_iam_member" "github_project_admin"' in terraform
+    assert '"roles/datastore.owner"' in terraform
     assert 'role   = "roles/storage.objectAdmin"' in terraform
     assert "google_project_iam_member.cloud_run_bigquery_read_session_user" in terraform
     assert (


### PR DESCRIPTION
- What changed: added the datastore admin role to the GitHub deployer Terraform admin set and covered it with a regression test.
- Why: the merged remote Terraform workflow still depended on a manual IAM grant to read the managed Feast online-store database.
- Verification: `uv run pytest tests/test_cloud_operator_contract.py -q` and `terraform -chdir=terraform init -backend=false -lockfile=readonly && terraform -chdir=terraform validate`.
- Closes: #109