### PR TITLE
fix(ci): tolerate repo variable sync limits

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -147,8 +147,6 @@ jobs:
       contents: read
       actions: write
       id-token: write
-    env:
-      GH_TOKEN: ${{ github.token }}
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -628,13 +626,30 @@ jobs:
 
       - name: Remote cleanup clear repository variables
         if: ${{ steps.flags.outputs.bootstrap_ready == 'true' && steps.flags.outputs.command == 'cleanup' && inputs.cleanup_clear_github_actions == true }}
+        env:
+          GH_TOKEN: ${{ github.token }}
         run:
           ./scripts/configure-github-actions.sh --clear --repo "${{ github.repository
           }}"
 
       - name: Sync repository variables
+        id: sync_repository_variables
         if: ${{ steps.flags.outputs.bootstrap_ready == 'true' && steps.flags.outputs.command == 'apply' }}
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: ./scripts/configure-github-actions.sh --repo "${{ github.repository }}"
+
+      - name: Explain skipped repository variable sync
+        if: ${{ steps.flags.outputs.bootstrap_ready == 'true' && steps.flags.outputs.command == 'apply' && steps.sync_repository_variables.outcome == 'failure' }}
+        run: |
+          {
+            echo "## Repository variable sync skipped"
+            echo
+            echo "Terraform apply succeeded, but the workflow token could not edit GitHub repository variables through the Actions variables API."
+            echo "Existing repository variables remain unchanged."
+            echo "If the shared contract needs a refresh, run ./scripts/configure-github-actions.sh from a maintainer shell authenticated with gh."
+          } >> "$GITHUB_STEP_SUMMARY"
 
       - name: Summarize outputs
         if: ${{ steps.flags.outputs.bootstrap_ready == 'true' && steps.flags.outputs.command == 'apply' }}

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -168,9 +168,9 @@ The normal shared-environment path is:
 
 1. one-time maintainer bootstrap from Google Cloud Shell
 2. GitHub Actions remote apply
-3. automatic repository-variable resync after each successful apply
+3. best-effort repository-variable resync after each successful apply
 
-In normal operation you should not edit these variables by hand. The bootstrap path and each successful remote apply keep the shared contract synchronized automatically.
+In normal operation you should not edit these variables by hand. The bootstrap path seeds the shared contract automatically. Remote applies also attempt to resync it, but GitHub's default workflow token may not be allowed to edit repository variables in every repository configuration.
 
 `GCP_CLOUD_RUN_SERVICE` stays unset until Terraform has actually provisioned the Cloud Run service. After that, publish automation can update the service with newly built images.
 
@@ -178,7 +178,7 @@ When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow
 
 ## GitHub Actions Terraform Path
 
-Use `.github/workflows/terraform.yml` to run validate, plan, apply, destroy, or cleanup from GitHub Actions without requiring local Terraform. After the one-time bootstrap has established OIDC and the remote backend, pushes to `main` automatically run the shared remote apply path for Terraform-managed cloud changes. Successful applies resync the repository variables automatically.
+Use `.github/workflows/terraform.yml` to run validate, plan, apply, destroy, or cleanup from GitHub Actions without requiring local Terraform. After the one-time bootstrap has established OIDC and the remote backend, pushes to `main` automatically run the shared remote apply path for Terraform-managed cloud changes. Successful applies also attempt to resync the repository variables, but a repository-variable permission limit should not mark the apply itself as failed.
 
 Manual workflow dispatch is still available for plan, destroy, cleanup, and explicit overrides. `./scripts/terraform-remote.sh` remains optional maintainer convenience for people who already use `gh`, but the GitHub Actions workflow is the primary operator surface.
 
@@ -190,6 +190,8 @@ For `command=cleanup`, the workflow skips Terraform execution entirely. Instead 
 
 - `cleanup_delete_state_bucket=true` deletes the remote Terraform state bucket if it still exists
 - `cleanup_clear_github_actions=true` clears the synced GitHub Actions repository variables on the target repository
+
+GitHub can reject repository-variable edits from the default workflow token with `Resource not accessible by integration`. When that happens during the automatic apply path, Terraform still applies successfully and the workflow records that the repository-variable sync was skipped. If you need to refresh or clear the variable contract explicitly, run `./scripts/configure-github-actions.sh` from a maintainer shell authenticated with `gh`.
 
 The recommended remote retirement sequence is:
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -332,6 +332,39 @@ def test_remote_terraform_workflow_auto_applies_on_push_when_bootstrapped() -> N
     assert "github.event_name == 'push'" in skipped_step["if"]
 
 
+def test_remote_terraform_workflow_treats_repo_variable_sync_as_best_effort() -> None:
+    workflow = _workflow_yaml(".github/workflows/terraform.yml")
+    remote_job = workflow["jobs"]["remote"]
+
+    assert "env" not in remote_job or "GH_TOKEN" not in remote_job.get("env", {})
+
+    skipped_sync_step = _workflow_step(
+        workflow, "remote", "Explain skipped repository variable sync"
+    )
+    assert "steps.flags.outputs.command == 'apply'" in skipped_sync_step["if"]
+    assert (
+        "steps.sync_repository_variables.outcome == 'failure'"
+        in skipped_sync_step["if"]
+    )
+    assert (
+        "workflow token could not edit GitHub repository variables"
+        in skipped_sync_step["run"]
+    )
+    assert "Existing repository variables remain unchanged." in skipped_sync_step["run"]
+    assert "./scripts/configure-github-actions.sh" in skipped_sync_step["run"]
+
+    cleanup_step = _workflow_step(
+        workflow, "remote", "Remote cleanup clear repository variables"
+    )
+    assert cleanup_step["env"]["GH_TOKEN"] == "${{ github.token }}"
+
+    sync_step = _workflow_step(workflow, "remote", "Sync repository variables")
+    assert sync_step["id"] == "sync_repository_variables"
+    assert sync_step["continue-on-error"] is True
+    assert sync_step["env"]["GH_TOKEN"] == "${{ github.token }}"
+    assert "steps.flags.outputs.command == 'apply'" in sync_step["if"]
+
+
 def test_remote_terraform_workflow_apply_summary_reports_hosted_feast_follow_up() -> (
     None
 ):


### PR DESCRIPTION
## Summary
- make Terraform apply keep succeeding when GitHub blocks repository-variable edits with the default workflow token
- summarize skipped variable syncs and document the maintainer follow-up path
- cover the best-effort sync behavior with a workflow contract regression

## Validation
- uv run pytest tests/test_cloud_operator_contract.py -q
- actionlint .github/workflows/terraform.yml
- curl --noproxy '*' http://34.65.98.119:8000/health

Closes #112
