### PR TITLE
feature(features): add circular wind-direction features

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,21 +6,23 @@ rider:
   home_lat: 47.02
   home_lon: 8.65
   home_location: "Schwyz"
-  quiver_m2: [ 5, 7, 8, 10, 12 ]
+  quiver_m2: [5, 7, 8, 10, 12]
 
 # Weather API settings
 api:
   open_meteo:
     forecast_url: "https://api.open-meteo.com/v1/forecast"
     archive_url: "https://archive-api.open-meteo.com/v1/archive"
-    hourly_params: "wind_speed_10m,wind_speed_80m,wind_speed_120m,wind_direction_10\
+    hourly_params:
+      "wind_speed_10m,wind_speed_80m,wind_speed_120m,wind_direction_10\
       m,wind_direction_80m,wind_gusts_10m,temperature_2m,precipitation,relative\
       _humidity_2m,cloud_cover,pressure_msl,cape,lifted_index"
     forecast_days: 7
     timezone: "Europe/Zurich"
     wind_speed_unit: "kmh"
   meteoswiss:
-    stations_url: "https://data.geo.admin.ch/ch.meteoschweiz.messwerte-windgeschwin\
+    stations_url:
+      "https://data.geo.admin.ch/ch.meteoschweiz.messwerte-windgeschwin\
       digkeit-kmh-10min/ch.meteoschweiz.messwerte-windgeschwindigkeit-kmh-10min\
       _en.json"
   osrm:
@@ -129,6 +131,8 @@ validation:
     - hour_of_day_cos
     - day_of_year_sin
     - day_of_year_cos
+    - wind_direction_10m_sin
+    - wind_direction_10m_cos
     - wind_steadiness
     - gust_factor
     - shore_alignment
@@ -171,6 +175,12 @@ validation:
     day_of_year_cos:
       min: -1
       max: 1
+    wind_direction_10m_sin:
+      min: -1
+      max: 1
+    wind_direction_10m_cos:
+      min: -1
+      max: 1
     wind_steadiness:
       min: 0
     gust_factor:
@@ -202,6 +212,8 @@ model:
     - hour_of_day_cos
     - day_of_year_sin
     - day_of_year_cos
+    - wind_direction_10m_sin
+    - wind_direction_10m_cos
     - wind_steadiness
     - gust_factor
     - shore_alignment
@@ -209,7 +221,6 @@ model:
   features:
     - wind_speed_10m
     - wind_speed_80m
-    - wind_direction_10m
     - wind_gusts_10m
     - temperature_2m
     - relative_humidity_2m
@@ -217,6 +228,8 @@ model:
     - hour_of_day_cos
     - day_of_year_sin
     - day_of_year_cos
+    - wind_direction_10m_sin
+    - wind_direction_10m_cos
     - wind_steadiness
     - gust_factor
     - shore_alignment

--- a/feature_repo/features.py
+++ b/feature_repo/features.py
@@ -63,6 +63,8 @@ spot_forecast_features = FeatureView(
         Field(name="hour_of_day_cos", dtype=Float64),
         Field(name="day_of_year_sin", dtype=Float64),
         Field(name="day_of_year_cos", dtype=Float64),
+        Field(name="wind_direction_10m_sin", dtype=Float64),
+        Field(name="wind_direction_10m_cos", dtype=Float64),
         Field(name="wind_steadiness", dtype=Float64),
         Field(name="gust_factor", dtype=Float64),
         Field(name="shore_alignment", dtype=Float64),

--- a/src/foehncast/feature_pipeline/engineer.py
+++ b/src/foehncast/feature_pipeline/engineer.py
@@ -62,6 +62,26 @@ def add_time_features(df: pd.DataFrame) -> pd.DataFrame:
     return out
 
 
+def wind_direction_10m_sin(df: pd.DataFrame) -> pd.Series:
+    """Cyclical sine encoding of 10m wind direction in degrees."""
+    values = np.sin(np.radians(df["wind_direction_10m"]))
+    return pd.Series(values, index=df.index, name="wind_direction_10m_sin")
+
+
+def wind_direction_10m_cos(df: pd.DataFrame) -> pd.Series:
+    """Cyclical cosine encoding of 10m wind direction in degrees."""
+    values = np.cos(np.radians(df["wind_direction_10m"]))
+    return pd.Series(values, index=df.index, name="wind_direction_10m_cos")
+
+
+def add_direction_features(df: pd.DataFrame) -> pd.DataFrame:
+    """Add cyclical encodings for raw direction features used by the model."""
+    out = df.copy()
+    out["wind_direction_10m_sin"] = wind_direction_10m_sin(df)
+    out["wind_direction_10m_cos"] = wind_direction_10m_cos(df)
+    return out
+
+
 def wind_steadiness(df: pd.DataFrame, window: int = 3) -> pd.Series:
     """Coefficient of variation of 10m wind over a rolling window.
 
@@ -122,9 +142,9 @@ def engineer_features(df: pd.DataFrame, shore_orientation_deg: float) -> pd.Data
 
     Returns:
         DataFrame with added columns for cyclical time, wind steadiness,
-        gust factor, and shore alignment.
+        wind direction, gust factor, and shore alignment.
     """
-    out = add_time_features(df)
+    out = add_direction_features(add_time_features(df))
     out["wind_steadiness"] = wind_steadiness(df)
     out["gust_factor"] = gust_factor(df)
     out["shore_alignment"] = shore_alignment(df, shore_orientation_deg)

--- a/src/foehncast/training_pipeline/train.py
+++ b/src/foehncast/training_pipeline/train.py
@@ -20,7 +20,10 @@ from foehncast.config import (
     get_rider_config,
     get_spots,
 )
-from foehncast.feature_pipeline.engineer import add_time_features
+from foehncast.feature_pipeline.engineer import (
+    add_direction_features,
+    add_time_features,
+)
 from foehncast.feature_pipeline.store import read_features
 from foehncast.training_pipeline.evaluate import compute_metrics
 from foehncast.training_pipeline.label import label_dataset
@@ -42,9 +45,9 @@ def load_training_data(dataset: str = "train") -> tuple[pd.DataFrame, pd.Series]
         if features_df.empty:
             continue
 
-        # Rebuild time features here so training still works with older stored
-        # datasets after the feature schema grows.
-        features_df = add_time_features(features_df)
+        # Rebuild schema-derived features here so training still works with
+        # older stored datasets after the feature schema grows.
+        features_df = add_direction_features(add_time_features(features_df))
         labeled_frames.append(label_dataset(features_df, rider_config))
 
     if not labeled_frames:

--- a/tests/test_engineer.py
+++ b/tests/test_engineer.py
@@ -7,6 +7,8 @@ from foehncast.feature_pipeline.engineer import (
     engineer_features,
     gust_factor,
     shore_alignment,
+    wind_direction_10m_cos,
+    wind_direction_10m_sin,
     wind_steadiness,
 )
 
@@ -74,6 +76,25 @@ class TestShoreAlignment:
         assert result.iloc[0] == pytest.approx(0.0, abs=1e-10)
 
 
+class TestWindDirectionEncoding:
+    def test_sine_encoding_wraps_zero_and_full_circle(self):
+        df = pd.DataFrame({"wind_direction_10m": [0.0, 360.0]})
+
+        result = wind_direction_10m_sin(df)
+
+        assert result.iloc[0] == pytest.approx(0.0, abs=1e-10)
+        assert result.iloc[1] == pytest.approx(0.0, abs=1e-10)
+
+    def test_cosine_encoding_matches_quadrants(self):
+        df = pd.DataFrame({"wind_direction_10m": [0.0, 90.0, 180.0]})
+
+        sine_result = wind_direction_10m_sin(df)
+        cosine_result = wind_direction_10m_cos(df)
+
+        assert sine_result.tolist() == pytest.approx([0.0, 1.0, 0.0], abs=1e-10)
+        assert cosine_result.tolist() == pytest.approx([1.0, 0.0, -1.0], abs=1e-10)
+
+
 class TestEngineerFeatures:
     def test_adds_all_columns(self, sample_df):
         result = engineer_features(sample_df, shore_orientation_deg=225.0)
@@ -81,6 +102,8 @@ class TestEngineerFeatures:
         assert "hour_of_day_cos" in result.columns
         assert "day_of_year_sin" in result.columns
         assert "day_of_year_cos" in result.columns
+        assert "wind_direction_10m_sin" in result.columns
+        assert "wind_direction_10m_cos" in result.columns
         assert "wind_steadiness" in result.columns
         assert "gust_factor" in result.columns
         assert "shore_alignment" in result.columns
@@ -92,6 +115,8 @@ class TestEngineerFeatures:
         assert result.iloc[0]["hour_of_day_cos"] == pytest.approx(1.0)
         assert result.iloc[0]["day_of_year_sin"] == pytest.approx(0.0)
         assert result.iloc[0]["day_of_year_cos"] == pytest.approx(1.0)
+        assert result.iloc[0]["wind_direction_10m_sin"] == pytest.approx(0.0)
+        assert result.iloc[0]["wind_direction_10m_cos"] == pytest.approx(-1.0)
 
     def test_preserves_original_columns(self, sample_df):
         result = engineer_features(sample_df, shore_orientation_deg=225.0)

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -21,11 +21,12 @@ def model_config() -> dict[str, object]:
         "features": [
             "wind_speed_10m",
             "wind_gusts_10m",
-            "wind_direction_10m",
             "hour_of_day_sin",
             "hour_of_day_cos",
             "day_of_year_sin",
             "day_of_year_cos",
+            "wind_direction_10m_sin",
+            "wind_direction_10m_cos",
             "wind_steadiness",
             "gust_factor",
             "shore_alignment",

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -15,7 +15,6 @@ def feature_columns() -> list[str]:
     return [
         "wind_speed_10m",
         "wind_speed_80m",
-        "wind_direction_10m",
         "wind_gusts_10m",
         "temperature_2m",
         "relative_humidity_2m",
@@ -23,6 +22,8 @@ def feature_columns() -> list[str]:
         "hour_of_day_cos",
         "day_of_year_sin",
         "day_of_year_cos",
+        "wind_direction_10m_sin",
+        "wind_direction_10m_cos",
         "wind_steadiness",
         "gust_factor",
         "shore_alignment",
@@ -54,12 +55,14 @@ def labeled_training_df(feature_columns: list[str]) -> pd.DataFrame:
         "hour_of_day_cos": [1.0, 0.9659258263, 0.8660254038],
         "day_of_year_sin": [0.0, 0.0, 0.0],
         "day_of_year_cos": [1.0, 1.0, 1.0],
+        "wind_direction_10m_sin": [-0.5, -0.6427876097, -0.7660444431],
+        "wind_direction_10m_cos": [-0.8660254038, -0.7660444431, -0.6427876097],
         "wind_steadiness": [0.12, 0.15, 0.10],
         "gust_factor": [1.2, 1.15, 1.1],
         "shore_alignment": [0.7, 0.8, 0.9],
         "quality_index": [2, 3, 4],
     }
-    return pd.DataFrame(base_data, index=index)[[*feature_columns, "quality_index"]]
+    return pd.DataFrame(base_data, index=index)
 
 
 def test_load_training_data_concatenates_spot_frames(
@@ -106,6 +109,8 @@ def test_load_training_data_adds_time_features_before_labeling(
             "hour_of_day_cos",
             "day_of_year_sin",
             "day_of_year_cos",
+            "wind_direction_10m_sin",
+            "wind_direction_10m_cos",
         ]
     )
 
@@ -132,6 +137,8 @@ def test_load_training_data_adds_time_features_before_labeling(
     assert "hour_of_day_cos" in logged["columns_before_labeling"]
     assert "day_of_year_sin" in logged["columns_before_labeling"]
     assert "day_of_year_cos" in logged["columns_before_labeling"]
+    assert "wind_direction_10m_sin" in logged["columns_before_labeling"]
+    assert "wind_direction_10m_cos" in logged["columns_before_labeling"]
     assert list(features_df.columns) == model_config["features"]
 
 

--- a/tests/test_validate.py
+++ b/tests/test_validate.py
@@ -40,6 +40,8 @@ def _sample_curated_features() -> pd.DataFrame:
     df["hour_of_day_cos"] = [1.0, 0.965926]
     df["day_of_year_sin"] = [0.845249, 0.845249]
     df["day_of_year_cos"] = [-0.534373, -0.534373]
+    df["wind_direction_10m_sin"] = [-0.642788, -0.819152]
+    df["wind_direction_10m_cos"] = [-0.766044, -0.573576]
     df["wind_steadiness"] = [0.0, 0.052632]
     df["gust_factor"] = [1.50, 1.33]
     df["shore_alignment"] = [0.85, 0.88]
@@ -99,6 +101,8 @@ def test_run_validation_returns_valid_result_for_clean_dataset(monkeypatch) -> N
                 "hour_of_day_cos": {"min": -1, "max": 1},
                 "day_of_year_sin": {"min": -1, "max": 1},
                 "day_of_year_cos": {"min": -1, "max": 1},
+                "wind_direction_10m_sin": {"min": -1, "max": 1},
+                "wind_direction_10m_cos": {"min": -1, "max": 1},
                 "wind_steadiness": {"min": 0},
                 "gust_factor": {"min": 0},
                 "shore_alignment": {"min": -1, "max": 1},
@@ -120,6 +124,7 @@ def test_run_validation_collects_missing_columns_and_range_violations(
 ) -> None:
     df = _sample_curated_features().drop(columns=["shore_alignment"])
     df.loc["row-2", "hour_of_day_sin"] = 1.2
+    df.loc["row-1", "wind_direction_10m_cos"] = 1.5
     monkeypatch.setattr(
         "foehncast.feature_pipeline.validate.get_validation_config",
         lambda: {
@@ -127,6 +132,7 @@ def test_run_validation_collects_missing_columns_and_range_violations(
             "completeness": {"max_null_pct": 0.1},
             "ranges": {
                 "hour_of_day_sin": {"min": -1, "max": 1},
+                "wind_direction_10m_cos": {"min": -1, "max": 1},
                 "shore_alignment": {"min": -1, "max": 1},
             },
         },
@@ -139,4 +145,7 @@ def test_run_validation_collects_missing_columns_and_range_violations(
     assert result.completeness_valid
     assert not result.range_valid
     assert result.missing_columns == ["shore_alignment"]
-    assert list(result.range_violations["column"]) == ["hour_of_day_sin"]
+    assert list(result.range_violations["column"]) == [
+        "hour_of_day_sin",
+        "wind_direction_10m_cos",
+    ]


### PR DESCRIPTION
## Summary
- add circular sine and cosine features for 10m wind direction in the feature pipeline
- switch the model-facing schema from raw `wind_direction_10m` to the new circular representation while keeping raw direction in curated data
- update Feast schema and tests so training, prediction, and validation all expect the same direction feature set

## Validation
- uv run pytest tests/test_engineer.py tests/test_train.py tests/test_predict.py tests/test_validate.py tests/test_online_features.py tests/test_feast_export.py tests/test_orchestration.py -q
- uv run pytest tests/test_config.py -q

Closes #63
