### PR TITLE
feature(automation): add Airflow auto retraining trigger

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,6 +47,9 @@ AIRFLOW__API_AUTH__JWT_SECRET=foehncast-local-jwt-secret
 # Leave AIRFLOW_FEATURE_SCHEDULE empty, manual, or off to disable recurring refreshes.
 AIRFLOW_FEATURE_DATASET=train
 AIRFLOW_FEATURE_SCHEDULE="0 */6 * * *"
+# Auto retraining mode after a successful feature refresh: always | drift | off
+AIRFLOW_AUTO_RETRAIN_MODE=always
+AIRFLOW_TRAINING_DATASET=train
 
 # App
 APP_BIND_HOST=127.0.0.1

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This is the default path for a fresh machine.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 The local bootstrap uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, prepares Feast against the bundled Datastore-mode emulator, and confirms Grafana loaded the checked-in dashboard plus alerting resources before declaring the stack ready. If the preferred host ports are already busy, the helper moves the local bindings to the next free ports and prints the resolved endpoints.
-On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically; the `training_pipeline` DAG remains manual.
+On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically, and it can continue into train, evaluate, and register steps through the same Airflow loop. The standalone `training_pipeline` DAG remains manual for ad hoc reruns.
 The optional `development_env` notebook container stays out of the default runtime path and starts only when you explicitly target the notebook or dev-shell Makefile commands.
 
 After bootstrap completes, the main local endpoints are:

--- a/dags/feature_dag.py
+++ b/dags/feature_dag.py
@@ -6,33 +6,85 @@ from datetime import datetime
 import os
 
 try:
-    from airflow.providers.standard.operators.python import PythonOperator
+    from airflow.providers.standard.operators.python import (
+        PythonOperator,
+        ShortCircuitOperator,
+    )
     from airflow.sdk import DAG
 except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
     dag = None
 else:
     from foehncast.orchestration import (
+        evaluate_training_run,
+        register_training_run,
+        resolve_auto_retraining_mode,
         resolve_airflow_schedule,
-        run_feature_pipeline_job,
+        run_feature_pipeline_job_context,
+        should_auto_retrain,
     )
+    from foehncast.training_pipeline.train import run_training_pipeline
 
     feature_dataset = os.getenv("AIRFLOW_FEATURE_DATASET", "train").strip() or "train"
     feature_schedule = resolve_airflow_schedule(
         os.getenv("AIRFLOW_FEATURE_SCHEDULE"),
         default="0 */6 * * *",
     )
+    auto_retrain_mode = resolve_auto_retraining_mode(
+        os.getenv("AIRFLOW_AUTO_RETRAIN_MODE"),
+        default="always",
+    )
 
     with DAG(
         dag_id="feature_pipeline",
-        description="Fetch forecasts, engineer features, validate them, and store them.",
+        description=(
+            "Fetch forecasts, engineer features, validate and store them, "
+            "and optionally continue into retraining."
+        ),
         start_date=datetime(2024, 1, 1),
         schedule=feature_schedule,
         catchup=False,
         is_paused_upon_creation=False,
         tags=["foehncast", "feature"],
     ) as dag:
-        PythonOperator(
+        run_feature_refresh = PythonOperator(
             task_id="run_feature_pipeline",
-            python_callable=run_feature_pipeline_job,
+            python_callable=run_feature_pipeline_job_context,
             op_kwargs={"dataset": feature_dataset},
         )
+
+        if auto_retrain_mode is not None:
+            retraining_gate = ShortCircuitOperator(
+                task_id="check_retraining_trigger",
+                python_callable=should_auto_retrain,
+                op_kwargs={
+                    "feature_result": run_feature_refresh.output,
+                    "mode": auto_retrain_mode,
+                },
+            )
+
+            train_model = PythonOperator(
+                task_id="train_model",
+                python_callable=run_training_pipeline,
+                op_kwargs={"dataset": feature_dataset},
+            )
+
+            evaluate_model_task = PythonOperator(
+                task_id="evaluate_model",
+                python_callable=evaluate_training_run,
+                op_args=[train_model.output],
+                op_kwargs={"dataset": feature_dataset},
+            )
+
+            register_model_task = PythonOperator(
+                task_id="register_model",
+                python_callable=register_training_run,
+                op_args=[train_model.output],
+            )
+
+            (
+                run_feature_refresh
+                >> retraining_gate
+                >> train_model
+                >> evaluate_model_task
+                >> register_model_task
+            )

--- a/dags/training_dag.py
+++ b/dags/training_dag.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from datetime import datetime
+import os
 
 try:
     from airflow.providers.standard.operators.python import PythonOperator
@@ -12,6 +13,8 @@ except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
 else:
     from foehncast.orchestration import evaluate_training_run, register_training_run
     from foehncast.training_pipeline.train import run_training_pipeline
+
+    training_dataset = os.getenv("AIRFLOW_TRAINING_DATASET", "train").strip() or "train"
 
     with DAG(
         dag_id="training_pipeline",
@@ -25,12 +28,14 @@ else:
         train_model = PythonOperator(
             task_id="train_model",
             python_callable=run_training_pipeline,
+            op_kwargs={"dataset": training_dataset},
         )
 
         evaluate_model_task = PythonOperator(
             task_id="evaluate_model",
             python_callable=evaluate_training_run,
             op_args=[train_model.output],
+            op_kwargs={"dataset": training_dataset},
         )
 
         register_model_task = PythonOperator(

--- a/src/foehncast/orchestration.py
+++ b/src/foehncast/orchestration.py
@@ -65,9 +65,9 @@ def _emit_feature_drift_metrics(
     dataset: str,
     reference_df: pd.DataFrame,
     current_df: pd.DataFrame,
-) -> None:
+) -> bool:
     if reference_df.empty or current_df.empty:
-        return
+        return False
 
     try:
         report = detect_data_drift(
@@ -75,12 +75,14 @@ def _emit_feature_drift_metrics(
             _feature_drift_frame(current_df, spot_id=spot_id, dataset=dataset),
         )
         push_drift_metrics(report)
+        return report.dataset_drift
     except Exception:
         logger.exception(
             "Failed to emit feature drift metrics for spot '%s' in dataset '%s'",
             spot_id,
             dataset,
         )
+        return False
 
 
 def resolve_airflow_schedule(
@@ -101,11 +103,55 @@ def resolve_airflow_schedule(
     return normalized
 
 
-def run_feature_pipeline(dataset: str = "train") -> list[str]:
-    """Fetch, engineer, validate, store, and monitor features for all spots."""
+def resolve_auto_retraining_mode(
+    mode: str | None, *, default: str | None = "always"
+) -> str | None:
+    """Normalize Airflow auto-retraining mode values."""
+    candidate = default if mode is None else mode
+    if candidate is None:
+        return None
+
+    normalized = candidate.strip().lower()
+    if not normalized or normalized in {"none", "off", "false", "manual"}:
+        return None
+
+    if normalized in {"always", "new-data", "new_data", "on-success", "on_success"}:
+        return "always"
+
+    if normalized in {"drift", "drift-only", "drift_only"}:
+        return "drift"
+
+    raise ValueError(
+        "Unsupported auto retraining mode. Use 'always', 'drift', or 'off'."
+    )
+
+
+def should_auto_retrain(
+    feature_result: dict[str, object], mode: str | None = "always"
+) -> bool:
+    """Return whether the Airflow feature refresh should continue into retraining."""
+    resolved_mode = resolve_auto_retraining_mode(mode, default="always")
+    if resolved_mode is None:
+        return False
+
+    stored_spots = [
+        str(spot_id).strip()
+        for spot_id in feature_result.get("stored_spots", [])
+        if str(spot_id).strip()
+    ]
+    if resolved_mode == "always":
+        return bool(stored_spots)
+
+    return bool(feature_result.get("dataset_drift_detected", False))
+
+
+def _run_feature_pipeline_result(dataset: str = "train") -> dict[str, object]:
+    """Run the feature pipeline and return stored spots plus retraining context."""
+    storage_backend = get_storage_config()["backend"]
     spots = get_spots()
     forecasts_by_spot: dict[str, pd.DataFrame] = {}
     stored_spots: list[str] = []
+    drifted_spots: list[str] = []
     spot_summaries: list[dict[str, object]] = []
     run_error: str | None = None
 
@@ -141,12 +187,13 @@ def run_feature_pipeline(dataset: str = "train") -> list[str]:
 
                 write_features(feature_df, spot_id=spot_id, dataset=dataset)
                 stored_df = read_features(spot_id=spot_id, dataset=dataset)
-                _emit_feature_drift_metrics(
+                if _emit_feature_drift_metrics(
                     spot_id=spot_id,
                     dataset=dataset,
                     reference_df=previous_stored_df,
                     current_df=stored_df,
-                )
+                ):
+                    drifted_spots.append(spot_id)
             except Exception as exc:
                 spot_summaries.append(
                     build_feature_pipeline_spot_summary(
@@ -176,7 +223,13 @@ def run_feature_pipeline(dataset: str = "train") -> list[str]:
         if not stored_spots:
             raise ValueError("No feature data was generated for any configured spot")
 
-        return stored_spots
+        return {
+            "dataset": dataset,
+            "storage_backend": storage_backend,
+            "stored_spots": stored_spots,
+            "drifted_spots": drifted_spots,
+            "dataset_drift_detected": bool(drifted_spots),
+        }
     except Exception as exc:
         run_error = str(exc)
         raise
@@ -188,7 +241,7 @@ def run_feature_pipeline(dataset: str = "train") -> list[str]:
         ]
         summary = build_feature_pipeline_run_summary(
             dataset=dataset,
-            storage_backend=get_storage_config()["backend"],
+            storage_backend=storage_backend,
             expected_spots=[spot["id"] for spot in spots],
             fetched_spots=fetched_spots,
             stored_spots=stored_spots,
@@ -200,6 +253,11 @@ def run_feature_pipeline(dataset: str = "train") -> list[str]:
             emit_feature_pipeline_run_summary(summary)
         except Exception:
             logger.exception("Failed to emit feature pipeline run summary")
+
+
+def run_feature_pipeline(dataset: str = "train") -> list[str]:
+    """Fetch, engineer, validate, store, and monitor features for all spots."""
+    return list(_run_feature_pipeline_result(dataset=dataset)["stored_spots"])
 
 
 def _scheduled_mlflow_tracking_uri() -> str | None:
@@ -227,6 +285,33 @@ def run_feature_pipeline_job(dataset: str = "train") -> list[str]:
         )
         mlflow.log_metric("stored_spot_count", len(stored_spots))
         return stored_spots
+
+
+def run_feature_pipeline_job_context(dataset: str = "train") -> dict[str, object]:
+    """Run the feature pipeline and return Airflow-friendly retraining context."""
+    result = _run_feature_pipeline_result(dataset=dataset)
+    tracking_uri = _scheduled_mlflow_tracking_uri()
+    if tracking_uri is None:
+        return result
+
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment(get_mlflow_config()["experiment_name"])
+
+    with mlflow.start_run(run_name=f"feature-{dataset}-refresh"):
+        mlflow.log_params(
+            {
+                "dataset": dataset,
+                "storage_backend": result["storage_backend"],
+                "stored_spots": ",".join(result["stored_spots"]),
+                "drifted_spots": ",".join(result["drifted_spots"]),
+            }
+        )
+        mlflow.log_metric("stored_spot_count", len(result["stored_spots"]))
+        mlflow.log_metric("drifted_spot_count", len(result["drifted_spots"]))
+        mlflow.log_metric(
+            "dataset_drift_detected", float(result["dataset_drift_detected"])
+        )
+        return result
 
 
 def evaluate_training_run(training_run_id: str, dataset: str = "train") -> str:

--- a/src/foehncast/training_pipeline/train.py
+++ b/src/foehncast/training_pipeline/train.py
@@ -117,14 +117,16 @@ def _model_pip_requirements() -> list[str]:
     return mlflow.sklearn.get_default_pip_requirements(include_cloudpickle=True)
 
 
-def run_training_pipeline(model_config: dict[str, Any] | None = None) -> str:
+def run_training_pipeline(
+    model_config: dict[str, Any] | None = None, dataset: str = "train"
+) -> str:
     """Train the configured model, log the run to MLflow, and return the run id."""
     resolved_model_config = model_config or get_model_config()
     mlflow_config = get_mlflow_config()
     mlflow.set_tracking_uri(get_mlflow_tracking_uri())
     mlflow.set_experiment(mlflow_config["experiment_name"])
 
-    features_df, target_series = load_training_data()
+    features_df, target_series = load_training_data(dataset=dataset)
     (
         features_train,
         features_test,
@@ -145,6 +147,7 @@ def run_training_pipeline(model_config: dict[str, Any] | None = None) -> str:
     ) as run:
         mlflow.log_params(
             {
+                "dataset": dataset,
                 "algorithm": resolved_model_config["algorithm"],
                 "test_size": resolved_model_config["test_size"],
                 "random_state": resolved_model_config["random_state"],

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -52,6 +52,7 @@ def _load_dag_module(
     operators_module.__path__ = []
     python_module = types.ModuleType("airflow.providers.standard.operators.python")
     python_module.PythonOperator = FakePythonOperator
+    python_module.ShortCircuitOperator = FakePythonOperator
 
     monkeypatch.setitem(sys.modules, "airflow", airflow_module)
     monkeypatch.setitem(sys.modules, "airflow.sdk", sdk_module)
@@ -67,6 +68,8 @@ def _load_dag_module(
     for name in (
         "AIRFLOW_FEATURE_DATASET",
         "AIRFLOW_FEATURE_SCHEDULE",
+        "AIRFLOW_AUTO_RETRAIN_MODE",
+        "AIRFLOW_TRAINING_DATASET",
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -94,12 +97,24 @@ def test_feature_dag_defaults_to_airflow_schedule(
     assert module.dag.kwargs["schedule"] == "0 */6 * * *"
     assert module.dag.kwargs["catchup"] is False
     assert module.dag.kwargs["is_paused_upon_creation"] is False
-    assert len(operators) == 1
-    assert operators[0].kwargs["task_id"] == "run_feature_pipeline"
+    assert [operator.kwargs["task_id"] for operator in operators] == [
+        "run_feature_pipeline",
+        "check_retraining_trigger",
+        "train_model",
+        "evaluate_model",
+        "register_model",
+    ]
     assert operators[0].kwargs["op_kwargs"] == {"dataset": "train"}
+    assert operators[1].kwargs["op_kwargs"] == {
+        "feature_result": "output:run_feature_pipeline",
+        "mode": "always",
+    }
+    assert operators[2].kwargs["op_kwargs"] == {"dataset": "train"}
+    assert operators[3].kwargs["op_args"] == ["output:train_model"]
+    assert operators[3].kwargs["op_kwargs"] == {"dataset": "train"}
 
 
-def test_feature_dag_supports_manual_override_and_dataset(
+def test_feature_dag_supports_manual_override_dataset_and_disabled_retraining(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     module, operators = _load_dag_module(
@@ -108,10 +123,12 @@ def test_feature_dag_supports_manual_override_and_dataset(
         env={
             "AIRFLOW_FEATURE_DATASET": "validation",
             "AIRFLOW_FEATURE_SCHEDULE": "manual",
+            "AIRFLOW_AUTO_RETRAIN_MODE": "off",
         },
     )
 
     assert module.dag.kwargs["schedule"] is None
+    assert len(operators) == 1
     assert operators[0].kwargs["op_kwargs"] == {"dataset": "validation"}
 
 
@@ -128,3 +145,18 @@ def test_training_dag_stays_manual_and_paused_by_default(
         "evaluate_model",
         "register_model",
     ]
+    assert operators[0].kwargs["op_kwargs"] == {"dataset": "train"}
+    assert operators[1].kwargs["op_kwargs"] == {"dataset": "train"}
+
+
+def test_training_dag_supports_dataset_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _, operators = _load_dag_module(
+        monkeypatch,
+        "dags/training_dag.py",
+        env={"AIRFLOW_TRAINING_DATASET": "validation"},
+    )
+
+    assert operators[0].kwargs["op_kwargs"] == {"dataset": "validation"}
+    assert operators[1].kwargs["op_kwargs"] == {"dataset": "validation"}

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -173,7 +173,11 @@ def test_run_feature_pipeline_emits_drift_metrics_when_previous_slice_exists(
                     "current_rows": len(current_df),
                 }
             )
-            or SimpleNamespace(dataset_name="silvaplana", dataset_version="train")
+            or SimpleNamespace(
+                dataset_name="silvaplana",
+                dataset_version="train",
+                dataset_drift=True,
+            )
         ),
     )
     monkeypatch.setattr(
@@ -364,6 +368,120 @@ def test_run_feature_pipeline_job_logs_to_mlflow_when_env_present(
         "stored_spots": "silvaplana,urnersee",
     }
     assert logged["metrics"] == {"stored_spot_count": 2}
+
+
+def test_run_feature_pipeline_job_context_reports_drift_and_logs_mlflow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: dict[str, object] = {}
+
+    class FakeRun:
+        def __enter__(self) -> FakeRun:
+            logged["entered"] = True
+            return self
+
+        def __exit__(self, exc_type, exc, exc_tb) -> None:
+            return None
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def set_experiment(self, experiment_name: str) -> None:
+            logged["experiment_name"] = experiment_name
+
+        def start_run(self, run_name: str) -> FakeRun:
+            logged["run_name"] = run_name
+            return FakeRun()
+
+        def log_params(self, params: dict[str, object]) -> None:
+            logged["params"] = params
+
+        def log_metric(self, name: str, value: float) -> None:
+            logged.setdefault("metrics", {})[name] = value
+
+    monkeypatch.setenv("MLFLOW_TRACKING_URI", "https://mlflow.example.com")
+    monkeypatch.setattr(orchestration, "mlflow", FakeMlflow())
+    monkeypatch.setattr(
+        orchestration,
+        "get_mlflow_config",
+        lambda: {"experiment_name": "foehncast"},
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "_run_feature_pipeline_result",
+        lambda dataset="train": {
+            "dataset": dataset,
+            "storage_backend": "s3",
+            "stored_spots": ["silvaplana", "urnersee"],
+            "drifted_spots": ["silvaplana"],
+            "dataset_drift_detected": True,
+        },
+    )
+
+    result = orchestration.run_feature_pipeline_job_context(dataset="train")
+
+    assert result == {
+        "dataset": "train",
+        "storage_backend": "s3",
+        "stored_spots": ["silvaplana", "urnersee"],
+        "drifted_spots": ["silvaplana"],
+        "dataset_drift_detected": True,
+    }
+    assert logged["tracking_uri"] == "https://mlflow.example.com"
+    assert logged["experiment_name"] == "foehncast"
+    assert logged["run_name"] == "feature-train-refresh"
+    assert logged["params"] == {
+        "dataset": "train",
+        "storage_backend": "s3",
+        "stored_spots": "silvaplana,urnersee",
+        "drifted_spots": "silvaplana",
+    }
+    assert logged["metrics"] == {
+        "stored_spot_count": 2,
+        "drifted_spot_count": 1,
+        "dataset_drift_detected": 1.0,
+    }
+
+
+@pytest.mark.parametrize(
+    ("mode", "expected"),
+    [
+        (None, "always"),
+        ("always", "always"),
+        ("new-data", "always"),
+        ("drift", "drift"),
+        ("drift-only", "drift"),
+        ("off", None),
+        ("manual", None),
+    ],
+)
+def test_resolve_auto_retraining_mode_normalizes_values(
+    mode: str | None, expected: str | None
+) -> None:
+    assert (
+        orchestration.resolve_auto_retraining_mode(mode, default="always") == expected
+    )
+
+
+def test_resolve_auto_retraining_mode_rejects_unknown_values() -> None:
+    with pytest.raises(ValueError, match="Unsupported auto retraining mode"):
+        orchestration.resolve_auto_retraining_mode("surprise")
+
+
+def test_should_auto_retrain_supports_always_and_drift_modes() -> None:
+    feature_result = {
+        "stored_spots": ["silvaplana"],
+        "dataset_drift_detected": False,
+    }
+    assert orchestration.should_auto_retrain(feature_result, mode="always") is True
+    assert orchestration.should_auto_retrain(feature_result, mode="drift") is False
+
+    drift_result = {
+        "stored_spots": ["silvaplana"],
+        "dataset_drift_detected": True,
+    }
+    assert orchestration.should_auto_retrain(drift_result, mode="drift") is True
 
 
 def test_resolve_airflow_schedule_uses_default_when_env_is_missing() -> None:

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -263,13 +263,20 @@ def test_run_training_pipeline_logs_mlflow_artifacts(
         lambda: {"tracking_uri": "http://mlflow", "experiment_name": "foehncast"},
     )
     monkeypatch.setattr(train, "get_mlflow_tracking_uri", lambda: "http://mlflow")
+
+    def fake_load_training_data(
+        dataset: str = "train",
+    ) -> tuple[pd.DataFrame, pd.Series]:
+        logged["dataset"] = dataset
+        return (
+            labeled_training_df[model_config["features"]],
+            labeled_training_df[model_config["target"]],
+        )
+
     monkeypatch.setattr(
         train,
         "load_training_data",
-        lambda: (
-            labeled_training_df[model_config["features"]],
-            labeled_training_df[model_config["target"]],
-        ),
+        fake_load_training_data,
     )
     monkeypatch.setattr(
         train,
@@ -297,12 +304,14 @@ def test_run_training_pipeline_logs_mlflow_artifacts(
         lambda: ["scikit-learn==1.8.0", "cloudpickle==3.1.1"],
     )
 
-    run_id = train.run_training_pipeline(model_config)
+    run_id = train.run_training_pipeline(model_config, dataset="validation")
 
     assert run_id == "run-123"
+    assert logged["dataset"] == "validation"
     assert logged["tracking_uri"] == "http://mlflow"
     assert logged["experiment_name"] == "foehncast"
     assert logged["run_name"] == "random_forest-train"
+    assert logged["params"]["dataset"] == "validation"
     assert logged["params"]["algorithm"] == "random_forest"
     assert set(logged["metrics"].keys()) >= {
         "mae",


### PR DESCRIPTION
What changed: add an Airflow-managed auto-retraining loop that can continue from the scheduled feature refresh into train, evaluate, and register steps; return drift-aware feature refresh context for gating; and make the training dataset explicit in both DAGs and training entrypoints.

Why: issue #19 requires demonstrating the full automation loop from feature refresh to model registration without introducing a second orchestration surface outside Airflow.

Verification:
- uv run --no-sync ruff check dags/feature_dag.py dags/training_dag.py src/foehncast/orchestration.py src/foehncast/training_pipeline/train.py tests/test_dags.py tests/test_orchestration.py tests/test_train.py
- uv run --no-sync python -m pytest tests/test_dags.py tests/test_orchestration.py tests/test_train.py

Closes: #19