### PR TITLE
feature(ui): add Streamlit live demo dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ flowchart LR
 |------|--------|---------|
 | Feature pipeline | Working | Airflow ingests, engineers, validates, and stores curated weather features |
 | Training pipeline | Working | Airflow labels data, trains the model, evaluates it, and registers versions in MLflow |
-| Inference pipeline | Working | FastAPI serves `/health`, `/spots`, `/predict`, `/rank`, and online-feature routes |
+| Inference pipeline | Working | FastAPI serves `/health`, `/spots`, `/predict`, `/rank`, and online-feature routes, and `ui/app.py` provides the Streamlit live-demo surface |
 | Hosted runtime | Working | The shared environment currently runs the hosted full-stack target on one GCP host; the inference-only Cloud Run target remains provisionable but is not enabled there |
 | Automation | Working | GitHub Actions publishes images, validates infrastructure, and drives remote Terraform workflows |
 | Monitoring | Working | Docker Compose provisions Prometheus, a StatsD exporter, and Grafana; the app exposes `/metrics`; and Grafana loads starter dashboards plus alert rules from checked-in config |
@@ -84,6 +84,8 @@ curl -fsS -X POST http://127.0.0.1:8000/rank \
   -d '{"spot_ids":["silvaplana","urnersee"]}'
 ```
 
+For the rider-facing MS3 demo, run `uv run streamlit run ui/app.py` from the repo root. The dashboard reuses the same prediction and ranking modules as the API, shows the configured rider profile plus current serving model version, and explicitly follows the current 14-hour live inference window instead of inventing a separate forecast contract.
+
 ## Shared Cloud Automation
 
 The shared hosted environment is not part of normal contributor setup.
@@ -101,6 +103,7 @@ Hosted deployment keeps its scope narrow. The cloud targets deploy runtime servi
 ## Repository Map
 
 - `src/foehncast/`: application code for configuration, feature engineering, training, inference, monitoring, and spot metadata
+- `ui/`: Streamlit rider-facing demo app for the MS3 presentation flow
 - `dags/`: Airflow entry points for the feature and training workflows
 - `scripts/`: local bootstrap plus maintainer utilities
 - `terraform/`: maintainer cloud infrastructure definition and reference

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "requests>=2.31",
     "scikit-learn>=1.5",
     "s3fs>=2024.0",
+    "streamlit>=1.45",
     "uvicorn>=0.30",
     "evidently>=0.7.21",
 ]

--- a/src/foehncast/inference_pipeline/dashboard.py
+++ b/src/foehncast/inference_pipeline/dashboard.py
@@ -1,0 +1,147 @@
+"""Helpers for the Streamlit live-demo dashboard."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any
+
+import pandas as pd
+
+from foehncast.config import get_inference_config, get_rider_config
+from foehncast.inference_pipeline.predict import list_available_spots, predict_spots
+from foehncast.inference_pipeline.rank import rank_spots
+
+_RIDEABLE_QUALITY_THRESHOLD = 2.0
+_QUALITY_LABELS = {
+    0: "Unsafe",
+    1: "Too Light",
+    2: "Marginal",
+    3: "Good Enough",
+    4: "Fun Day",
+    5: "Perfect Storm",
+}
+
+
+def list_dashboard_spots() -> list[dict[str, Any]]:
+    """Return the configured spots available to the dashboard."""
+    return list_available_spots()
+
+
+def quality_bucket(value: float) -> int:
+    """Round a continuous quality score into the nearest rider-facing band."""
+    rounded = int(round(float(value)))
+    return min(max(rounded, 0), 5)
+
+
+def quality_label(value: float) -> str:
+    """Return the rider-facing label for a quality score."""
+    return _QUALITY_LABELS[quality_bucket(value)]
+
+
+def build_forecast_frame(prediction: dict[str, Any]) -> pd.DataFrame:
+    """Convert a spot prediction payload into a chart-friendly dataframe."""
+    forecast_rows = prediction.get("forecast", [])
+    if not forecast_rows:
+        return pd.DataFrame(
+            columns=[
+                "time",
+                "display_time",
+                "quality_index",
+                "quality_label",
+                "rideable",
+            ]
+        )
+
+    frame = pd.DataFrame(forecast_rows)
+    frame["time"] = pd.to_datetime(frame["time"])
+    frame["quality_index"] = frame["quality_index"].astype(float)
+    frame = frame.sort_values("time").reset_index(drop=True)
+    frame["quality_label"] = frame["quality_index"].map(quality_label)
+    frame["rideable"] = frame["quality_index"] >= _RIDEABLE_QUALITY_THRESHOLD
+    frame["display_time"] = frame["time"].dt.strftime("%a %d %b %H:%M")
+    return frame
+
+
+def summarize_forecast(prediction: dict[str, Any]) -> dict[str, Any]:
+    """Summarize the strongest part of a spot forecast for dashboard cards."""
+    frame = build_forecast_frame(prediction)
+    if frame.empty:
+        return {
+            "peak_quality": 0.0,
+            "peak_label": quality_label(0.0),
+            "peak_time": None,
+            "peak_time_label": "No forecast rows",
+            "rideable_hours": 0,
+            "forecast_rows": 0,
+        }
+
+    peak_row = frame.loc[frame["quality_index"].idxmax()]
+    return {
+        "peak_quality": float(peak_row["quality_index"]),
+        "peak_label": str(peak_row["quality_label"]),
+        "peak_time": peak_row["time"].isoformat(),
+        "peak_time_label": str(peak_row["display_time"]),
+        "rideable_hours": int(frame["rideable"].sum()),
+        "forecast_rows": int(len(frame)),
+    }
+
+
+def build_ranking_frame(ranked_spots: list[dict[str, Any]]) -> pd.DataFrame:
+    """Build a compact dataframe for the ranked recommendations table."""
+    rows: list[dict[str, object]] = []
+    for position, spot in enumerate(ranked_spots, start=1):
+        rows.append(
+            {
+                "Rank": position,
+                "Spot": spot["spot_name"],
+                "Signal": spot["quality_label"],
+                "Peak quality": round(float(spot["quality_index"]), 2),
+                "Rideable hrs": int(spot["rideable_hours"]),
+                "Drive min": round(float(spot["drive_minutes"]), 1),
+                "Session hrs": round(float(spot["session_hours"]), 1),
+                "Ride/drive": round(float(spot["ride_drive_ratio"]), 2),
+                "Score": round(float(spot["score"]), 3),
+            }
+        )
+    return pd.DataFrame(rows)
+
+
+def horizon_caption(hours: int) -> str:
+    """Describe the currently supported live forecast window."""
+    unit = "hour" if hours == 1 else "hours"
+    return (
+        "The live demo follows the current inference contract: "
+        f"{hours} forecast {unit} from the active Open-Meteo pull."
+    )
+
+
+def load_dashboard_data(spot_ids: list[str] | None = None) -> dict[str, Any]:
+    """Load live predictions, rankings, and demo metadata for the Streamlit UI."""
+    resolved_spot_ids = spot_ids or None
+    available_spots = list_dashboard_spots()
+    rider_profile = get_rider_config()
+    predictions = predict_spots(resolved_spot_ids)
+    ranked_spots = rank_spots(predictions, rider_profile)
+    prediction_by_spot_id = {
+        prediction["spot_id"]: prediction for prediction in predictions["predictions"]
+    }
+    ranked_cards: list[dict[str, Any]] = []
+
+    for ranked_spot in ranked_spots:
+        summary = summarize_forecast(prediction_by_spot_id[ranked_spot.spot_id])
+        ranked_cards.append(
+            {
+                **asdict(ranked_spot),
+                "quality_label": quality_label(ranked_spot.quality_index),
+                **summary,
+            }
+        )
+
+    return {
+        "available_spots": available_spots,
+        "model_version": predictions["model_version"],
+        "rider_profile": rider_profile,
+        "horizon_hours": int(get_inference_config()["max_horizon_hours"]),
+        "predictions": predictions["predictions"],
+        "ranked_spots": ranked_cards,
+    }

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -1,0 +1,126 @@
+"""Tests for Streamlit dashboard helper logic."""
+
+from __future__ import annotations
+
+import pytest
+
+from foehncast.inference_pipeline import dashboard
+from foehncast.inference_pipeline.rank import RankedSpot
+
+
+def test_quality_label_rounds_to_nearest_band() -> None:
+    assert dashboard.quality_label(0.2) == "Unsafe"
+    assert dashboard.quality_label(1.8) == "Marginal"
+    assert dashboard.quality_label(3.6) == "Fun Day"
+
+
+def test_build_forecast_frame_sorts_rows_and_marks_rideable_windows() -> None:
+    frame = dashboard.build_forecast_frame(
+        {
+            "forecast": [
+                {"time": "2025-01-01T03:00:00+00:00", "quality_index": 4.2},
+                {"time": "2025-01-01T01:00:00+00:00", "quality_index": 1.8},
+            ]
+        }
+    )
+
+    assert list(frame["quality_index"]) == [1.8, 4.2]
+    assert list(frame["quality_label"]) == ["Marginal", "Fun Day"]
+    assert list(frame["rideable"]) == [False, True]
+    assert frame.iloc[0]["display_time"].endswith("01:00")
+
+
+def test_summarize_forecast_returns_defaults_for_empty_predictions() -> None:
+    summary = dashboard.summarize_forecast({"forecast": []})
+
+    assert summary == {
+        "peak_quality": 0.0,
+        "peak_label": "Unsafe",
+        "peak_time": None,
+        "peak_time_label": "No forecast rows",
+        "rideable_hours": 0,
+        "forecast_rows": 0,
+    }
+
+
+def test_load_dashboard_data_combines_predictions_rankings_and_metadata(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        dashboard,
+        "list_dashboard_spots",
+        lambda: [{"id": "silvaplana", "name": "Silvaplana"}],
+    )
+    monkeypatch.setattr(
+        dashboard,
+        "get_rider_config",
+        lambda: {
+            "weight_kg": 80,
+            "home_location": "Schwyz",
+            "home_lat": 47.02,
+            "home_lon": 8.65,
+            "quiver_m2": [5, 7, 8, 10, 12],
+        },
+    )
+    monkeypatch.setattr(
+        dashboard,
+        "predict_spots",
+        lambda spot_ids: {
+            "model_version": "11",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {
+                            "time": "2025-01-01T00:00:00+00:00",
+                            "quality_index": 2.2,
+                        },
+                        {
+                            "time": "2025-01-01T01:00:00+00:00",
+                            "quality_index": 3.4,
+                        },
+                    ],
+                }
+            ],
+        },
+    )
+    monkeypatch.setattr(
+        dashboard,
+        "rank_spots",
+        lambda predictions, rider_config: [
+            RankedSpot(
+                spot_id="silvaplana",
+                spot_name="Silvaplana",
+                quality_index=3.4,
+                drive_minutes=95.0,
+                session_hours=2.0,
+                ride_drive_ratio=4.29,
+                score=1.0,
+            )
+        ],
+    )
+    monkeypatch.setattr(
+        dashboard,
+        "get_inference_config",
+        lambda: {"max_horizon_hours": 14},
+    )
+
+    payload = dashboard.load_dashboard_data(["silvaplana"])
+
+    assert payload["model_version"] == "11"
+    assert payload["horizon_hours"] == 14
+    assert payload["rider_profile"]["home_location"] == "Schwyz"
+    assert payload["available_spots"] == [{"id": "silvaplana", "name": "Silvaplana"}]
+    assert payload["ranked_spots"][0]["spot_id"] == "silvaplana"
+    assert payload["ranked_spots"][0]["quality_label"] == "Good Enough"
+    assert payload["ranked_spots"][0]["rideable_hours"] == 2
+    assert payload["ranked_spots"][0]["peak_time_label"].endswith("01:00")
+
+    ranking_frame = dashboard.build_ranking_frame(payload["ranked_spots"])
+    assert list(ranking_frame["Spot"]) == ["Silvaplana"]
+    assert list(ranking_frame["Signal"]) == ["Good Enough"]
+
+
+def test_horizon_caption_describes_hour_based_contract() -> None:
+    assert "14 forecast hours" in dashboard.horizon_caption(14)

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,0 +1,397 @@
+"""Streamlit dashboard for the FoehnCast live demo."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import streamlit as st
+
+from foehncast.inference_pipeline.dashboard import (
+    build_forecast_frame,
+    build_ranking_frame,
+    horizon_caption,
+    list_dashboard_spots,
+    load_dashboard_data,
+)
+
+st.set_page_config(
+    page_title="FoehnCast Live Demo",
+    layout="wide",
+    initial_sidebar_state="expanded",
+)
+
+
+@st.cache_data(show_spinner=False)
+def _available_spots() -> list[dict[str, Any]]:
+    return list_dashboard_spots()
+
+
+@st.cache_data(ttl=900, show_spinner=False)
+def _live_dashboard_data(selected_spot_ids: tuple[str, ...]) -> dict[str, Any]:
+    return load_dashboard_data(list(selected_spot_ids) if selected_spot_ids else None)
+
+
+def _inject_styles() -> None:
+    st.markdown(
+        """
+        <style>
+          @import url('https://fonts.googleapis.com/css2?family=Manrope:wght@400;600;700;800&family=Newsreader:opsz,wght@6..72,500;6..72,700&display=swap');
+
+          :root {
+            --bg: #f3eee2;
+            --panel: rgba(255, 251, 244, 0.94);
+            --panel-strong: rgba(255, 248, 237, 0.98);
+            --ink: #17324d;
+            --muted: #5f6f7f;
+            --accent: #0e6d6e;
+            --accent-soft: rgba(14, 109, 110, 0.12);
+            --warm: #d1833d;
+            --line: rgba(23, 50, 77, 0.12);
+            --shadow: 0 20px 60px rgba(23, 50, 77, 0.08);
+          }
+
+          .stApp {
+            background:
+              radial-gradient(circle at top left, rgba(14, 109, 110, 0.15), transparent 30%),
+              radial-gradient(circle at top right, rgba(209, 131, 61, 0.18), transparent 28%),
+              linear-gradient(180deg, #faf6ee 0%, var(--bg) 100%);
+            color: var(--ink);
+          }
+
+          .block-container {
+            padding-top: 2.2rem;
+            padding-bottom: 2rem;
+          }
+
+          h1, h2, h3 {
+            font-family: 'Newsreader', serif;
+            color: var(--ink);
+            letter-spacing: -0.02em;
+          }
+
+          p, li, div[data-testid="stMarkdownContainer"] {
+            font-family: 'Manrope', sans-serif;
+          }
+
+          section[data-testid="stSidebar"] {
+            background: rgba(252, 248, 242, 0.86);
+            border-right: 1px solid var(--line);
+          }
+
+          div[data-testid="stMetric"] {
+            background: var(--panel);
+            border: 1px solid var(--line);
+            border-radius: 20px;
+            padding: 16px 18px;
+            box-shadow: var(--shadow);
+          }
+
+          .hero-shell,
+          .feature-card,
+          .profile-card,
+          .top-pick {
+            border: 1px solid var(--line);
+            border-radius: 28px;
+            background: var(--panel);
+            box-shadow: var(--shadow);
+          }
+
+          .hero-shell {
+            padding: 28px 30px;
+            margin-bottom: 1.2rem;
+          }
+
+          .eyebrow {
+            margin: 0 0 8px;
+            font-family: 'Manrope', sans-serif;
+            font-size: 0.85rem;
+            font-weight: 800;
+            letter-spacing: 0.18em;
+            text-transform: uppercase;
+            color: var(--accent);
+          }
+
+          .hero-title {
+            margin: 0;
+            font-size: clamp(2.5rem, 5vw, 4.2rem);
+            line-height: 0.95;
+          }
+
+          .hero-lede {
+            margin: 12px 0 0;
+            max-width: 68ch;
+            color: var(--muted);
+            font-size: 1.02rem;
+            line-height: 1.6;
+          }
+
+          .top-pick {
+            padding: 24px 26px;
+            margin-bottom: 1rem;
+            background:
+              linear-gradient(135deg, rgba(14, 109, 110, 0.08), rgba(209, 131, 61, 0.12)),
+              var(--panel-strong);
+          }
+
+          .top-pick h3,
+          .profile-card h3 {
+            margin: 0 0 10px;
+            font-size: 1.6rem;
+          }
+
+          .spot-line {
+            margin: 0;
+            color: var(--muted);
+            font-size: 0.98rem;
+          }
+
+          .stat-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+            gap: 12px;
+            margin-top: 16px;
+          }
+
+          .stat-chip {
+            border-radius: 18px;
+            padding: 12px 14px;
+            background: rgba(255, 255, 255, 0.72);
+            border: 1px solid rgba(23, 50, 77, 0.08);
+          }
+
+          .stat-chip span {
+            display: block;
+            color: var(--muted);
+            font-size: 0.78rem;
+            font-weight: 700;
+            letter-spacing: 0.04em;
+            text-transform: uppercase;
+          }
+
+          .stat-chip strong {
+            display: block;
+            margin-top: 4px;
+            font-family: 'Newsreader', serif;
+            font-size: 1.35rem;
+            color: var(--ink);
+          }
+
+          .profile-card {
+            padding: 18px 18px 10px;
+            margin-top: 1rem;
+          }
+
+          .profile-row {
+            display: flex;
+            justify-content: space-between;
+            gap: 12px;
+            padding: 10px 0;
+            border-top: 1px solid rgba(23, 50, 77, 0.08);
+            color: var(--muted);
+            font-size: 0.94rem;
+          }
+
+          .profile-row:first-of-type {
+            border-top: 0;
+            padding-top: 0;
+          }
+
+          .profile-row strong {
+            color: var(--ink);
+            font-weight: 800;
+          }
+        </style>
+        """,
+        unsafe_allow_html=True,
+    )
+
+
+def _spot_label(spot_lookup: dict[str, dict[str, Any]], spot_id: str) -> str:
+    spot = spot_lookup[spot_id]
+    return f"{spot['name']} ({spot_id})"
+
+
+def _profile_card(rider_profile: dict[str, Any]) -> str:
+    quiver = ", ".join(str(size) for size in rider_profile.get("quiver_m2", []))
+    return f"""
+    <section class="profile-card">
+      <p class="eyebrow">Configured Rider</p>
+      <h3>{rider_profile["home_location"]}</h3>
+      <div class="profile-row"><span>Weight</span><strong>{rider_profile["weight_kg"]} kg</strong></div>
+      <div class="profile-row"><span>Home coordinates</span><strong>{rider_profile["home_lat"]}, {rider_profile["home_lon"]}</strong></div>
+      <div class="profile-row"><span>Quiver</span><strong>{quiver} m²</strong></div>
+    </section>
+    """
+
+
+def _top_pick_card(top_spot: dict[str, Any], model_version: str) -> str:
+    return f"""
+    <section class="top-pick">
+      <p class="eyebrow">Top Recommendation</p>
+      <h3>{top_spot["spot_name"]}</h3>
+      <p class="spot-line">
+        Signal: <strong>{top_spot["quality_label"]}</strong> · Best window {top_spot["peak_time_label"]} · Model v{model_version}
+      </p>
+      <div class="stat-grid">
+        <div class="stat-chip"><span>Peak quality</span><strong>{top_spot["quality_index"]:.2f}</strong></div>
+        <div class="stat-chip"><span>Rideable hours</span><strong>{top_spot["rideable_hours"]}</strong></div>
+        <div class="stat-chip"><span>Drive time</span><strong>{top_spot["drive_minutes"]:.0f} min</strong></div>
+        <div class="stat-chip"><span>Ride / drive</span><strong>{top_spot["ride_drive_ratio"]:.2f}</strong></div>
+      </div>
+    </section>
+    """
+
+
+def main() -> None:
+    _inject_styles()
+    st.markdown(
+        """
+        <section class="hero-shell">
+          <p class="eyebrow">MS3 Live Demo</p>
+          <h1 class="hero-title">FoehnCast Rider Console</h1>
+          <p class="hero-lede">
+            One rider profile, six validated Swiss spots, one current serving model. This dashboard
+            reuses the live prediction and ranking modules behind the API so the demo stays on the
+            same inference path the repository already validates.
+          </p>
+        </section>
+        """,
+        unsafe_allow_html=True,
+    )
+
+    available_spots = _available_spots()
+    spot_lookup = {spot["id"]: spot for spot in available_spots}
+    default_spot_ids = [spot["id"] for spot in available_spots]
+
+    with st.sidebar:
+        st.markdown("### Demo Scope")
+        selected_spot_ids = st.multiselect(
+            "Spot selector",
+            options=default_spot_ids,
+            default=default_spot_ids,
+            format_func=lambda spot_id: _spot_label(spot_lookup, spot_id),
+            help="Choose the configured spots you want in the live ranking run.",
+        )
+        if st.button("Refresh live forecast", use_container_width=True):
+            _live_dashboard_data.clear()
+
+    if not selected_spot_ids:
+        st.warning("Choose at least one spot to load the live ranking view.")
+        st.stop()
+
+    try:
+        with st.spinner(
+            "Loading live forecasts, drive times, and ranked recommendations..."
+        ):
+            dashboard_data = _live_dashboard_data(tuple(selected_spot_ids))
+    except Exception as exc:
+        st.error(
+            "The live demo could not load the current forecast-model stack. "
+            "Check MLflow, network access, and the configured serving model alias."
+        )
+        st.exception(exc)
+        st.stop()
+
+    rider_profile = dashboard_data["rider_profile"]
+    ranked_spots = dashboard_data["ranked_spots"]
+    prediction_by_spot_id = {
+        prediction["spot_id"]: prediction
+        for prediction in dashboard_data["predictions"]
+    }
+
+    with st.sidebar:
+        st.markdown(_profile_card(rider_profile), unsafe_allow_html=True)
+        st.caption(
+            "Drive-time ranking uses the configured rider home in config.yaml and live OSRM route estimates."
+        )
+
+    metric_columns = st.columns(4)
+    top_spot = ranked_spots[0] if ranked_spots else None
+    metric_columns[0].metric("Model version", dashboard_data["model_version"])
+    metric_columns[1].metric("Spots in scope", len(selected_spot_ids))
+    metric_columns[2].metric("Forecast window", f"{dashboard_data['horizon_hours']} h")
+    metric_columns[3].metric(
+        "Top signal",
+        top_spot["quality_label"] if top_spot is not None else "Unavailable",
+    )
+    st.caption(horizon_caption(dashboard_data["horizon_hours"]))
+
+    if top_spot is not None:
+        st.markdown(
+            _top_pick_card(top_spot, dashboard_data["model_version"]),
+            unsafe_allow_html=True,
+        )
+
+    left_column, right_column = st.columns([1.25, 1.0], gap="large")
+
+    with left_column:
+        st.subheader("Ranked Spot Recommendations")
+        st.dataframe(
+            build_ranking_frame(ranked_spots),
+            use_container_width=True,
+            hide_index=True,
+        )
+        st.caption(
+            "Ranking combines peak forecast quality, rideable duration, and ride-to-drive return for the configured rider."
+        )
+
+    with right_column:
+        st.subheader("Forecast Detail")
+        focus_spot_ids = [spot["spot_id"] for spot in ranked_spots]
+        focus_default = focus_spot_ids[0] if focus_spot_ids else selected_spot_ids[0]
+        focus_spot_id = st.selectbox(
+            "Spot detail",
+            options=focus_spot_ids or selected_spot_ids,
+            index=(focus_spot_ids or selected_spot_ids).index(focus_default),
+            format_func=lambda spot_id: _spot_label(spot_lookup, spot_id),
+        )
+        focus_prediction = prediction_by_spot_id[focus_spot_id]
+        focus_summary = next(
+            spot for spot in ranked_spots if spot["spot_id"] == focus_spot_id
+        )
+        focus_frame = build_forecast_frame(focus_prediction)
+
+        detail_metrics = st.columns(2)
+        detail_metrics[0].metric("Best window", focus_summary["peak_time_label"])
+        detail_metrics[1].metric("Rideable hours", focus_summary["rideable_hours"])
+
+        if focus_frame.empty:
+            st.info("The current API call returned no forecast rows for this spot.")
+        else:
+            chart_frame = focus_frame.set_index("time")[["quality_index"]].copy()
+            chart_frame["rideable_threshold"] = 2.0
+            st.line_chart(chart_frame, use_container_width=True, height=320)
+
+            best_windows = (
+                focus_frame.sort_values(
+                    ["quality_index", "time"], ascending=[False, True]
+                )
+                .head(5)
+                .loc[:, ["display_time", "quality_index", "quality_label"]]
+                .rename(
+                    columns={
+                        "display_time": "Time",
+                        "quality_index": "Quality",
+                        "quality_label": "Signal",
+                    }
+                )
+            )
+            st.dataframe(best_windows, use_container_width=True, hide_index=True)
+
+    with st.expander("Full forecast rows", expanded=False):
+        full_forecast_frame = focus_frame.rename(
+            columns={
+                "display_time": "Time",
+                "quality_index": "Quality",
+                "quality_label": "Signal",
+                "rideable": "Rideable",
+            }
+        )
+        st.dataframe(
+            full_forecast_frame[["Time", "Quality", "Signal", "Rideable"]],
+            use_container_width=True,
+            hide_index=True,
+        )
+
+
+main()

--- a/uv.lock
+++ b/uv.lock
@@ -165,6 +165,22 @@ wheels = [
 ]
 
 [[package]]
+name = "altair"
+version = "6.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "jsonschema" },
+    { name = "narwhals" },
+    { name = "packaging" },
+    { name = "typing-extensions", marker = "python_full_version < '3.15'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3a/1e/365a9144db3254f86f1b974660b9ede1e9a38c9dc0730e4a9b1192eec5d6/altair-6.1.0.tar.gz", hash = "sha256:dda699216cf85b040d968ae5a569ad45957616811e38760a85e5118269daca67", size = 765519, upload-time = "2026-04-21T13:08:46.44Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/63/5dacc8d8306c715088b897a479e551bc0779fd2f0f26c97fec5e36542b4e/altair-6.1.0-py3-none-any.whl", hash = "sha256:fdf5fd939512e5b2fc4441c82dfd2635e706defbd037db0ac429ef5ddce66c3b", size = 796996, upload-time = "2026-04-21T13:08:48.549Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -1042,6 +1058,7 @@ dependencies = [
     { name = "requests" },
     { name = "s3fs" },
     { name = "scikit-learn" },
+    { name = "streamlit" },
     { name = "uvicorn" },
 ]
 
@@ -1077,6 +1094,7 @@ requires-dist = [
     { name = "requests", specifier = ">=2.31" },
     { name = "s3fs", specifier = ">=2024.0" },
     { name = "scikit-learn", specifier = ">=1.5" },
+    { name = "streamlit", specifier = ">=1.45" },
     { name = "uvicorn", specifier = ">=0.30" },
 ]
 
@@ -2942,6 +2960,15 @@ wheels = [
 ]
 
 [[package]]
+name = "narwhals"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2d/0e/3ad61eb87088cc4932e0d851531fa82f845a6230b68b091a0e298cc7e537/narwhals-2.21.0.tar.gz", hash = "sha256:7c6e7f50528e62b7a967dd864d7e117d2955d38d4f730653ce46a9861358e2dc", size = 633083, upload-time = "2026-05-08T12:29:02.587Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c7/e1/68c2256b69a314eba133673377ba9118c356f6342a0c02b61de449cf2bf2/narwhals-2.21.0-py3-none-any.whl", hash = "sha256:1e6617d0fca68ae1fda29e5397c4eaacd3ffc9fffe6bcd6ded0c690475e853be", size = 451943, upload-time = "2026-05-08T12:29:01.058Z" },
+]
+
+[[package]]
 name = "nbclient"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3792,6 +3819,19 @@ wheels = [
 ]
 
 [[package]]
+name = "pydeck"
+version = "0.9.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "jinja2" },
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/eb/df/4e9e7f20f8034a37c6571c93809f6d22388c39978c98d174d656c1a18fd2/pydeck-0.9.2.tar.gz", hash = "sha256:c10d9035e81ead6385264cac8d19402471f6866a15ca1f7df1400f52142bcf87", size = 5849672, upload-time = "2026-04-16T18:30:30.089Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/88/24/b30ee7d723100fd822de1bb4c0adea62f3419884a75a536f35f355d1e7c0/pydeck-0.9.2-py2.py3-none-any.whl", hash = "sha256:8213dfeacc5f6bfe6825f61c8ee34e3850e8a31fc43924379ec98edb34a75b25", size = 11305615, upload-time = "2026-04-16T18:30:28.133Z" },
+]
+
+[[package]]
 name = "pygments"
 version = "2.20.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3887,6 +3927,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f7/ff/3cc9165fd44106973cd7ac9facb674a65ed853494592541d339bdc9a30eb/python_json_logger-4.1.0.tar.gz", hash = "sha256:b396b9e3ed782b09ff9d6e4f1683d46c83ad0d35d2e407c09a9ebbf038f88195", size = 17573, upload-time = "2026-03-29T04:39:56.805Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/27/be/0631a861af4d1c875f096c07d34e9a63639560a717130e7a87cbc82b7e3f/python_json_logger-4.1.0-py3-none-any.whl", hash = "sha256:132994765cf75bf44554be9aa49b06ef2345d23661a96720262716438141b6b2", size = 15021, upload-time = "2026-03-29T04:39:55.266Z" },
+]
+
+[[package]]
+name = "python-multipart"
+version = "0.0.28"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/82/54/a85eb421fbdd5007bc5af39d0f4ed9fa609e0fedbfdc2adcf0b34526870e/python_multipart-0.0.28.tar.gz", hash = "sha256:8550da197eac0f7ab748961fc9509b999fa2662ea25cef857f05249f6893c0f8", size = 45314, upload-time = "2026-05-10T11:05:16.596Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f3/a2/43bbc5860b5034e2af4ef99a0e04d726ff329c43e192ef3abaa8d7ecfce5/python_multipart-0.0.28-py3-none-any.whl", hash = "sha256:10faac07eb966c3f48dc415f9dee46c04cb10d58d30a35677db8027c825ed9b6", size = 29438, upload-time = "2026-05-10T11:05:15.052Z" },
 ]
 
 [[package]]
@@ -4645,6 +4694,41 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/34/0e/2408735aca9e764643196212f9069912100151414dd617d39ffc72d77eee/statsmodels-0.14.6-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3414e40c073d725007a6603a18247ab7af3467e1af4a5e5a24e4c27bc26673b4", size = 10337587, upload-time = "2025-12-05T23:13:37.597Z" },
     { url = "https://files.pythonhosted.org/packages/0f/36/4d44f7035ab3c0b2b6a4c4ebb98dedf36246ccbc1b3e2f51ebcd7ac83abb/statsmodels-0.14.6-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:a518d3f9889ef920116f9fa56d0338069e110f823926356946dae83bc9e33e19", size = 10363350, upload-time = "2025-12-05T23:13:53.08Z" },
     { url = "https://files.pythonhosted.org/packages/26/33/f1652d0c59fa51de18492ee2345b65372550501ad061daa38f950be390b6/statsmodels-0.14.6-cp314-cp314-win_amd64.whl", hash = "sha256:151b73e29f01fe619dbce7f66d61a356e9d1fe5e906529b78807df9189c37721", size = 9588010, upload-time = "2025-12-05T23:14:07.28Z" },
+]
+
+[[package]]
+name = "streamlit"
+version = "1.57.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "altair" },
+    { name = "anyio" },
+    { name = "blinker" },
+    { name = "cachetools" },
+    { name = "click" },
+    { name = "gitpython" },
+    { name = "httptools" },
+    { name = "itsdangerous" },
+    { name = "numpy" },
+    { name = "packaging" },
+    { name = "pandas" },
+    { name = "pillow" },
+    { name = "protobuf" },
+    { name = "pyarrow" },
+    { name = "pydeck" },
+    { name = "python-multipart" },
+    { name = "requests" },
+    { name = "starlette" },
+    { name = "tenacity" },
+    { name = "toml" },
+    { name = "typing-extensions" },
+    { name = "uvicorn" },
+    { name = "watchdog", marker = "sys_platform != 'darwin'" },
+    { name = "websockets" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/5d/f8/b2daf7a5f8ae15527daf94406e771bb6075e958a01c3dde9eba79dc3c9a3/streamlit-1.57.0.tar.gz", hash = "sha256:0b028d305c1a1a757071b2c9504966787602842fc8af6e873795ca58d2b4d12f", size = 8678859, upload-time = "2026-04-28T22:13:32.238Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d8/1a/3ca2293d8552bacea3e67e9600d2d1df7df4a325059769ad83d91c279595/streamlit-1.57.0-py3-none-any.whl", hash = "sha256:0d1d41972aeade5637dbb0e7f0eefa5312272f85304923d240a1b1f0475249c8", size = 9194216, upload-time = "2026-04-28T22:13:29.624Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
What changed: add a Streamlit rider-facing dashboard in ui/app.py, move dashboard data shaping into a testable inference helper module, add focused dashboard tests, and document the live demo entrypoint.

Why: issue #16 requires a presentation-ready live demo surface that shows the configured spots, ranked recommendations, the current serving model version, and the rider profile without creating a separate inference path from the API.

Verification:
- uv run --no-sync ruff check src/foehncast/inference_pipeline/dashboard.py ui/app.py tests/test_dashboard.py tests/test_predict.py tests/test_rank.py tests/test_demo.py
- uv run --no-sync python -m pytest tests/test_dashboard.py tests/test_predict.py tests/test_rank.py tests/test_demo.py
- python -m py_compile ui/app.py src/foehncast/inference_pipeline/dashboard.py
- uv lock && uv run python -c "import streamlit; print(streamlit.__version__)"

Closes: #16