### PR TITLE
feature(monitoring): expose hosted sync freshness and staged pipeline progress

### DIFF
--- a/dags/feature_dag.py
+++ b/dags/feature_dag.py
@@ -15,12 +15,15 @@ except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
     dag = None
 else:
     from foehncast.orchestration import (
+        engineer_feature_pipeline_context,
         evaluate_training_run,
+        fetch_feature_pipeline_context,
         register_training_run,
         resolve_auto_retraining_mode,
         resolve_airflow_schedule,
-        run_feature_pipeline_job_context,
+        store_feature_pipeline_job_context,
         should_auto_retrain,
+        validate_feature_pipeline_context,
     )
     from foehncast.training_pipeline.train import run_training_pipeline
 
@@ -37,8 +40,8 @@ else:
     with DAG(
         dag_id="feature_pipeline",
         description=(
-            "Fetch forecasts, engineer features, validate and store them, "
-            "and optionally continue into retraining."
+            "Fetch forecasts, engineer features, validate them, persist curated "
+            "slices, and optionally continue into retraining."
         ),
         start_date=datetime(2024, 1, 1),
         schedule=feature_schedule,
@@ -46,10 +49,28 @@ else:
         is_paused_upon_creation=False,
         tags=["foehncast", "feature"],
     ) as dag:
-        run_feature_refresh = PythonOperator(
-            task_id="run_feature_pipeline",
-            python_callable=run_feature_pipeline_job_context,
-            op_kwargs={"dataset": feature_dataset},
+        fetch_feature_inputs = PythonOperator(
+            task_id="fetch_feature_inputs",
+            python_callable=fetch_feature_pipeline_context,
+            op_kwargs={"dataset": feature_dataset, "run_key": "{{ run_id }}"},
+        )
+
+        engineer_feature_set = PythonOperator(
+            task_id="engineer_feature_set",
+            python_callable=engineer_feature_pipeline_context,
+            op_args=[fetch_feature_inputs.output],
+        )
+
+        validate_feature_set = PythonOperator(
+            task_id="validate_feature_set",
+            python_callable=validate_feature_pipeline_context,
+            op_args=[engineer_feature_set.output],
+        )
+
+        store_feature_set = PythonOperator(
+            task_id="store_feature_set",
+            python_callable=store_feature_pipeline_job_context,
+            op_args=[validate_feature_set.output],
         )
 
         if auto_retrain_mode is not None:
@@ -57,7 +78,7 @@ else:
                 task_id="check_retraining_trigger",
                 python_callable=should_auto_retrain,
                 op_kwargs={
-                    "feature_result": run_feature_refresh.output,
+                    "feature_result": store_feature_set.output,
                     "mode": auto_retrain_mode,
                 },
             )
@@ -82,9 +103,20 @@ else:
             )
 
             (
-                run_feature_refresh
+                fetch_feature_inputs
+                >> engineer_feature_set
+                >> validate_feature_set
+                >> store_feature_set
                 >> retraining_gate
                 >> train_model
                 >> evaluate_model_task
                 >> register_model_task
+            )
+
+        else:
+            (
+                fetch_feature_inputs
+                >> engineer_feature_set
+                >> validate_feature_set
+                >> store_feature_set
             )

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -4,9 +4,9 @@ FoehnCast has two hosted targets: a hosted full-stack target on one GCP host and
 
 !!! note "What this page does and does not claim"
 
-    The shared GCP baseline and the hosted entry points exist today.
-    Not every longer-term managed service is finished yet, so this page distinguishes between what is implemented now and what remains a transition target.
-    The current shared environment uses the hosted full-stack target. The inference-only Cloud Run path is implemented, but it is not the active shared deployment surface today.
+    The shared GCP baseline and the hosted entry points already exist.
+    Some longer-term managed services are still future work.
+    The current shared environment uses the hosted full-stack target. The inference-only Cloud Run path exists, but it is not the active shared deployment path today.
 
 ## Cloud Paths In One View
 
@@ -22,11 +22,11 @@ FoehnCast has two hosted targets: a hosted full-stack target on one GCP host and
 </li>
 <li>
 <p><strong>Hosted inference target</strong></p>
-<p>The FastAPI inference service can also be deployed as an inference-only Cloud Run surface.</p>
+<p>The FastAPI inference service can also run as an inference-only Cloud Run target.</p>
 </li>
 <li>
 <p><strong>Managed direction</strong></p>
-<p>Later milestones can replace parts of the host-based path with more managed orchestration and monitoring services.</p>
+<p>Future work can replace parts of the host-based path with more managed services.</p>
 </li>
 </ul>
 </div>
@@ -58,15 +58,15 @@ flowchart LR
 
 | Surface | Deploys | Leaves out | Current state |
 |--------|---------|------------|---------------|
-| Shared GCP baseline | APIs, Artifact Registry, GCS, BigQuery, Datastore, and OIDC identities | app containers | implemented as Terraform inputs and resources |
-| Hosted full-stack target | Airflow, MLflow, and the API on one Compute Engine host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented as a Terraform path and active in the shared environment |
-| Hosted inference target | the FastAPI inference API on Cloud Run | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented as a Terraform and image-delivery path, currently disabled in the shared environment |
+| Shared GCP baseline | APIs, Artifact Registry, GCS, BigQuery, Datastore, and OIDC identities | app containers | implemented through Terraform |
+| Hosted full-stack target | Airflow, MLflow, and the API on one Compute Engine host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented and active in the shared environment |
+| Hosted inference target | the FastAPI inference API on Cloud Run | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented, but not active in the shared environment |
 | GitHub delivery | image publishing and remote Terraform runs | runtime services | implemented and bootstrapped for the shared environment |
+| BigQuery backend support | support for a BigQuery storage backend in the app | none | available in both local and hosted runtimes |
 
 The hosted paths deploy runtime services only. Development assets stay local or CI-only.
-| BigQuery backend support | implemented in the application | local and hosted runtimes can point the storage backend at BigQuery |
 
-Today the shared environment uses the hosted full-stack target because it keeps Airflow and MLflow co-located with the API. The Cloud Run path remains the smaller optional API-only surface for a later or separate deployment slice.
+The shared environment uses the hosted full-stack target because it keeps Airflow, MLflow, and the API together. The Cloud Run path stays available as a smaller API-only option.
 
 ## Honest Mapping From Local To Cloud
 
@@ -106,7 +106,7 @@ flowchart TD
 
 ## Storage Layering In Cloud
 
-The current cloud direction works best when storage is split by role rather than by forcing every layer into one system.
+The current cloud design works best when storage is split by role instead of forcing every layer into one system.
 
 | Data role | Recommended cloud surface | Why |
 |----------|---------------------------|-----|
@@ -115,11 +115,11 @@ The current cloud direction works best when storage is split by role rather than
 | Feast registry and staging | GCS | metadata and staging artifacts fit object storage better than warehouse tables |
 | Feast offline source | BigQuery table or view | same curated layer used by analytics and training |
 
-External tables still have a place for raw or staging access, but they are not the preferred primary store for repeatedly queried curated features.
+External tables still make sense for raw or staging access, but they are not the preferred main store for curated features that are queried often.
 
 ## Cloud Storage Control Surface
 
-The cloud path stays coherent because it is driven by explicit application and infrastructure surfaces rather than by a vague translation of the local setup.
+The cloud path stays clear because it is built from explicit application and infrastructure surfaces, not from a loose translation of the local setup.
 
 | Surface | Cloud-facing implementation | Why it matters |
 |------|-----------------------------|----------------|
@@ -133,7 +133,7 @@ The cloud path stays coherent because it is driven by explicit application and i
 | Terraform baseline | Terraform-managed GCS, BigQuery, and Datastore-mode Firestore surfaces | supplies the bucket and warehouse baseline without taking ownership of feature semantics |
 | Local object-store baseline | S3-compatible backend plus the bundled MinIO service back the local operator path | keeps the local object-access layer aligned with the cloud bucket/artifact pattern |
 
-In practical terms, GCS owns raw landing and registry-style metadata for the cloud path, BigQuery owns the curated analytical layer for the cloud path, and Feast reads the curated layer instead of redefining it. The local path uses the bundled MinIO surface as its default object-access layer while keeping the hosted-only BigQuery and Datastore roles separate.
+In practice, GCS stores raw landing data and registry-style metadata for the cloud path. BigQuery stores the curated analytical layer. Feast reads that curated layer instead of creating a separate one. The local path uses the bundled MinIO service as its default object-access layer, while BigQuery and Datastore stay hosted-only surfaces.
 
 ## Runtime Differences That Matter
 
@@ -155,12 +155,12 @@ In practical terms, GCS owns raw landing and registry-style metadata for the clo
 ## Current Gaps
 
 - The current online path still keeps MLflow on the compose host rather than a separate managed service.
-- Managed Airflow provisioning and DAG deployment are not yet fully automated in the same way as the local stack.
-- Monitoring is still lighter than the final MS4 target.
+- Airflow is still running on the host, not in a managed Composer-style service. The hosted compose path does keep the repo in sync, write the last successful refresh to the host, and show that timestamp in Prometheus and Grafana.
+- Monitoring is still lighter than the long-term target.
 - The two hosted paths solve different needs today: one keeps the full stack online, the other isolates inference as a service.
 
 ## Why This Fits The Project Brief
 
-The project brief asks for cloud-ready pipelines and cloud orchestration. This mapping keeps the backend already validated in MS2, but replaces the local support stack with cloud services that can run autonomously after deployment.
+The goal is cloud-ready pipelines and cloud orchestration. This mapping keeps the validated backend design, but replaces the local support stack with cloud services that can run after deployment.
 
 See [Architecture](architecture.md) for the current runtime view. The repository root also includes a Terraform README with the deployment details.

--- a/grafana_work/dashboards/foehncast-overview.json
+++ b/grafana_work/dashboards/foehncast-overview.json
@@ -136,6 +136,169 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 0,
+        "y": 38
+      },
+      "id": 15,
+      "targets": [
+        {
+          "expr": "sum by (dataset, storage_backend) (foehncast_feature_pipeline_engineered_spot_count)",
+          "legendFormat": "{{dataset}} / {{storage_backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Engineered Spots",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 6,
+        "w": 12,
+        "x": 12,
+        "y": 38
+      },
+      "id": 16,
+      "targets": [
+        {
+          "expr": "sum by (dataset, storage_backend) (foehncast_feature_pipeline_validated_spot_count)",
+          "legendFormat": "{{dataset}} / {{storage_backend}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Validated Spots",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 44
+      },
+      "id": 17,
+      "targets": [
+        {
+          "expr": "max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_duration_seconds)",
+          "legendFormat": "{{dataset}} / {{storage_backend}} / {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Feature Stage Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 0.5
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 52
+      },
+      "id": 18,
+      "targets": [
+        {
+          "expr": "max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_failure_count)",
+          "legendFormat": "{{dataset}} / {{storage_backend}} / {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Feature Stage Failures",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 60
+      },
+      "id": 19,
+      "targets": [
+        {
+          "expr": "time() - max by (git_ref, compose_deploy_mode) (foehncast_online_compose_sync_last_success_timestamp_seconds)",
+          "legendFormat": "{{git_ref}} / {{compose_deploy_mode}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Seconds Since Last Hosted Sync",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
       "fieldConfig": {
         "defaults": {
           "color": {
@@ -448,6 +611,6 @@
   "timezone": "browser",
   "title": "FoehnCast Monitoring",
   "uid": "foehncast-monitoring",
-  "version": 5,
+  "version": 9,
   "weekStart": ""
 }

--- a/grafana_work/etc/provisioning/alerting/foehncast-alert-rules.yml
+++ b/grafana_work/etc/provisioning/alerting/foehncast-alert-rules.yml
@@ -203,7 +203,7 @@ groups:
               expr: '((time() - max by (endpoint) (foehncast_prediction_monitoring_last_execution_timestamp_seconds{result="succeeded"})) * on (endpoint) (sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="scheduled"}[15m])) > bool 0))'
               instant: true
               intervalMs: 1000
-              legendFormat: '{{endpoint}}'
+              legendFormat: "{{endpoint}}"
               maxDataPoints: 43200
               range: false
               refId: A
@@ -211,7 +211,7 @@ groups:
             relativeTimeRange:
               from: 900
               to: 0
-            datasourceUid: '__expr__'
+            datasourceUid: "__expr__"
             model:
               conditions:
                 - evaluator:
@@ -228,7 +228,7 @@ groups:
                   type: query
               datasource:
                 type: __expr__
-                uid: '__expr__'
+                uid: "__expr__"
               expression: A
               intervalMs: 1000
               maxDataPoints: 43200
@@ -239,7 +239,7 @@ groups:
             relativeTimeRange:
               from: 900
               to: 0
-            datasourceUid: '__expr__'
+            datasourceUid: "__expr__"
             model:
               conditions:
                 - evaluator:
@@ -257,7 +257,7 @@ groups:
                   type: query
               datasource:
                 type: __expr__
-                uid: '__expr__'
+                uid: "__expr__"
               expression: B
               intervalMs: 1000
               maxDataPoints: 43200
@@ -270,9 +270,189 @@ groups:
         for: 0s
         annotations:
           __dashboardUid__: foehncast-monitoring
-          __panelId__: '14'
+          __panelId__: "14"
           summary: Prediction monitoring has been active without a successful background execution for more than 15 minutes.
         labels:
           component: inference-monitoring
+          severity: warning
+        isPaused: false
+      - uid: foehncast_feature_stage_failures
+        title: FoehnCast Feature Stage Failures
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: "max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_failure_count)"
+              instant: true
+              intervalMs: 1000
+              legendFormat: "{{dataset}} / {{storage_backend}} / {{stage}}"
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: "__expr__"
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 0
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: "__expr__"
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: foehncast-monitoring
+        panelId: 18
+        noDataState: OK
+        execErrState: Error
+        for: 0s
+        annotations:
+          __dashboardUid__: foehncast-monitoring
+          __panelId__: "18"
+          summary: The latest feature-pipeline summary reports a failing stage.
+        labels:
+          component: feature-pipeline
+          severity: warning
+        isPaused: false
+      - uid: foehncast_hosted_sync_stale
+        title: FoehnCast Hosted Sync Stale
+        condition: C
+        data:
+          - refId: A
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: prometheus
+            model:
+              datasource:
+                type: prometheus
+                uid: prometheus
+              editorMode: code
+              expr: "time() - max by (git_ref, compose_deploy_mode) (foehncast_online_compose_sync_last_success_timestamp_seconds)"
+              instant: true
+              intervalMs: 1000
+              legendFormat: "{{git_ref}} / {{compose_deploy_mode}}"
+              maxDataPoints: 43200
+              range: false
+              refId: A
+          - refId: B
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              conditions:
+                - evaluator:
+                    params: []
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - B
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: "__expr__"
+              expression: A
+              intervalMs: 1000
+              maxDataPoints: 43200
+              reducer: last
+              refId: B
+              type: reduce
+          - refId: C
+            relativeTimeRange:
+              from: 900
+              to: 0
+            datasourceUid: "__expr__"
+            model:
+              conditions:
+                - evaluator:
+                    params:
+                      - 900
+                    type: gt
+                  operator:
+                    type: and
+                  query:
+                    params:
+                      - C
+                  reducer:
+                    params: []
+                    type: last
+                  type: query
+              datasource:
+                type: __expr__
+                uid: "__expr__"
+              expression: B
+              intervalMs: 1000
+              maxDataPoints: 43200
+              refId: C
+              type: threshold
+        dashboardUid: foehncast-monitoring
+        panelId: 19
+        noDataState: OK
+        execErrState: Error
+        for: 0s
+        annotations:
+          __dashboardUid__: foehncast-monitoring
+          __panelId__: "19"
+          summary: The hosted compose sync has not reported a successful refresh for more than 15 minutes.
+        labels:
+          component: hosted-operator
           severity: warning
         isPaused: false

--- a/grafana_work/etc/provisioning/alerting/foehncast-notification-policies.yml
+++ b/grafana_work/etc/provisioning/alerting/foehncast-notification-policies.yml
@@ -20,3 +20,26 @@ policies:
         group_wait: 0s
         group_interval: 15m
         repeat_interval: 4h
+      - receiver: foehncast-email
+        object_matchers:
+          - [component, "=", feature-pipeline]
+        group_by:
+          - alertname
+          - dataset
+          - storage_backend
+          - stage
+          - severity
+        group_wait: 0s
+        group_interval: 15m
+        repeat_interval: 4h
+      - receiver: foehncast-email
+        object_matchers:
+          - [component, "=", hosted-operator]
+        group_by:
+          - alertname
+          - git_ref
+          - compose_deploy_mode
+          - severity
+        group_wait: 0s
+        group_interval: 15m
+        repeat_interval: 4h

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -28,6 +28,18 @@ usage() {
   echo "Maintainer-only cloud bootstrap. Supported no-local-install path: run this from Google Cloud Shell." >&2
 }
 
+require_payload_pattern() {
+  local payload="$1"
+  local pattern="$2"
+  local description="$3"
+
+  if ! printf '%s' "$payload" | grep -Eq "$pattern"; then
+    echo "Hosted bootstrap verification failed: expected ${description}." >&2
+    printf '%s\n' "$payload" >&2
+    exit 1
+  fi
+}
+
 in_cloud_shell() {
   [[ -n "${CLOUD_SHELL:-}" || -n "${DEVSHELL_PROJECT_ID:-}" ]]
 }
@@ -220,6 +232,73 @@ read_tfvars_value() {
     echo "Hosted Feast offline source table: ${feast_bigquery_table}"
     echo "Hosted Feast online store database: ${FOEHNCAST_TF_FEAST_ONLINE_STORE_DATABASE}"
     echo "After curated BigQuery rows are available, run ./scripts/prepare-feast-cloud.sh to apply the Feast repo and materialize the hosted online store."
+  }
+
+  print_online_compose_summary() {
+    local host_ip app_url airflow_url mlflow_url
+
+    FOEHNCAST_TERRAFORM_TFVARS_FILE="$TFVARS_FILE" load_terraform_platform_state "$TERRAFORM_DIR"
+
+    if [[ "$FOEHNCAST_TF_PROVISION_ONLINE_COMPOSE_HOST" != "true" ]]; then
+      return
+    fi
+
+    host_ip="$(optional_terraform_output_value "$TERRAFORM_DIR" online_compose_host_ip)"
+    host_ip="$(trim_whitespace "$host_ip")"
+    app_url="$(optional_terraform_output_value "$TERRAFORM_DIR" online_compose_app_url)"
+    app_url="$(trim_whitespace "$app_url")"
+    airflow_url="$(optional_terraform_output_value "$TERRAFORM_DIR" online_compose_airflow_url)"
+    airflow_url="$(trim_whitespace "$airflow_url")"
+    mlflow_url="$(optional_terraform_output_value "$TERRAFORM_DIR" online_compose_mlflow_url)"
+    mlflow_url="$(trim_whitespace "$mlflow_url")"
+
+    if [[ -n "$host_ip" && "$host_ip" != "null" ]]; then
+      echo "Online compose host IP: ${host_ip}"
+    fi
+    if [[ -n "$app_url" && "$app_url" != "null" ]]; then
+      echo "Online compose app URL: ${app_url}"
+    fi
+    if [[ -n "$airflow_url" && "$airflow_url" != "null" ]]; then
+      echo "Online compose Airflow URL: ${airflow_url}"
+    fi
+    if [[ -n "$mlflow_url" && "$mlflow_url" != "null" ]]; then
+      echo "Online compose MLflow URL: ${mlflow_url}"
+    fi
+  }
+
+  verify_online_compose_runtime() {
+    local app_url health_url metrics_url metrics_payload
+
+    FOEHNCAST_TERRAFORM_TFVARS_FILE="$TFVARS_FILE" load_terraform_platform_state "$TERRAFORM_DIR"
+
+    if [[ "$FOEHNCAST_TF_PROVISION_ONLINE_COMPOSE_HOST" != "true" ]]; then
+      return
+    fi
+
+    app_url="$(optional_terraform_output_value "$TERRAFORM_DIR" online_compose_app_url)"
+    app_url="$(trim_whitespace "$app_url")"
+
+    if [[ -z "$app_url" || "$app_url" == "null" ]]; then
+      echo "Hosted online compose app URL is not publicly exposed; skipping hosted runtime verification."
+      return
+    fi
+
+    health_url="${app_url%/}/health"
+    metrics_url="${app_url%/}/metrics"
+
+    echo "Waiting for hosted app health at ${health_url}..."
+    curl --retry 90 --retry-all-errors --retry-delay 10 -fsS "$health_url" >/dev/null
+
+    echo "Checking hosted sync metrics at ${metrics_url}..."
+    metrics_payload="$(curl --retry 30 --retry-all-errors --retry-delay 10 -fsS "$metrics_url")"
+    require_payload_pattern \
+      "$metrics_payload" \
+      'foehncast_online_compose_sync_status_file_present[[:space:]]+1(\.0)?' \
+      'hosted sync status-file-present metric'
+    require_payload_pattern \
+      "$metrics_payload" \
+      'foehncast_online_compose_sync_last_success_timestamp_seconds\{' \
+      'hosted sync last-success timestamp metric'
   }
 
   print_bootstrap_only_summary() {
@@ -666,6 +745,7 @@ print_bootstrap_context
 
 require_command gcloud
 ensure_terraform_command
+require_command curl
 
 if [[ "$CONFIGURE_GITHUB" == "true" ]]; then
   require_command gh
@@ -748,7 +828,9 @@ else
     echo "Syncing local cloud identifiers into .env..."
     sync_env_from_terraform_outputs
     print_auth_summary
+    print_online_compose_summary
     print_feast_runtime_summary
+    verify_online_compose_runtime
   fi
 fi
 

--- a/scripts/bootstrap-local.sh
+++ b/scripts/bootstrap-local.sh
@@ -9,6 +9,7 @@ FEATURE_DATE="${FEATURE_DATE:-2024-01-01}"
 TRAINING_DATE="${TRAINING_DATE:-2024-01-02}"
 AIRFLOW_HEALTH_URL="${AIRFLOW_HEALTH_URL:-http://127.0.0.1:8080/api/v2/monitor/health}"
 APP_HEALTH_URL="${APP_HEALTH_URL:-http://127.0.0.1:8000/health}"
+APP_METRICS_URL="${APP_METRICS_URL:-http://127.0.0.1:8000/metrics}"
 ONLINE_FEATURES_URL="${ONLINE_FEATURES_URL:-http://127.0.0.1:8000/features/online}"
 GRAFANA_BASE_URL="${GRAFANA_BASE_URL:-http://127.0.0.1:3000}"
 GRAFANA_HEALTH_URL="${GRAFANA_HEALTH_URL:-${GRAFANA_BASE_URL}/api/health}"
@@ -193,8 +194,20 @@ cleanup_local_runtime_state() {
   rm -rf "$ROOT_DIR/airflow/reports"
   rm -rf "$ROOT_DIR/.state/feast"
   rm -rf "$ROOT_DIR/.state/monitoring"
+  rm -rf "$ROOT_DIR/.state/online-compose-sync"
   rm -rf "$ROOT_DIR/data/$dataset"
   rm -f "$ROOT_DIR/data/feast/$dataset.parquet"
+}
+
+seed_local_online_compose_sync_status() {
+  local sync_dir="$ROOT_DIR/.state/online-compose-sync"
+  local sync_status_file="$sync_dir/last-success.json"
+  local sync_time
+
+  sync_time="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  mkdir -p "$sync_dir"
+  printf '{\n  "state": "succeeded",\n  "git_ref": "local-bootstrap",\n  "last_successful_sync_at": "%s",\n  "last_successful_commit": "local-smoke",\n  "compose_deploy_mode": "bootstrap"\n}\n' \
+    "$sync_time" > "$sync_status_file"
 }
 
 wait_for_service_health() {
@@ -271,6 +284,14 @@ verify_grafana_provisioning() {
     "$alert_rules_payload" \
     '"uid"[[:space:]]*:[[:space:]]*"foehncast_predmon_stale_success"' \
     'stale success alert rule'
+  require_payload_pattern \
+    "$alert_rules_payload" \
+    '"uid"[[:space:]]*:[[:space:]]*"foehncast_feature_stage_failures"' \
+    'feature stage failure alert rule'
+  require_payload_pattern \
+    "$alert_rules_payload" \
+    '"uid"[[:space:]]*:[[:space:]]*"foehncast_hosted_sync_stale"' \
+    'hosted sync stale alert rule'
 
   echo "Checking Grafana contact point provisioning..."
   contact_points_payload="$(grafana_api_get "/api/v1/provisioning/contact-points?name=foehncast-email")"
@@ -297,6 +318,29 @@ verify_grafana_provisioning() {
     "$policies_payload" \
     '"inference-monitoring"' \
     'notification policy inference-monitoring matcher'
+  require_payload_pattern \
+    "$policies_payload" \
+    '"feature-pipeline"' \
+    'notification policy feature-pipeline matcher'
+  require_payload_pattern \
+    "$policies_payload" \
+    '"hosted-operator"' \
+    'notification policy hosted-operator matcher'
+}
+
+verify_hosted_sync_metrics() {
+  local metrics_payload
+
+  echo "Checking hosted sync metrics exposure..."
+  metrics_payload="$(curl --retry 60 --retry-all-errors --retry-delay 2 -fsS "$APP_METRICS_URL")"
+  require_payload_pattern \
+    "$metrics_payload" \
+    'foehncast_online_compose_sync_status_file_present[[:space:]]+1(\.0)?' \
+    'hosted sync status-file-present metric'
+  require_payload_pattern \
+    "$metrics_payload" \
+    'foehncast_online_compose_sync_last_success_timestamp_seconds\{compose_deploy_mode="bootstrap",git_ref="local-bootstrap"\}[[:space:]]+[0-9.e+-]+' \
+    'hosted sync last-success timestamp metric'
 }
 
 RUN_MODE_LABEL="local MinIO-backed objectstore baseline"
@@ -361,6 +405,7 @@ echo "Resetting local stack state for a clean run..."
 compose down -v --remove-orphans >/dev/null 2>&1 || true
 echo "Removing disposable local runtime artifacts..."
 cleanup_local_runtime_state "$FEAST_DATASET"
+seed_local_online_compose_sync_status
 
 echo "Starting local stack..."
 compose up --build -d --remove-orphans "${BOOTSTRAP_SERVICES[@]}"
@@ -385,6 +430,7 @@ echo "Preparing Feast serving state for ${FEAST_DATASET}..."
 
 echo "Waiting for app health..."
 curl --retry 60 --retry-all-errors --retry-delay 2 -fsS "$APP_HEALTH_URL" >/dev/null
+verify_hosted_sync_metrics
 
 echo "Checking Feast online features..."
 curl --retry 30 --retry-all-errors --retry-delay 2 -fsS \

--- a/src/foehncast/inference_pipeline/serve.py
+++ b/src/foehncast/inference_pipeline/serve.py
@@ -24,6 +24,9 @@ from foehncast.monitoring.pipeline_prometheus import (
     CONTENT_TYPE_LATEST,
     render_feature_pipeline_prometheus_metrics,
 )
+from foehncast.monitoring.online_compose_sync_prometheus import (
+    render_online_compose_sync_prometheus_metrics,
+)
 from foehncast.monitoring.prediction_monitoring_prometheus import (
     record_prediction_monitoring_execution,
     record_prediction_monitoring_schedule,
@@ -108,6 +111,7 @@ def _metrics_payload() -> bytes:
         render_feature_pipeline_prometheus_metrics()
         + render_prediction_log_prometheus_metrics()
         + render_prediction_monitoring_prometheus_metrics()
+        + render_online_compose_sync_prometheus_metrics()
     )
 
 

--- a/src/foehncast/monitoring/__init__.py
+++ b/src/foehncast/monitoring/__init__.py
@@ -7,6 +7,11 @@ from foehncast.monitoring.drift import (
     detect_prediction_drift,
     push_drift_metrics,
 )
+from foehncast.monitoring.online_compose_sync_prometheus import (
+    build_online_compose_sync_prometheus_registry,
+    read_online_compose_sync_status,
+    render_online_compose_sync_prometheus_metrics,
+)
 from foehncast.monitoring.pipeline_metrics import (
     FEATURE_PIPELINE_METRIC_CONTRACT,
     emit_feature_pipeline_run_summary,
@@ -30,6 +35,7 @@ __all__ = [
     "FEATURE_PIPELINE_METRIC_CONTRACT",
     "append_prediction_log",
     "build_prediction_log_prometheus_registry",
+    "build_online_compose_sync_prometheus_registry",
     "detect_data_drift",
     "detect_prediction_drift",
     "emit_prediction_drift_metrics",
@@ -37,7 +43,9 @@ __all__ = [
     "feature_pipeline_stage_overview",
     "feature_pipeline_summary_path",
     "push_drift_metrics",
+    "read_online_compose_sync_status",
     "read_prediction_log",
     "read_feature_pipeline_run_summary",
+    "render_online_compose_sync_prometheus_metrics",
     "render_prediction_log_prometheus_metrics",
 ]

--- a/src/foehncast/monitoring/online_compose_sync_prometheus.py
+++ b/src/foehncast/monitoring/online_compose_sync_prometheus.py
@@ -1,0 +1,90 @@
+"""Prometheus export helpers for the hosted online-compose sync status file."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import json
+from pathlib import Path
+from typing import Any
+
+from prometheus_client import CollectorRegistry, Gauge, generate_latest
+
+from foehncast.paths import project_root
+
+
+def _default_online_compose_sync_status_path() -> Path:
+    return project_root() / ".state" / "online-compose-sync" / "last-success.json"
+
+
+def read_online_compose_sync_status(
+    status_path: Path | None = None,
+) -> dict[str, Any] | None:
+    """Load the latest hosted compose sync status if the file exists."""
+    resolved_path = (
+        _default_online_compose_sync_status_path()
+        if status_path is None
+        else status_path
+    )
+    if not resolved_path.exists():
+        return None
+    return json.loads(resolved_path.read_text())
+
+
+def _timestamp_seconds(value: Any) -> float | None:
+    if value in (None, ""):
+        return None
+    text = str(value)
+    normalized = text[:-1] + "+00:00" if text.endswith("Z") else text
+    try:
+        return float(datetime.fromisoformat(normalized).timestamp())
+    except ValueError:
+        return None
+
+
+def build_online_compose_sync_prometheus_registry(
+    status: dict[str, Any] | None = None,
+) -> CollectorRegistry:
+    """Render the hosted compose sync status file into a scrapeable registry."""
+    resolved_status = read_online_compose_sync_status() if status is None else status
+    registry = CollectorRegistry()
+
+    status_file_present = Gauge(
+        "foehncast_online_compose_sync_status_file_present",
+        "Whether the hosted online-compose sync status file is available.",
+        registry=registry,
+    )
+    status_file_present.set(float(resolved_status is not None))
+
+    last_success_timestamp = Gauge(
+        "foehncast_online_compose_sync_last_success_timestamp_seconds",
+        "Unix timestamp of the latest successful hosted online-compose sync.",
+        labelnames=("git_ref", "compose_deploy_mode"),
+        registry=registry,
+    )
+
+    if resolved_status is None:
+        return registry
+
+    timestamp = _timestamp_seconds(resolved_status.get("last_successful_sync_at"))
+    if timestamp is None:
+        return registry
+
+    git_ref = str(resolved_status.get("git_ref") or "unknown")
+    compose_deploy_mode = str(resolved_status.get("compose_deploy_mode") or "unknown")
+    last_success_timestamp.labels(git_ref, compose_deploy_mode).set(timestamp)
+    return registry
+
+
+def render_online_compose_sync_prometheus_metrics(
+    status: dict[str, Any] | None = None,
+) -> bytes:
+    """Return Prometheus exposition text for the hosted compose sync status."""
+    registry = build_online_compose_sync_prometheus_registry(status=status)
+    return generate_latest(registry)
+
+
+__all__ = [
+    "build_online_compose_sync_prometheus_registry",
+    "read_online_compose_sync_status",
+    "render_online_compose_sync_prometheus_metrics",
+]

--- a/src/foehncast/monitoring/pipeline_metrics.py
+++ b/src/foehncast/monitoring/pipeline_metrics.py
@@ -24,7 +24,11 @@ FEATURE_PIPELINE_METRIC_CONTRACT: dict[str, tuple[str, ...]] = {
         "storage_backend",
         "expected_spot_count",
         "fetched_spot_count",
+        "engineered_spot_count",
+        "validated_spot_count",
         "stored_spot_count",
+        "stage_durations_seconds",
+        "stage_failure_counts",
         "skipped_spot_count",
         "failed_spot_count",
     ),
@@ -267,7 +271,11 @@ def build_feature_pipeline_run_summary(
     storage_backend: str,
     expected_spots: list[str],
     fetched_spots: list[str],
+    engineered_spots: list[str],
+    validated_spots: list[str],
     stored_spots: list[str],
+    stage_durations_seconds: dict[str, float] | None,
+    stage_failure_counts: dict[str, int] | None,
     spot_summaries: list[dict[str, Any]],
     run_status: str,
     error: str | None = None,
@@ -282,10 +290,22 @@ def build_feature_pipeline_run_summary(
         "storage_backend": storage_backend,
         "expected_spots": expected_spots,
         "fetched_spots": fetched_spots,
+        "engineered_spots": engineered_spots,
+        "validated_spots": validated_spots,
         "stored_spots": stored_spots,
         "expected_spot_count": int(len(expected_spots)),
         "fetched_spot_count": int(len(fetched_spots)),
+        "engineered_spot_count": int(len(engineered_spots)),
+        "validated_spot_count": int(len(validated_spots)),
         "stored_spot_count": int(len(stored_spots)),
+        "stage_durations_seconds": {
+            str(stage): float(duration)
+            for stage, duration in dict(stage_durations_seconds or {}).items()
+        },
+        "stage_failure_counts": {
+            str(stage): int(count)
+            for stage, count in dict(stage_failure_counts or {}).items()
+        },
         "skipped_spot_count": int(
             sum(summary["status"] == "skipped" for summary in spot_summaries)
         ),
@@ -362,10 +382,18 @@ def _summary_metrics(summary: dict[str, Any]) -> dict[str, float]:
     metrics = {
         "feature_expected_spot_count": float(summary["expected_spot_count"]),
         "feature_fetched_spot_count": float(summary["fetched_spot_count"]),
+        "feature_engineered_spot_count": float(summary["engineered_spot_count"]),
+        "feature_validated_spot_count": float(summary["validated_spot_count"]),
         "feature_stored_spot_count": float(summary["stored_spot_count"]),
         "feature_skipped_spot_count": float(summary["skipped_spot_count"]),
         "feature_failed_spot_count": float(summary["failed_spot_count"]),
     }
+
+    for stage, duration in dict(summary.get("stage_durations_seconds", {})).items():
+        metrics[f"feature_{stage}_duration_seconds"] = float(duration)
+
+    for stage, count in dict(summary.get("stage_failure_counts", {})).items():
+        metrics[f"feature_{stage}_failure_count"] = float(count)
 
     for spot_summary in summary.get("spots", []):
         prefix = f"feature_{spot_summary['spot_id']}"

--- a/src/foehncast/monitoring/pipeline_prometheus.py
+++ b/src/foehncast/monitoring/pipeline_prometheus.py
@@ -57,6 +57,30 @@ def build_feature_pipeline_prometheus_registry(
         labelnames=("dataset", "storage_backend"),
         registry=registry,
     )
+    engineered_spots = Gauge(
+        "foehncast_feature_pipeline_engineered_spot_count",
+        "Engineered spot count for the latest feature-pipeline summary.",
+        labelnames=("dataset", "storage_backend"),
+        registry=registry,
+    )
+    validated_spots = Gauge(
+        "foehncast_feature_pipeline_validated_spot_count",
+        "Validated spot count for the latest feature-pipeline summary.",
+        labelnames=("dataset", "storage_backend"),
+        registry=registry,
+    )
+    stage_duration = Gauge(
+        "foehncast_feature_pipeline_stage_duration_seconds",
+        "Stage duration in seconds for the latest feature-pipeline summary.",
+        labelnames=("dataset", "storage_backend", "stage"),
+        registry=registry,
+    )
+    stage_failure_count = Gauge(
+        "foehncast_feature_pipeline_stage_failure_count",
+        "Stage failure count for the latest feature-pipeline summary.",
+        labelnames=("dataset", "storage_backend", "stage"),
+        registry=registry,
+    )
     stored_spots = Gauge(
         "foehncast_feature_pipeline_stored_spot_count",
         "Stored spot count for the latest feature-pipeline summary.",
@@ -150,6 +174,20 @@ def build_feature_pipeline_prometheus_registry(
         fetched_spots.labels(*run_labels).set(
             float(summary.get("fetched_spot_count", 0))
         )
+        engineered_spots.labels(*run_labels).set(
+            float(summary.get("engineered_spot_count", 0))
+        )
+        validated_spots.labels(*run_labels).set(
+            float(summary.get("validated_spot_count", 0))
+        )
+        for stage, duration in dict(summary.get("stage_durations_seconds", {})).items():
+            stage_duration.labels(dataset, storage_backend, str(stage)).set(
+                float(duration)
+            )
+        for stage, count in dict(summary.get("stage_failure_counts", {})).items():
+            stage_failure_count.labels(dataset, storage_backend, str(stage)).set(
+                float(count)
+            )
         stored_spots.labels(*run_labels).set(float(summary.get("stored_spot_count", 0)))
         skipped_spots.labels(*run_labels).set(
             float(summary.get("skipped_spot_count", 0))

--- a/src/foehncast/orchestration.py
+++ b/src/foehncast/orchestration.py
@@ -2,8 +2,16 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime
+import json
 import logging
 import os
+from pathlib import Path
+import re
+import shutil
+from time import perf_counter
+from types import SimpleNamespace
+from typing import Any
 
 import mlflow
 import pandas as pd
@@ -29,6 +37,600 @@ from foehncast.training_pipeline.evaluate import generate_evaluation_report
 from foehncast.training_pipeline.register import promote_model, register_model
 
 logger = logging.getLogger(__name__)
+
+_FEATURE_PIPELINE_STAGES = ("fetch", "engineer", "validate", "store")
+
+
+def _feature_pipeline_state_root() -> Path:
+    return project_root() / ".state" / "airflow" / "feature-pipeline"
+
+
+def _sanitize_feature_pipeline_run_key(run_key: str | None = None) -> str:
+    candidate = (run_key or datetime.now(tz=UTC).strftime("%Y%m%dT%H%M%S%fZ")).strip()
+    normalized = re.sub(r"[^A-Za-z0-9._-]+", "-", candidate).strip(".-")
+    return normalized or "manual"
+
+
+def _feature_pipeline_run_dir(dataset: str, run_key: str | None = None) -> Path:
+    return (
+        _feature_pipeline_state_root()
+        / dataset
+        / _sanitize_feature_pipeline_run_key(run_key)
+    )
+
+
+def _feature_pipeline_stage_path(run_dir: Path, stage: str, spot_id: str) -> Path:
+    return run_dir / stage / f"{spot_id}.pkl"
+
+
+def _feature_pipeline_validation_path(run_dir: Path, spot_id: str) -> Path:
+    return run_dir / "validation" / f"{spot_id}.json"
+
+
+def _write_feature_pipeline_frame(destination: Path, frame: pd.DataFrame) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    frame.to_pickle(destination)
+
+
+def _read_feature_pipeline_frame(source: Path) -> pd.DataFrame:
+    return pd.read_pickle(source)
+
+
+def _read_optional_feature_pipeline_frame(source: Path) -> pd.DataFrame:
+    if not source.exists():
+        return pd.DataFrame()
+    return _read_feature_pipeline_frame(source)
+
+
+def _write_feature_pipeline_validation(
+    destination: Path,
+    validation: Any,
+) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    range_violations = getattr(validation, "range_violations", None)
+    payload = {
+        "is_valid": bool(getattr(validation, "is_valid", False)),
+        "missing_columns": list(getattr(validation, "missing_columns", []) or []),
+        "null_fractions": dict(getattr(validation, "null_fractions", {}) or {}),
+        "range_violations": (
+            range_violations.to_dict(orient="records")
+            if isinstance(range_violations, pd.DataFrame)
+            else []
+        ),
+    }
+    destination.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")
+
+
+def _read_feature_pipeline_validation(source: Path) -> SimpleNamespace | None:
+    if not source.exists():
+        return None
+
+    payload = json.loads(source.read_text())
+    return SimpleNamespace(
+        is_valid=bool(payload.get("is_valid", False)),
+        missing_columns=list(payload.get("missing_columns", [])),
+        null_fractions=dict(payload.get("null_fractions", {})),
+        range_violations=pd.DataFrame(payload.get("range_violations", [])),
+    )
+
+
+def _copy_feature_pipeline_context(
+    feature_context: dict[str, object],
+) -> dict[str, object]:
+    context = dict(feature_context)
+
+    for key in (
+        "expected_spots",
+        "fetched_spots",
+        "engineered_spots",
+        "validated_spots",
+        "stored_spots",
+        "drifted_spots",
+    ):
+        context[key] = list(feature_context.get(key, []))
+
+    context["stage_durations_seconds"] = dict(
+        feature_context.get("stage_durations_seconds", {})
+    )
+    context["stage_failure_counts"] = dict(
+        feature_context.get("stage_failure_counts", {})
+    )
+    context["spot_config"] = dict(feature_context.get("spot_config", {}))
+    context["spot_errors"] = dict(feature_context.get("spot_errors", {}))
+    return context
+
+
+def _set_feature_pipeline_stage_duration(
+    feature_context: dict[str, object],
+    *,
+    stage: str,
+    started_at: float,
+) -> None:
+    durations = dict(feature_context.get("stage_durations_seconds", {}))
+    durations[str(stage)] = float(perf_counter() - started_at)
+    feature_context["stage_durations_seconds"] = durations
+
+
+def _increment_feature_pipeline_stage_failure(
+    feature_context: dict[str, object],
+    *,
+    stage: str,
+) -> None:
+    counts = {
+        known_stage: int(
+            dict(feature_context.get("stage_failure_counts", {})).get(known_stage, 0)
+        )
+        for known_stage in _FEATURE_PIPELINE_STAGES
+    }
+    counts[str(stage)] = int(counts.get(str(stage), 0)) + 1
+    feature_context["stage_failure_counts"] = counts
+
+
+def _feature_pipeline_context(
+    dataset: str = "train",
+    *,
+    run_key: str | None = None,
+) -> dict[str, object]:
+    spots = get_spots()
+    resolved_run_key = _sanitize_feature_pipeline_run_key(run_key)
+    run_dir = _feature_pipeline_run_dir(dataset, resolved_run_key)
+
+    return {
+        "dataset": dataset,
+        "run_key": resolved_run_key,
+        "run_dir": str(run_dir),
+        "storage_backend": get_storage_config()["backend"],
+        "expected_spots": [str(spot["id"]) for spot in spots],
+        "fetched_spots": [],
+        "engineered_spots": [],
+        "validated_spots": [],
+        "stored_spots": [],
+        "drifted_spots": [],
+        "stage_durations_seconds": {},
+        "stage_failure_counts": {stage: 0 for stage in _FEATURE_PIPELINE_STAGES},
+        "spot_errors": {},
+        "spot_config": {
+            str(spot["id"]): {
+                "shore_orientation_deg": spot["shore_orientation_deg"],
+            }
+            for spot in spots
+        },
+    }
+
+
+def _feature_pipeline_metric_count(
+    feature_result: dict[str, object],
+    *,
+    count_key: str,
+    items_key: str,
+) -> int | None:
+    if count_key in feature_result:
+        return int(feature_result[count_key])
+    if items_key in feature_result:
+        return int(len(feature_result.get(items_key, [])))
+    return None
+
+
+def _feature_pipeline_result(
+    feature_context: dict[str, object],
+) -> dict[str, object]:
+    context = _copy_feature_pipeline_context(feature_context)
+    expected_spots = list(context.get("expected_spots", []))
+    fetched_spots = list(context.get("fetched_spots", []))
+    engineered_spots = list(context.get("engineered_spots", []))
+    validated_spots = list(context.get("validated_spots", []))
+    stored_spots = list(context.get("stored_spots", []))
+    drifted_spots = list(context.get("drifted_spots", []))
+    stage_durations_seconds = dict(context.get("stage_durations_seconds", {}))
+    stage_failure_counts = {
+        str(stage): int(count)
+        for stage, count in dict(context.get("stage_failure_counts", {})).items()
+    }
+
+    return {
+        "dataset": context["dataset"],
+        "storage_backend": context["storage_backend"],
+        "expected_spots": expected_spots,
+        "fetched_spots": fetched_spots,
+        "engineered_spots": engineered_spots,
+        "validated_spots": validated_spots,
+        "stored_spots": stored_spots,
+        "drifted_spots": drifted_spots,
+        "expected_spot_count": len(expected_spots),
+        "fetched_spot_count": len(fetched_spots),
+        "engineered_spot_count": len(engineered_spots),
+        "validated_spot_count": len(validated_spots),
+        "stored_spot_count": len(stored_spots),
+        "drifted_spot_count": len(drifted_spots),
+        "stage_durations_seconds": stage_durations_seconds,
+        "stage_failure_counts": stage_failure_counts,
+        "dataset_drift_detected": bool(drifted_spots),
+    }
+
+
+def _emit_feature_pipeline_summary(
+    feature_context: dict[str, object],
+    *,
+    run_status: str,
+    error: str | None = None,
+) -> None:
+    context = _copy_feature_pipeline_context(feature_context)
+    run_dir = Path(str(context["run_dir"]))
+    fetched_spots = set(context.get("fetched_spots", []))
+    stored_spots = set(context.get("stored_spots", []))
+    spot_errors = dict(context.get("spot_errors", {}))
+    spot_summaries: list[dict[str, object]] = []
+
+    has_stage_artifacts = run_dir.exists() and any(run_dir.rglob("*"))
+
+    if (
+        run_status == "failed"
+        and not fetched_spots
+        and not spot_errors
+        and not has_stage_artifacts
+    ):
+        summary = build_feature_pipeline_run_summary(
+            dataset=str(context["dataset"]),
+            storage_backend=str(context["storage_backend"]),
+            expected_spots=list(context.get("expected_spots", [])),
+            fetched_spots=[],
+            engineered_spots=[],
+            validated_spots=[],
+            stored_spots=[],
+            stage_durations_seconds=dict(context.get("stage_durations_seconds", {})),
+            stage_failure_counts=dict(context.get("stage_failure_counts", {})),
+            spot_summaries=[],
+            run_status=run_status,
+            error=error,
+        )
+        emit_feature_pipeline_run_summary(summary)
+        return
+
+    for spot_id in context.get("expected_spots", []):
+        forecast_df = _read_optional_feature_pipeline_frame(
+            _feature_pipeline_stage_path(run_dir, "forecast", str(spot_id))
+        )
+        feature_df = _read_optional_feature_pipeline_frame(
+            _feature_pipeline_stage_path(run_dir, "feature", str(spot_id))
+        )
+        validation = _read_feature_pipeline_validation(
+            _feature_pipeline_validation_path(run_dir, str(spot_id))
+        )
+        stored_df = _read_optional_feature_pipeline_frame(
+            _feature_pipeline_stage_path(run_dir, "stored", str(spot_id))
+        )
+
+        status = "stored"
+        if str(spot_id) not in stored_spots:
+            status = "failed" if str(spot_id) in spot_errors else "skipped"
+
+        spot_summaries.append(
+            build_feature_pipeline_spot_summary(
+                spot_id=str(spot_id),
+                forecast_df=forecast_df,
+                feature_df=feature_df,
+                validation=validation,
+                stored_df=stored_df,
+                status=status,
+                error=spot_errors.get(str(spot_id)),
+            )
+        )
+
+    summary = build_feature_pipeline_run_summary(
+        dataset=str(context["dataset"]),
+        storage_backend=str(context["storage_backend"]),
+        expected_spots=list(context.get("expected_spots", [])),
+        fetched_spots=[str(spot_id) for spot_id in context.get("fetched_spots", [])],
+        engineered_spots=[
+            str(spot_id) for spot_id in context.get("engineered_spots", [])
+        ],
+        validated_spots=[
+            str(spot_id) for spot_id in context.get("validated_spots", [])
+        ],
+        stored_spots=[str(spot_id) for spot_id in context.get("stored_spots", [])],
+        stage_durations_seconds=dict(context.get("stage_durations_seconds", {})),
+        stage_failure_counts=dict(context.get("stage_failure_counts", {})),
+        spot_summaries=spot_summaries,
+        run_status=run_status,
+        error=error,
+    )
+    emit_feature_pipeline_run_summary(summary)
+
+
+def fetch_feature_pipeline_context(
+    dataset: str = "train",
+    run_key: str | None = None,
+) -> dict[str, object]:
+    """Fetch forecasts and persist them for downstream Airflow feature tasks."""
+    context = _feature_pipeline_context(dataset=dataset, run_key=run_key)
+    run_dir = Path(str(context["run_dir"]))
+    started_at = perf_counter()
+
+    if run_dir.exists():
+        shutil.rmtree(run_dir)
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        forecasts_by_spot = fetch_all_spots()
+        fetched_spots: list[str] = []
+
+        for spot_id in context["expected_spots"]:
+            forecast_df = forecasts_by_spot.get(str(spot_id), pd.DataFrame())
+            if forecast_df.empty:
+                continue
+
+            _write_feature_pipeline_frame(
+                _feature_pipeline_stage_path(run_dir, "forecast", str(spot_id)),
+                forecast_df,
+            )
+            fetched_spots.append(str(spot_id))
+
+        context["fetched_spots"] = fetched_spots
+        _set_feature_pipeline_stage_duration(
+            context,
+            stage="fetch",
+            started_at=started_at,
+        )
+        return context
+    except Exception as exc:
+        _increment_feature_pipeline_stage_failure(context, stage="fetch")
+        _set_feature_pipeline_stage_duration(
+            context,
+            stage="fetch",
+            started_at=started_at,
+        )
+        _emit_feature_pipeline_summary(context, run_status="failed", error=str(exc))
+        raise
+
+
+def engineer_feature_pipeline_context(
+    feature_context: dict[str, object],
+) -> dict[str, object]:
+    """Engineer features from fetched forecasts for downstream Airflow tasks."""
+    context = _copy_feature_pipeline_context(feature_context)
+    run_dir = Path(str(context["run_dir"]))
+    engineered_spots: list[str] = []
+    started_at = perf_counter()
+
+    try:
+        for spot_id in context.get("fetched_spots", []):
+            try:
+                forecast_df = _read_feature_pipeline_frame(
+                    _feature_pipeline_stage_path(run_dir, "forecast", str(spot_id))
+                )
+                feature_df = engineer_features(
+                    forecast_df,
+                    context["spot_config"][str(spot_id)]["shore_orientation_deg"],
+                )
+                _write_feature_pipeline_frame(
+                    _feature_pipeline_stage_path(run_dir, "feature", str(spot_id)),
+                    feature_df,
+                )
+                engineered_spots.append(str(spot_id))
+            except Exception as exc:
+                context["engineered_spots"] = engineered_spots
+                context["spot_errors"][str(spot_id)] = str(exc)
+                _increment_feature_pipeline_stage_failure(context, stage="engineer")
+                _set_feature_pipeline_stage_duration(
+                    context,
+                    stage="engineer",
+                    started_at=started_at,
+                )
+                _emit_feature_pipeline_summary(
+                    context,
+                    run_status="failed",
+                    error=str(exc),
+                )
+                raise
+
+        context["engineered_spots"] = engineered_spots
+        _set_feature_pipeline_stage_duration(
+            context,
+            stage="engineer",
+            started_at=started_at,
+        )
+        return context
+    except Exception:
+        raise
+
+
+def validate_feature_pipeline_context(
+    feature_context: dict[str, object],
+) -> dict[str, object]:
+    """Validate engineered features and persist validation outcomes."""
+    context = _copy_feature_pipeline_context(feature_context)
+    run_dir = Path(str(context["run_dir"]))
+    validated_spots: list[str] = []
+    started_at = perf_counter()
+
+    try:
+        for spot_id in context.get("engineered_spots", []):
+            try:
+                feature_df = _read_feature_pipeline_frame(
+                    _feature_pipeline_stage_path(run_dir, "feature", str(spot_id))
+                )
+                validation = run_validation(feature_df, str(spot_id))
+                _write_feature_pipeline_validation(
+                    _feature_pipeline_validation_path(run_dir, str(spot_id)),
+                    validation,
+                )
+                if not validation.is_valid:
+                    raise ValueError(f"Feature validation failed for spot '{spot_id}'")
+                validated_spots.append(str(spot_id))
+            except Exception as exc:
+                context["validated_spots"] = validated_spots
+                context["spot_errors"][str(spot_id)] = str(exc)
+                _increment_feature_pipeline_stage_failure(context, stage="validate")
+                _set_feature_pipeline_stage_duration(
+                    context,
+                    stage="validate",
+                    started_at=started_at,
+                )
+                _emit_feature_pipeline_summary(
+                    context,
+                    run_status="failed",
+                    error=str(exc),
+                )
+                raise
+
+        context["validated_spots"] = validated_spots
+        _set_feature_pipeline_stage_duration(
+            context,
+            stage="validate",
+            started_at=started_at,
+        )
+        return context
+    except Exception:
+        raise
+
+
+def store_feature_pipeline_context(
+    feature_context: dict[str, object],
+) -> dict[str, object]:
+    """Store validated features, emit drift metrics, and return retraining context."""
+    context = _copy_feature_pipeline_context(feature_context)
+    run_dir = Path(str(context["run_dir"]))
+    stored_spots: list[str] = []
+    drifted_spots: list[str] = []
+    started_at = perf_counter()
+
+    try:
+        for spot_id in context.get("validated_spots", []):
+            try:
+                feature_df = _read_feature_pipeline_frame(
+                    _feature_pipeline_stage_path(run_dir, "feature", str(spot_id))
+                )
+                previous_stored_df = _read_optional_feature_slice(
+                    str(spot_id),
+                    str(context["dataset"]),
+                )
+                write_features(
+                    feature_df,
+                    spot_id=str(spot_id),
+                    dataset=str(context["dataset"]),
+                )
+                stored_df = read_features(
+                    spot_id=str(spot_id),
+                    dataset=str(context["dataset"]),
+                )
+                _write_feature_pipeline_frame(
+                    _feature_pipeline_stage_path(run_dir, "stored", str(spot_id)),
+                    stored_df,
+                )
+
+                if _emit_feature_drift_metrics(
+                    spot_id=str(spot_id),
+                    dataset=str(context["dataset"]),
+                    reference_df=previous_stored_df,
+                    current_df=stored_df,
+                ):
+                    drifted_spots.append(str(spot_id))
+
+                stored_spots.append(str(spot_id))
+            except Exception as exc:
+                context["stored_spots"] = stored_spots
+                context["drifted_spots"] = drifted_spots
+                context["spot_errors"][str(spot_id)] = str(exc)
+                _increment_feature_pipeline_stage_failure(context, stage="store")
+                _set_feature_pipeline_stage_duration(
+                    context,
+                    stage="store",
+                    started_at=started_at,
+                )
+                _emit_feature_pipeline_summary(
+                    context,
+                    run_status="failed",
+                    error=str(exc),
+                )
+                raise
+
+        if not stored_spots:
+            context["stored_spots"] = []
+            context["drifted_spots"] = []
+            error = "No feature data was generated for any configured spot"
+            _increment_feature_pipeline_stage_failure(context, stage="store")
+            _set_feature_pipeline_stage_duration(
+                context,
+                stage="store",
+                started_at=started_at,
+            )
+            _emit_feature_pipeline_summary(
+                context,
+                run_status="failed",
+                error=error,
+            )
+            raise ValueError(error)
+
+        context["stored_spots"] = stored_spots
+        context["drifted_spots"] = drifted_spots
+        _set_feature_pipeline_stage_duration(
+            context,
+            stage="store",
+            started_at=started_at,
+        )
+        _emit_feature_pipeline_summary(context, run_status="succeeded")
+        return _feature_pipeline_result(context)
+    except Exception:
+        raise
+
+
+def _log_feature_pipeline_job_context(feature_result: dict[str, object]) -> None:
+    tracking_uri = _scheduled_mlflow_tracking_uri()
+    if tracking_uri is None:
+        return
+
+    mlflow.set_tracking_uri(tracking_uri)
+    mlflow.set_experiment(get_mlflow_config()["experiment_name"])
+
+    metrics: dict[str, float] = {}
+    for count_key, items_key in (
+        ("expected_spot_count", "expected_spots"),
+        ("fetched_spot_count", "fetched_spots"),
+        ("engineered_spot_count", "engineered_spots"),
+        ("validated_spot_count", "validated_spots"),
+        ("stored_spot_count", "stored_spots"),
+        ("drifted_spot_count", "drifted_spots"),
+    ):
+        count = _feature_pipeline_metric_count(
+            feature_result,
+            count_key=count_key,
+            items_key=items_key,
+        )
+        if count is not None:
+            metrics[count_key] = float(count)
+
+    for stage, duration in dict(
+        feature_result.get("stage_durations_seconds", {})
+    ).items():
+        metrics[f"{stage}_duration_seconds"] = float(duration)
+
+    for stage, count in dict(feature_result.get("stage_failure_counts", {})).items():
+        metrics[f"{stage}_failure_count"] = float(count)
+
+    metrics["dataset_drift_detected"] = float(
+        feature_result.get("dataset_drift_detected", False)
+    )
+
+    with mlflow.start_run(run_name=f"feature-{feature_result['dataset']}-refresh"):
+        mlflow.log_params(
+            {
+                "dataset": feature_result["dataset"],
+                "storage_backend": feature_result["storage_backend"],
+                "stored_spots": ",".join(feature_result.get("stored_spots", [])),
+                "drifted_spots": ",".join(feature_result.get("drifted_spots", [])),
+            }
+        )
+        for name, value in metrics.items():
+            mlflow.log_metric(name, value)
+
+
+def store_feature_pipeline_job_context(
+    feature_context: dict[str, object],
+) -> dict[str, object]:
+    """Store validated features and log the final Airflow-friendly refresh context."""
+    result = store_feature_pipeline_context(feature_context)
+    _log_feature_pipeline_job_context(result)
+    return result
 
 
 def _read_optional_feature_slice(spot_id: str, dataset: str) -> pd.DataFrame:
@@ -147,112 +749,10 @@ def should_auto_retrain(
 
 def _run_feature_pipeline_result(dataset: str = "train") -> dict[str, object]:
     """Run the feature pipeline and return stored spots plus retraining context."""
-    storage_backend = get_storage_config()["backend"]
-    spots = get_spots()
-    forecasts_by_spot: dict[str, pd.DataFrame] = {}
-    stored_spots: list[str] = []
-    drifted_spots: list[str] = []
-    spot_summaries: list[dict[str, object]] = []
-    run_error: str | None = None
-
-    try:
-        forecasts_by_spot = fetch_all_spots()
-
-        for spot in spots:
-            spot_id = spot["id"]
-            forecast_df = forecasts_by_spot.get(spot_id, pd.DataFrame())
-            if forecast_df.empty:
-                spot_summaries.append(
-                    build_feature_pipeline_spot_summary(
-                        spot_id=spot_id,
-                        forecast_df=forecast_df,
-                        status="skipped",
-                        error="No forecast data returned for this spot",
-                    )
-                )
-                continue
-
-            feature_df = pd.DataFrame()
-            previous_stored_df = _read_optional_feature_slice(spot_id, dataset)
-            validation = None
-            stored_df = pd.DataFrame()
-
-            try:
-                feature_df = engineer_features(
-                    forecast_df, spot["shore_orientation_deg"]
-                )
-                validation = run_validation(feature_df, spot_id)
-                if not validation.is_valid:
-                    raise ValueError(f"Feature validation failed for spot '{spot_id}'")
-
-                write_features(feature_df, spot_id=spot_id, dataset=dataset)
-                stored_df = read_features(spot_id=spot_id, dataset=dataset)
-                if _emit_feature_drift_metrics(
-                    spot_id=spot_id,
-                    dataset=dataset,
-                    reference_df=previous_stored_df,
-                    current_df=stored_df,
-                ):
-                    drifted_spots.append(spot_id)
-            except Exception as exc:
-                spot_summaries.append(
-                    build_feature_pipeline_spot_summary(
-                        spot_id=spot_id,
-                        forecast_df=forecast_df,
-                        feature_df=feature_df,
-                        validation=validation,
-                        stored_df=stored_df,
-                        status="failed",
-                        error=str(exc),
-                    )
-                )
-                raise
-
-            spot_summaries.append(
-                build_feature_pipeline_spot_summary(
-                    spot_id=spot_id,
-                    forecast_df=forecast_df,
-                    feature_df=feature_df,
-                    validation=validation,
-                    stored_df=stored_df,
-                    status="stored",
-                )
-            )
-            stored_spots.append(spot_id)
-
-        if not stored_spots:
-            raise ValueError("No feature data was generated for any configured spot")
-
-        return {
-            "dataset": dataset,
-            "storage_backend": storage_backend,
-            "stored_spots": stored_spots,
-            "drifted_spots": drifted_spots,
-            "dataset_drift_detected": bool(drifted_spots),
-        }
-    except Exception as exc:
-        run_error = str(exc)
-        raise
-    finally:
-        fetched_spots = [
-            spot["id"]
-            for spot in spots
-            if not forecasts_by_spot.get(spot["id"], pd.DataFrame()).empty
-        ]
-        summary = build_feature_pipeline_run_summary(
-            dataset=dataset,
-            storage_backend=storage_backend,
-            expected_spots=[spot["id"] for spot in spots],
-            fetched_spots=fetched_spots,
-            stored_spots=stored_spots,
-            spot_summaries=spot_summaries,
-            run_status="succeeded" if run_error is None else "failed",
-            error=run_error,
-        )
-        try:
-            emit_feature_pipeline_run_summary(summary)
-        except Exception:
-            logger.exception("Failed to emit feature pipeline run summary")
+    feature_context = fetch_feature_pipeline_context(dataset=dataset)
+    feature_context = engineer_feature_pipeline_context(feature_context)
+    feature_context = validate_feature_pipeline_context(feature_context)
+    return store_feature_pipeline_context(feature_context)
 
 
 def run_feature_pipeline(dataset: str = "train") -> list[str]:
@@ -290,28 +790,8 @@ def run_feature_pipeline_job(dataset: str = "train") -> list[str]:
 def run_feature_pipeline_job_context(dataset: str = "train") -> dict[str, object]:
     """Run the feature pipeline and return Airflow-friendly retraining context."""
     result = _run_feature_pipeline_result(dataset=dataset)
-    tracking_uri = _scheduled_mlflow_tracking_uri()
-    if tracking_uri is None:
-        return result
-
-    mlflow.set_tracking_uri(tracking_uri)
-    mlflow.set_experiment(get_mlflow_config()["experiment_name"])
-
-    with mlflow.start_run(run_name=f"feature-{dataset}-refresh"):
-        mlflow.log_params(
-            {
-                "dataset": dataset,
-                "storage_backend": result["storage_backend"],
-                "stored_spots": ",".join(result["stored_spots"]),
-                "drifted_spots": ",".join(result["drifted_spots"]),
-            }
-        )
-        mlflow.log_metric("stored_spot_count", len(result["stored_spots"]))
-        mlflow.log_metric("drifted_spot_count", len(result["drifted_spots"]))
-        mlflow.log_metric(
-            "dataset_drift_detected", float(result["dataset_drift_detected"])
-        )
-        return result
+    _log_feature_pipeline_job_context(result)
+    return result
 
 
 def evaluate_training_run(training_run_id: str, dataset: str = "train") -> str:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -79,17 +79,21 @@ When `provision_online_compose_host = true`, provide:
 
 If the hosted Grafana tenant should deliver the provisioned monitoring alerts by email, set `FOEHNCAST_GRAFANA_ALERT_EMAIL` in `online_compose_env_vars`. The local Docker path intentionally leaves that override out of `.env.example` and relies on the placeholder route instead.
 
-Terraform provisions a dedicated network, static public IP, and Compute Engine instance. The instance clones the repo, writes a runtime `.env` file with the Terraform-managed GCP and BigQuery settings, tries to pull the GHCR images, and falls back to local Docker builds on the host if the packages are not available yet.
-That generated `.env` now includes the same Feast runtime env contract as the Cloud Run path, so the online host and the inference-only service render the same logical Feast config with different runtime surfaces.
-The same generated `.env` also points the hosted MLflow service at `gs://<artifact-bucket>/mlflow/artifacts`, so artifact storage uses the shared cloud object plane instead of a host-local volume.
+Terraform creates a network, a static public IP, and a Compute Engine VM. The VM clones the repo, writes a runtime `.env` file with the GCP and BigQuery settings, and tries to pull the GHCR images. If the images are not available yet, it builds them on the VM instead.
+That `.env` file uses the same Feast runtime settings as the Cloud Run path, so both hosted targets use the same Feast config.
+It also points MLflow artifacts to `gs://<artifact-bucket>/mlflow/artifacts`, so artifacts go to the shared bucket instead of a VM-local volume.
+The VM installs a `foehncast-online-compose-sync` systemd timer. Every run fetches the configured Git ref and refreshes the hosted compose stack, so DAG and runtime changes land on the host without a manual SSH pull.
+Each successful sync also updates `/opt/foehncast/.state/online-compose-sync/last-success.json`.
+The app exposes that status through Prometheus `/metrics`, and Grafana shows it on the monitoring dashboard.
 
-The hosted baseline also provisions a Firestore Datastore-mode database dedicated to Feast online serving. Using a named database avoids coupling the repo to whatever default Firestore state a reused GCP project may already have.
+Terraform also creates a Firestore Datastore-mode database for Feast online serving. Using a named database keeps this setup separate from any default Firestore state in the project.
 
-The host uses a dedicated runtime service account with BigQuery job access, BigQuery Storage API read-session access, BigQuery dataset edit access, bucket object-admin access for MLflow and Feast artifacts, and Datastore user access, so the Airflow, training, Feast, app, and MLflow containers can rely on Application Default Credentials instead of mounted key files.
+The VM uses a dedicated service account with access to BigQuery jobs, BigQuery Storage API read sessions, BigQuery dataset edits, bucket objects for MLflow and Feast, and Datastore. This lets the Airflow, training, Feast, app, and MLflow containers use Application Default Credentials instead of key files.
 
-After curated BigQuery rows are available, run `./scripts/prepare-feast-cloud.sh` on the host or from another shell with ADC to apply the Feast repo and materialize the hosted online store.
+When curated BigQuery rows are ready, run `./scripts/prepare-feast-cloud.sh` on the host, or from another shell with ADC, to apply the Feast repo and materialize the hosted online store.
 
-On first boot, the host generates an Airflow admin password locally and stores it at `/opt/foehncast/airflow/.admin-password`. Retrieve it over SSH when you need to sign in instead of passing it through Terraform input variables.
+On first boot, the host creates an Airflow admin password and stores it at `/opt/foehncast/airflow/.admin-password`. Use SSH to read it when you need to sign in.
+You can also check `/opt/foehncast/.state/online-compose-sync/last-success.json` over SSH to see the last successful hosted DAG and runtime refresh.
 
 The online host starts:
 
@@ -99,7 +103,7 @@ The online host starts:
 
 By default, `online_compose_public_ports = [8000]`, so only the app is internet-reachable. If you want public admin UIs, add `8080` or `5001` deliberately.
 
-The compose-host path is the simplest way to keep the whole course stack online without forcing Airflow into Cloud Run.
+The compose-host path is the simplest way to keep the whole stack online without forcing Airflow into Cloud Run.
 
 ## What The Hosted Paths Expose
 
@@ -230,28 +234,30 @@ Automatic Terraform apply on `main` is no longer paused behind a GitHub environm
 
 Use this only for the initial hosted-environment bootstrap, or when you intentionally need direct admin access to the cloud project.
 
-Preferred environment: Google Cloud Shell. That keeps the admin toolchain off the default evaluator machine and matches the intended operator path.
+Preferred environment: Google Cloud Shell. It keeps the admin tools off the default evaluator machine and matches the intended operator path.
 
-If you run from another admin shell, keep `gcloud`, `gh`, and `terraform` available there. The supported no-local-install path remains Google Cloud Shell for bootstrap, followed by GitHub Actions for day-2 work.
+If you use another admin shell, make sure `gcloud`, `gh`, and `terraform` are available there. The supported no-local-install path is still: bootstrap in Google Cloud Shell, then use GitHub Actions for normal follow-up work.
 
-Supported first-time maintainer path:
+For the first setup, run:
 
 `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions`
 
 The bootstrap script will:
 
-1. Sign in in the browser when `gcloud` opens the login flow.
-2. Pick an existing GCP project or type `n` to create a new one.
-3. Pick a billing account from the list shown by the script.
-4. Confirm or edit the values for region, bucket, Artifact Registry repository, BigQuery dataset, and BigQuery table.
-5. Decide which hosted targets should exist after GitHub Actions takes over.
-6. Sync the repository variables that GitHub Actions needs for the shared cloud path.
+1. Sign in when `gcloud` opens the browser login.
+2. Choose an existing GCP project, or type `n` to create one.
+3. Choose a billing account.
+4. Confirm or edit the region, bucket, Artifact Registry repository, BigQuery dataset, and BigQuery table.
+5. Choose which hosted targets to enable.
+6. Sync the GitHub repository variables used by the shared cloud path.
 
-After bootstrap, run the Terraform workflow with `apply` once if you want the shared environment provisioned immediately. After that, pushes to `main` keep the shared environment aligned automatically.
+After bootstrap, run the Terraform workflow with `apply` if you want to provision the shared environment right away. After that, pushes to `main` keep it up to date automatically.
 
-The script writes `.env` and `terraform/terraform.tfvars` during setup and asks explicitly whether the next apply should enable the inference-only Cloud Run target and/or the full online compose host target.
+If a normal apply creates the hosted online compose target and exposes port `8000`, `./scripts/bootstrap-gcp.sh` waits for the hosted `/health` endpoint and checks that `/metrics` contains the online compose sync metrics.
 
-Authentication stays in the active `gcloud` application default credentials for the admin shell you used, while Terraform creates the runtime service accounts for Cloud Run and GitHub delivery.
+The script writes `.env` and `terraform/terraform.tfvars` during setup. It also asks whether the next apply should enable the inference-only Cloud Run target or the full online compose host target.
+
+Authentication stays in the active `gcloud` application default credentials for the shell you used. Terraform creates the runtime service accounts for Cloud Run and GitHub delivery.
 
 ## Local BigQuery Use
 

--- a/terraform/templates/online-compose-host.sh.tftpl
+++ b/terraform/templates/online-compose-host.sh.tftpl
@@ -35,7 +35,7 @@ git -C /opt/foehncast fetch --depth 1 origin "${git_ref}"
 git -C /opt/foehncast checkout --force FETCH_HEAD
 
 install -d -m 0775 /opt/foehncast/airflow /opt/foehncast/airflow/logs /opt/foehncast/airflow/reports
-install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast
+install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync
 install -d -m 0755 /opt/foehncast/grafana_work/data
 
 chown -R $${airflow_uid}:0 /opt/foehncast/airflow
@@ -55,8 +55,76 @@ ${key}=${value}
 %{ endfor ~}
 EOF
 
+cat > /opt/foehncast/.state/online-compose-sync/last-success.json <<'EOF'
+{
+  "state": "pending",
+  "git_ref": "${git_ref}",
+  "last_successful_sync_at": null,
+  "last_successful_commit": null,
+  "compose_deploy_mode": null
+}
+EOF
+chmod 0644 /opt/foehncast/.state/online-compose-sync/last-success.json
+
+cat > /usr/local/bin/foehncast-online-compose-sync <<'EOF'
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+sync_status_file="/opt/foehncast/.state/online-compose-sync/last-success.json"
+compose_deploy_mode="build"
+
+git -C /opt/foehncast fetch --depth 1 origin "${git_ref}"
+git -C /opt/foehncast checkout --force FETCH_HEAD
+
 if docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env pull model-registry app airflow-init airflow-webserver airflow-dag-processor airflow-scheduler airflow-triggerer; then
+  compose_deploy_mode="pull"
   docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env up -d --no-build
 else
   docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env up -d --build
 fi
+
+sync_timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+sync_commit="$(git -C /opt/foehncast rev-parse HEAD)"
+
+cat > "${sync_status_file}.tmp" <<STATUS
+{
+  "state": "succeeded",
+  "git_ref": "${git_ref}",
+  "last_successful_sync_at": "${sync_timestamp}",
+  "last_successful_commit": "${sync_commit}",
+  "compose_deploy_mode": "${compose_deploy_mode}"
+}
+STATUS
+mv "${sync_status_file}.tmp" "$sync_status_file"
+chmod 0644 "$sync_status_file"
+EOF
+chmod 0755 /usr/local/bin/foehncast-online-compose-sync
+
+cat > /etc/systemd/system/foehncast-online-compose-sync.service <<'EOF'
+[Unit]
+Description=Synchronize the FoehnCast online compose checkout and runtime stack
+After=network-online.target docker.service
+Wants=network-online.target docker.service
+
+[Service]
+Type=oneshot
+ExecStart=/usr/local/bin/foehncast-online-compose-sync
+EOF
+
+cat > /etc/systemd/system/foehncast-online-compose-sync.timer <<'EOF'
+[Unit]
+Description=Refresh the FoehnCast online compose checkout and runtime stack
+
+[Timer]
+OnBootSec=2m
+OnUnitActiveSec=5m
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+EOF
+
+systemctl daemon-reload
+systemctl enable --now foehncast-online-compose-sync.timer
+systemctl start foehncast-online-compose-sync.service

--- a/terraform/templates/online-compose-host.sh.tftpl
+++ b/terraform/templates/online-compose-host.sh.tftpl
@@ -87,17 +87,17 @@ fi
 sync_timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 sync_commit="$(git -C /opt/foehncast rev-parse HEAD)"
 
-cat > "${sync_status_file}.tmp" <<STATUS
+cat > "$${sync_status_file}.tmp" <<STATUS
 {
   "state": "succeeded",
   "git_ref": "${git_ref}",
-  "last_successful_sync_at": "${sync_timestamp}",
-  "last_successful_commit": "${sync_commit}",
-  "compose_deploy_mode": "${compose_deploy_mode}"
+  "last_successful_sync_at": "$${sync_timestamp}",
+  "last_successful_commit": "$${sync_commit}",
+  "compose_deploy_mode": "$${compose_deploy_mode}"
 }
 STATUS
-mv "${sync_status_file}.tmp" "$sync_status_file"
-chmod 0644 "$sync_status_file"
+mv "$${sync_status_file}.tmp" "$${sync_status_file}"
+chmod 0644 "$${sync_status_file}"
 EOF
 chmod 0755 /usr/local/bin/foehncast-online-compose-sync
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -506,7 +506,7 @@ def test_online_compose_startup_template_prepares_writable_runtime_dirs() -> Non
         in template
     )
     assert (
-        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast"
+        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync"
         in template
     )
     assert "install -d -m 0755 /opt/foehncast/grafana_work/data" in template
@@ -517,6 +517,10 @@ def test_online_compose_startup_template_prepares_writable_runtime_dirs() -> Non
         in template
     )
     assert "chown $${airflow_uid}:0 /opt/foehncast/airflow/.admin-password" in template
+    assert "cat > /usr/local/bin/foehncast-online-compose-sync <<'EOF'" in template
+    assert "chmod 0755 /usr/local/bin/foehncast-online-compose-sync" in template
+    assert "systemctl enable --now foehncast-online-compose-sync.timer" in template
+    assert "systemctl start foehncast-online-compose-sync.service" in template
 
 
 def test_online_compose_startup_template_prepares_writable_runtime_directories() -> (
@@ -532,7 +536,7 @@ def test_online_compose_startup_template_prepares_writable_runtime_directories()
         in template
     )
     assert (
-        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast"
+        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync"
         in template
     )
     assert "install -d -m 0755 /opt/foehncast/grafana_work/data" in template
@@ -544,6 +548,48 @@ def test_online_compose_startup_template_prepares_writable_runtime_directories()
     )
     assert "chown $${airflow_uid}:0 /opt/foehncast/airflow/.admin-password" in template
     assert "chmod 600 /opt/foehncast/airflow/.admin-password" in template
+
+
+def test_online_compose_startup_template_installs_periodic_repo_sync_timer() -> None:
+    template = _read_text("terraform/templates/online-compose-host.sh.tftpl")
+
+    assert 'git -C /opt/foehncast fetch --depth 1 origin "${git_ref}"' in template
+    assert "git -C /opt/foehncast checkout --force FETCH_HEAD" in template
+    assert (
+        "cat > /etc/systemd/system/foehncast-online-compose-sync.service <<'EOF'"
+        in template
+    )
+    assert "ExecStart=/usr/local/bin/foehncast-online-compose-sync" in template
+    assert (
+        "cat > /etc/systemd/system/foehncast-online-compose-sync.timer <<'EOF'"
+        in template
+    )
+    assert "OnBootSec=2m" in template
+    assert "OnUnitActiveSec=5m" in template
+    assert "Persistent=true" in template
+    assert (
+        "docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env pull"
+        in template
+    )
+
+
+def test_online_compose_sync_template_records_last_success_status_file() -> None:
+    template = _read_text("terraform/templates/online-compose-host.sh.tftpl")
+
+    assert (
+        "cat > /opt/foehncast/.state/online-compose-sync/last-success.json <<'EOF'"
+        in template
+    )
+    assert '"state": "pending"' in template
+    assert (
+        'sync_status_file="/opt/foehncast/.state/online-compose-sync/last-success.json"'
+        in template
+    )
+    assert 'sync_timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' in template
+    assert 'sync_commit="$(git -C /opt/foehncast rev-parse HEAD)"' in template
+    assert '"last_successful_sync_at": "${sync_timestamp}"' in template
+    assert '"last_successful_commit": "${sync_commit}"' in template
+    assert '"compose_deploy_mode": "${compose_deploy_mode}"' in template
 
 
 def test_terraform_runtime_iam_includes_bigquery_storage_api_and_bucket_access() -> (
@@ -590,6 +636,61 @@ def test_bootstrap_gcp_reports_hosted_feast_follow_up_step() -> None:
     assert (
         "After curated BigQuery rows are available, run ./scripts/prepare-feast-cloud.sh to apply the Feast repo and materialize the hosted online store."
         in bootstrap
+    )
+
+
+def test_bootstrap_gcp_requires_curl_for_hosted_runtime_verification() -> None:
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert "require_command curl" in bootstrap
+
+
+def test_bootstrap_gcp_reports_online_compose_urls_when_hosted_vm_is_enabled() -> None:
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert "print_online_compose_summary()" in bootstrap
+    assert (
+        'optional_terraform_output_value "$TERRAFORM_DIR" online_compose_host_ip'
+        in bootstrap
+    )
+    assert (
+        'optional_terraform_output_value "$TERRAFORM_DIR" online_compose_app_url'
+        in bootstrap
+    )
+    assert (
+        'optional_terraform_output_value "$TERRAFORM_DIR" online_compose_airflow_url'
+        in bootstrap
+    )
+    assert (
+        'optional_terraform_output_value "$TERRAFORM_DIR" online_compose_mlflow_url'
+        in bootstrap
+    )
+    assert 'echo "Online compose app URL: ${app_url}"' in bootstrap
+
+
+def test_bootstrap_gcp_verifies_hosted_app_health_and_sync_metrics_after_apply() -> (
+    None
+):
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert "verify_online_compose_runtime()" in bootstrap
+    assert 'health_url="${app_url%/}/health"' in bootstrap
+    assert 'metrics_url="${app_url%/}/metrics"' in bootstrap
+    assert 'echo "Waiting for hosted app health at ${health_url}..."' in bootstrap
+    assert 'echo "Checking hosted sync metrics at ${metrics_url}..."' in bootstrap
+    assert (
+        "foehncast_online_compose_sync_status_file_present[[:space:]]+1(\\.0)?"
+        in bootstrap
+    )
+    assert (
+        "foehncast_online_compose_sync_last_success_timestamp_seconds\\{" in bootstrap
+    )
+    assert (
+        'echo "Hosted online compose app URL is not publicly exposed; skipping hosted runtime verification."'
+        in bootstrap
+    )
+    assert bootstrap.index("print_feast_runtime_summary") < bootstrap.rindex(
+        "verify_online_compose_runtime"
     )
 
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -587,9 +587,12 @@ def test_online_compose_sync_template_records_last_success_status_file() -> None
     )
     assert 'sync_timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"' in template
     assert 'sync_commit="$(git -C /opt/foehncast rev-parse HEAD)"' in template
-    assert '"last_successful_sync_at": "${sync_timestamp}"' in template
-    assert '"last_successful_commit": "${sync_commit}"' in template
-    assert '"compose_deploy_mode": "${compose_deploy_mode}"' in template
+    assert 'cat > "$${sync_status_file}.tmp" <<STATUS' in template
+    assert 'mv "$${sync_status_file}.tmp" "$${sync_status_file}"' in template
+    assert 'chmod 0644 "$${sync_status_file}"' in template
+    assert '"last_successful_sync_at": "$${sync_timestamp}"' in template
+    assert '"last_successful_commit": "$${sync_commit}"' in template
+    assert '"compose_deploy_mode": "$${compose_deploy_mode}"' in template
 
 
 def test_terraform_runtime_iam_includes_bigquery_storage_api_and_bucket_access() -> (

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -98,20 +98,29 @@ def test_feature_dag_defaults_to_airflow_schedule(
     assert module.dag.kwargs["catchup"] is False
     assert module.dag.kwargs["is_paused_upon_creation"] is False
     assert [operator.kwargs["task_id"] for operator in operators] == [
-        "run_feature_pipeline",
+        "fetch_feature_inputs",
+        "engineer_feature_set",
+        "validate_feature_set",
+        "store_feature_set",
         "check_retraining_trigger",
         "train_model",
         "evaluate_model",
         "register_model",
     ]
-    assert operators[0].kwargs["op_kwargs"] == {"dataset": "train"}
-    assert operators[1].kwargs["op_kwargs"] == {
-        "feature_result": "output:run_feature_pipeline",
+    assert operators[0].kwargs["op_kwargs"] == {
+        "dataset": "train",
+        "run_key": "{{ run_id }}",
+    }
+    assert operators[1].kwargs["op_args"] == ["output:fetch_feature_inputs"]
+    assert operators[2].kwargs["op_args"] == ["output:engineer_feature_set"]
+    assert operators[3].kwargs["op_args"] == ["output:validate_feature_set"]
+    assert operators[4].kwargs["op_kwargs"] == {
+        "feature_result": "output:store_feature_set",
         "mode": "always",
     }
-    assert operators[2].kwargs["op_kwargs"] == {"dataset": "train"}
-    assert operators[3].kwargs["op_args"] == ["output:train_model"]
-    assert operators[3].kwargs["op_kwargs"] == {"dataset": "train"}
+    assert operators[5].kwargs["op_kwargs"] == {"dataset": "train"}
+    assert operators[6].kwargs["op_args"] == ["output:train_model"]
+    assert operators[6].kwargs["op_kwargs"] == {"dataset": "train"}
 
 
 def test_feature_dag_supports_manual_override_dataset_and_disabled_retraining(
@@ -128,8 +137,16 @@ def test_feature_dag_supports_manual_override_dataset_and_disabled_retraining(
     )
 
     assert module.dag.kwargs["schedule"] is None
-    assert len(operators) == 1
-    assert operators[0].kwargs["op_kwargs"] == {"dataset": "validation"}
+    assert [operator.kwargs["task_id"] for operator in operators] == [
+        "fetch_feature_inputs",
+        "engineer_feature_set",
+        "validate_feature_set",
+        "store_feature_set",
+    ]
+    assert operators[0].kwargs["op_kwargs"] == {
+        "dataset": "validation",
+        "run_key": "{{ run_id }}",
+    }
 
 
 def test_training_dag_stays_manual_and_paused_by_default(

--- a/tests/test_monitoring_stack.py
+++ b/tests/test_monitoring_stack.py
@@ -120,6 +120,22 @@ def test_grafana_alerting_provisions_background_monitoring_rules() -> None:
         == '((time() - max by (endpoint) (foehncast_prediction_monitoring_last_execution_timestamp_seconds{result="succeeded"})) * on (endpoint) (sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="scheduled"}[15m])) > bool 0))'
     )
     assert rules["FoehnCast Prediction Monitoring Stale Success"]["panelId"] == 14
+    assert (
+        rules["FoehnCast Feature Stage Failures"]["data"][0]["model"]["expr"]
+        == "max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_failure_count)"
+    )
+    assert rules["FoehnCast Feature Stage Failures"]["panelId"] == 18
+    assert rules["FoehnCast Feature Stage Failures"]["labels"]["component"] == (
+        "feature-pipeline"
+    )
+    assert (
+        rules["FoehnCast Hosted Sync Stale"]["data"][0]["model"]["expr"]
+        == "time() - max by (git_ref, compose_deploy_mode) (foehncast_online_compose_sync_last_success_timestamp_seconds)"
+    )
+    assert rules["FoehnCast Hosted Sync Stale"]["panelId"] == 19
+    assert rules["FoehnCast Hosted Sync Stale"]["labels"]["component"] == (
+        "hosted-operator"
+    )
     assert all(
         rule["dashboardUid"] == "foehncast-monitoring" for rule in rules.values()
     )
@@ -136,7 +152,22 @@ def test_grafana_alerting_provisions_contact_point_and_policy_tree() -> None:
     contact_point = contact_points["contactPoints"][0]
     receiver = contact_point["receivers"][0]
     policy = policies["policies"][0]
-    route = policy["routes"][0]
+    routes = policy["routes"]
+    inference_route = next(
+        route
+        for route in routes
+        if route["object_matchers"] == [["component", "=", "inference-monitoring"]]
+    )
+    feature_route = next(
+        route
+        for route in routes
+        if route["object_matchers"] == [["component", "=", "feature-pipeline"]]
+    )
+    hosted_route = next(
+        route
+        for route in routes
+        if route["object_matchers"] == [["component", "=", "hosted-operator"]]
+    )
 
     assert contact_points["apiVersion"] == 1
     assert contact_point["name"] == "foehncast-email"
@@ -147,9 +178,27 @@ def test_grafana_alerting_provisions_contact_point_and_policy_tree() -> None:
     assert policies["apiVersion"] == 1
     assert policy["receiver"] == "foehncast-email"
     assert policy["group_by"] == ["alertname", "severity"]
-    assert route["receiver"] == "foehncast-email"
-    assert route["object_matchers"] == [["component", "=", "inference-monitoring"]]
-    assert route["group_by"] == ["alertname", "endpoint", "severity"]
+    assert inference_route["receiver"] == "foehncast-email"
+    assert inference_route["object_matchers"] == [
+        ["component", "=", "inference-monitoring"]
+    ]
+    assert inference_route["group_by"] == ["alertname", "endpoint", "severity"]
+    assert feature_route["receiver"] == "foehncast-email"
+    assert feature_route["object_matchers"] == [["component", "=", "feature-pipeline"]]
+    assert feature_route["group_by"] == [
+        "alertname",
+        "dataset",
+        "storage_backend",
+        "stage",
+        "severity",
+    ]
+    assert hosted_route["receiver"] == "foehncast-email"
+    assert hosted_route["group_by"] == [
+        "alertname",
+        "git_ref",
+        "compose_deploy_mode",
+        "severity",
+    ]
 
 
 def test_grafana_dashboard_includes_feature_and_inference_drift_panels() -> None:
@@ -197,10 +246,36 @@ def test_grafana_dashboard_includes_feature_and_inference_drift_panels() -> None
         == 'sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="failed"}[15m]))'
     )
     assert (
+        panels["Engineered Spots"]["targets"][0]["expr"]
+        == "sum by (dataset, storage_backend) (foehncast_feature_pipeline_engineered_spot_count)"
+    )
+    assert (
+        panels["Validated Spots"]["targets"][0]["expr"]
+        == "sum by (dataset, storage_backend) (foehncast_feature_pipeline_validated_spot_count)"
+    )
+    assert (
+        panels["Feature Stage Duration"]["targets"][0]["expr"]
+        == "max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_duration_seconds)"
+    )
+    assert (
+        panels["Feature Stage Failures"]["targets"][0]["expr"]
+        == "max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_failure_count)"
+    )
+    assert (
+        panels["Seconds Since Last Hosted Sync"]["targets"][0]["expr"]
+        == "time() - max by (git_ref, compose_deploy_mode) (foehncast_online_compose_sync_last_success_timestamp_seconds)"
+    )
+    assert (
         panels["Prediction Monitoring Schedule Failures (15m)"]["fieldConfig"][
             "defaults"
         ]["thresholds"]["steps"][1]["value"]
         == 0.5
+    )
+    assert (
+        panels["Seconds Since Last Hosted Sync"]["fieldConfig"]["defaults"][
+            "thresholds"
+        ]["steps"][1]["value"]
+        == 900
     )
     assert (
         panels["Prediction Monitoring Execution Failures (15m)"]["targets"][0]["expr"]
@@ -239,8 +314,12 @@ def test_local_bootstrap_verifies_grafana_provisioning() -> None:
     assert "foehncast_predmon_schedule_fail" in bootstrap
     assert "foehncast_predmon_execution_fail" in bootstrap
     assert "foehncast_predmon_stale_success" in bootstrap
+    assert "foehncast_feature_stage_failures" in bootstrap
+    assert "foehncast_hosted_sync_stale" in bootstrap
     assert "/api/v1/provisioning/contact-points?name=foehncast-email" in bootstrap
     assert "/api/v1/provisioning/policies" in bootstrap
+    assert '"feature-pipeline"' in bootstrap
+    assert '"hosted-operator"' in bootstrap
 
 
 def test_app_compose_routes_monitoring_metrics_to_statsd_service() -> None:
@@ -269,6 +348,31 @@ def test_local_bootstrap_waits_for_app_health_after_training_pipeline() -> None:
     assert bootstrap.index(
         'echo "Running training pipeline for ${TRAINING_DATE}..."'
     ) < bootstrap.index('echo "Waiting for app health..."')
+
+
+def test_local_bootstrap_seeds_hosted_sync_status_before_stack_start() -> None:
+    bootstrap = _read_text("scripts/bootstrap-local.sh")
+
+    assert "seed_local_online_compose_sync_status" in bootstrap
+    assert 'sync_status_file="$sync_dir/last-success.json"' in bootstrap
+    assert bootstrap.rindex("seed_local_online_compose_sync_status") < bootstrap.index(
+        'echo "Starting local stack..."'
+    )
+
+
+def test_local_bootstrap_verifies_hosted_sync_metrics_after_app_health() -> None:
+    bootstrap = _read_text("scripts/bootstrap-local.sh")
+
+    assert (
+        'APP_METRICS_URL="${APP_METRICS_URL:-http://127.0.0.1:8000/metrics}"'
+        in bootstrap
+    )
+    assert "verify_hosted_sync_metrics" in bootstrap
+    assert "foehncast_online_compose_sync_status_file_present" in bootstrap
+    assert "foehncast_online_compose_sync_last_success_timestamp_seconds" in bootstrap
+    assert bootstrap.index('echo "Waiting for app health..."') < bootstrap.rindex(
+        "verify_hosted_sync_metrics"
+    )
 
 
 def test_local_bootstrap_starts_monitoring_services_without_development_env() -> None:

--- a/tests/test_online_compose_sync_prometheus.py
+++ b/tests/test_online_compose_sync_prometheus.py
@@ -1,0 +1,82 @@
+"""Tests for Prometheus export of hosted online-compose sync state."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from foehncast.monitoring import online_compose_sync_prometheus
+
+
+def _metric_value(payload: str, metric_prefix: str) -> float:
+    for line in payload.splitlines():
+        if line.startswith(metric_prefix):
+            return float(line.split()[-1])
+    raise AssertionError(f"Metric not found: {metric_prefix}")
+
+
+def test_render_online_compose_sync_prometheus_metrics_reports_last_success() -> None:
+    payload = (
+        online_compose_sync_prometheus.render_online_compose_sync_prometheus_metrics(
+            {
+                "state": "succeeded",
+                "git_ref": "main",
+                "last_successful_sync_at": "2026-05-11T18:50:00Z",
+                "last_successful_commit": "abc123",
+                "compose_deploy_mode": "pull",
+            }
+        ).decode("utf-8")
+    )
+
+    assert "foehncast_online_compose_sync_status_file_present 1.0" in payload
+    assert _metric_value(
+        payload,
+        'foehncast_online_compose_sync_last_success_timestamp_seconds{compose_deploy_mode="pull",git_ref="main"}',
+    ) == pytest.approx(1778525400.0)
+
+
+def test_render_online_compose_sync_prometheus_metrics_handles_missing_status(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        online_compose_sync_prometheus,
+        "_default_online_compose_sync_status_path",
+        lambda: tmp_path / "last-success.json",
+    )
+
+    payload = (
+        online_compose_sync_prometheus.render_online_compose_sync_prometheus_metrics(
+            None
+        ).decode("utf-8")
+    )
+
+    assert "foehncast_online_compose_sync_status_file_present 0.0" in payload
+    assert "foehncast_online_compose_sync_last_success_timestamp_seconds" in payload
+
+
+def test_read_online_compose_sync_status_loads_json(tmp_path: Path) -> None:
+    status_path = tmp_path / "last-success.json"
+    status_path.write_text(
+        json.dumps(
+            {
+                "state": "succeeded",
+                "git_ref": "main",
+                "last_successful_sync_at": "2026-05-11T18:50:00Z",
+                "last_successful_commit": "abc123",
+                "compose_deploy_mode": "build",
+            }
+        )
+    )
+
+    assert online_compose_sync_prometheus.read_online_compose_sync_status(
+        status_path
+    ) == {
+        "state": "succeeded",
+        "git_ref": "main",
+        "last_successful_sync_at": "2026-05-11T18:50:00Z",
+        "last_successful_commit": "abc123",
+        "compose_deploy_mode": "build",
+    }

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -11,6 +11,18 @@ import pytest
 from foehncast import orchestration
 
 
+@pytest.fixture(autouse=True)
+def _feature_pipeline_state_root(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(
+        orchestration,
+        "_feature_pipeline_state_root",
+        lambda: tmp_path / "feature-pipeline-state",
+    )
+
+
 def test_run_feature_pipeline_fetches_validated_features(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -248,6 +260,7 @@ def test_run_feature_pipeline_raises_on_validation_failure(
 
     assert emitted["summary"]["run_status"] == "failed"
     assert emitted["summary"]["failed_spot_count"] == 1
+    assert emitted["summary"]["stage_failure_counts"]["validate"] == 1
     assert emitted["summary"]["spots"][0]["validation"]["is_valid"] is False
 
 
@@ -281,6 +294,7 @@ def test_run_feature_pipeline_emits_failed_summary_on_ingest_contract_error(
     assert emitted["summary"]["error"] == (
         "Unexpected unit for wind_speed_10m: expected km/h, got 'kn'"
     )
+    assert emitted["summary"]["stage_failure_counts"]["fetch"] == 1
     assert emitted["summary"]["fetched_spot_count"] == 0
     assert emitted["summary"]["spots"] == []
 
@@ -415,6 +429,13 @@ def test_run_feature_pipeline_job_context_reports_drift_and_logs_mlflow(
             "storage_backend": "s3",
             "stored_spots": ["silvaplana", "urnersee"],
             "drifted_spots": ["silvaplana"],
+            "stage_durations_seconds": {"fetch": 1.5, "store": 2.5},
+            "stage_failure_counts": {
+                "fetch": 0,
+                "engineer": 0,
+                "validate": 0,
+                "store": 0,
+            },
             "dataset_drift_detected": True,
         },
     )
@@ -426,6 +447,13 @@ def test_run_feature_pipeline_job_context_reports_drift_and_logs_mlflow(
         "storage_backend": "s3",
         "stored_spots": ["silvaplana", "urnersee"],
         "drifted_spots": ["silvaplana"],
+        "stage_durations_seconds": {"fetch": 1.5, "store": 2.5},
+        "stage_failure_counts": {
+            "fetch": 0,
+            "engineer": 0,
+            "validate": 0,
+            "store": 0,
+        },
         "dataset_drift_detected": True,
     }
     assert logged["tracking_uri"] == "https://mlflow.example.com"
@@ -440,6 +468,12 @@ def test_run_feature_pipeline_job_context_reports_drift_and_logs_mlflow(
     assert logged["metrics"] == {
         "stored_spot_count": 2,
         "drifted_spot_count": 1,
+        "fetch_duration_seconds": 1.5,
+        "store_duration_seconds": 2.5,
+        "fetch_failure_count": 0.0,
+        "engineer_failure_count": 0.0,
+        "validate_failure_count": 0.0,
+        "store_failure_count": 0.0,
         "dataset_drift_detected": 1.0,
     }
 

--- a/tests/test_pipeline_metrics.py
+++ b/tests/test_pipeline_metrics.py
@@ -59,7 +59,16 @@ def test_emit_feature_pipeline_run_summary_writes_json_and_logs_mlflow(
         "dataset": "notebook_eval",
         "expected_spot_count": 1,
         "fetched_spot_count": 1,
+        "engineered_spot_count": 1,
+        "validated_spot_count": 1,
         "stored_spot_count": 1,
+        "stage_durations_seconds": {"fetch": 12.5, "store": 3.5},
+        "stage_failure_counts": {
+            "fetch": 0,
+            "engineer": 0,
+            "validate": 0,
+            "store": 0,
+        },
         "skipped_spot_count": 0,
         "failed_spot_count": 0,
         "spots": [
@@ -85,6 +94,11 @@ def test_emit_feature_pipeline_run_summary_writes_json_and_logs_mlflow(
         "monitoring/feature_pipeline",
     )
     assert logged["metrics"]["feature_stored_spot_count"] == 1.0
+    assert logged["metrics"]["feature_engineered_spot_count"] == 1.0
+    assert logged["metrics"]["feature_validated_spot_count"] == 1.0
+    assert logged["metrics"]["feature_fetch_duration_seconds"] == 12.5
+    assert logged["metrics"]["feature_store_duration_seconds"] == 3.5
+    assert logged["metrics"]["feature_validate_failure_count"] == 0.0
     assert logged["metrics"]["feature_silvaplana_feast_projection_ready"] == 1.0
 
 

--- a/tests/test_pipeline_prometheus.py
+++ b/tests/test_pipeline_prometheus.py
@@ -21,7 +21,16 @@ def test_render_feature_pipeline_prometheus_metrics_uses_labelled_gauges(
             "storage_backend": "s3",
             "expected_spot_count": 2,
             "fetched_spot_count": 2,
+            "engineered_spot_count": 2,
+            "validated_spot_count": 2,
             "stored_spot_count": 2,
+            "stage_durations_seconds": {"fetch": 12.5, "store": 3.5},
+            "stage_failure_counts": {
+                "fetch": 0,
+                "engineer": 0,
+                "validate": 0,
+                "store": 0,
+            },
             "skipped_spot_count": 0,
             "failed_spot_count": 0,
             "spots": [
@@ -52,6 +61,22 @@ def test_render_feature_pipeline_prometheus_metrics_uses_labelled_gauges(
     )
     assert (
         'foehncast_feature_pipeline_spot_ingest_rows{dataset="train",spot_id="silvaplana",storage_backend="s3"} 168.0'
+        in payload
+    )
+    assert (
+        'foehncast_feature_pipeline_engineered_spot_count{dataset="train",storage_backend="s3"} 2.0'
+        in payload
+    )
+    assert (
+        'foehncast_feature_pipeline_validated_spot_count{dataset="train",storage_backend="s3"} 2.0'
+        in payload
+    )
+    assert (
+        'foehncast_feature_pipeline_stage_duration_seconds{dataset="train",stage="fetch",storage_backend="s3"} 12.5'
+        in payload
+    )
+    assert (
+        'foehncast_feature_pipeline_stage_failure_count{dataset="train",stage="fetch",storage_backend="s3"} 0.0'
         in payload
     )
     assert (

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -473,6 +473,10 @@ def test_metrics_endpoint_returns_prometheus_payload(
         b"# HELP foehncast_prediction_monitoring_schedule_total example\n"
         b'foehncast_prediction_monitoring_schedule_total{endpoint="predict",result="scheduled"} 1\n'
     )
+    hosted_sync_payload = (
+        b"# HELP foehncast_online_compose_sync_status_file_present example\n"
+        b"foehncast_online_compose_sync_status_file_present 1\n"
+    )
     monkeypatch.setattr(
         serve,
         "render_feature_pipeline_prometheus_metrics",
@@ -488,12 +492,17 @@ def test_metrics_endpoint_returns_prometheus_payload(
         "render_prediction_monitoring_prometheus_metrics",
         lambda: monitoring_payload,
     )
+    monkeypatch.setattr(
+        serve,
+        "render_online_compose_sync_prometheus_metrics",
+        lambda: hosted_sync_payload,
+    )
     client = TestClient(serve.app)
 
     response = client.get("/metrics")
 
     assert response.status_code == 200
     assert response.content == (
-        feature_payload + prediction_payload + monitoring_payload
+        feature_payload + prediction_payload + monitoring_payload + hosted_sync_payload
     )
     assert response.headers["content-type"] == CONTENT_TYPE_LATEST


### PR DESCRIPTION
### What Changed
- split the feature DAG into explicit fetch, engineer, validate, and store stages
- exposed hosted online-compose sync freshness through the app `/metrics` endpoint, Grafana, and alerting
- extended local and GCP bootstrap verification for the hosted runtime path

### Why
- operators need one monitoring surface that shows both pipeline progress and whether the hosted compose stack is still syncing the configured Git ref

### Verification
- `uv run pytest tests/test_online_compose_sync_prometheus.py tests/test_predict.py tests/test_monitoring_stack.py tests/test_cloud_operator_contract.py tests/test_dags.py tests/test_orchestration.py tests/test_pipeline_metrics.py tests/test_pipeline_prometheus.py`
- `uv run mkdocs build -f docs/mkdocs.yml --strict`

### Closes
- Closes #118