### PR TITLE
fix(cloud-run): verify runtime after bootstrap apply

### DIFF
--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -222,6 +222,25 @@ read_tfvars_value() {
     fi
   }
 
+  print_cloud_run_summary() {
+    local service_url
+
+    FOEHNCAST_TERRAFORM_TFVARS_FILE="$TFVARS_FILE" load_terraform_platform_state "$TERRAFORM_DIR"
+
+    if [[ "$FOEHNCAST_TF_PROVISION_CLOUD_RUN_SERVICE" != "true" ]]; then
+      return
+    fi
+
+    service_url="$(optional_terraform_output_value "$TERRAFORM_DIR" cloud_run_service_url)"
+    service_url="$(trim_whitespace "$service_url")"
+
+    if [[ -n "$service_url" && "$service_url" != "null" ]]; then
+      echo "Cloud Run service URL: ${service_url}"
+    fi
+
+    echo "Cloud Run allows unauthenticated access: ${FOEHNCAST_TF_CLOUD_RUN_ALLOW_UNAUTHENTICATED}"
+  }
+
   print_feast_runtime_summary() {
     local feast_bigquery_table
 
@@ -299,6 +318,45 @@ read_tfvars_value() {
       "$metrics_payload" \
       'foehncast_online_compose_sync_last_success_timestamp_seconds\{' \
       'hosted sync last-success timestamp metric'
+  }
+
+  verify_cloud_run_runtime() {
+    local service_url health_url spots_url spots_payload identity_token
+    local -a curl_args
+
+    FOEHNCAST_TERRAFORM_TFVARS_FILE="$TFVARS_FILE" load_terraform_platform_state "$TERRAFORM_DIR"
+
+    if [[ "$FOEHNCAST_TF_PROVISION_CLOUD_RUN_SERVICE" != "true" ]]; then
+      return
+    fi
+
+    service_url="$(optional_terraform_output_value "$TERRAFORM_DIR" cloud_run_service_url)"
+    service_url="$(trim_whitespace "$service_url")"
+
+    if [[ -z "$service_url" || "$service_url" == "null" ]]; then
+      echo "Cloud Run service URL is not available; skipping Cloud Run runtime verification."
+      return
+    fi
+
+    health_url="${service_url%/}/health"
+    spots_url="${service_url%/}/spots"
+    curl_args=(--retry 90 --retry-all-errors --retry-delay 10 -fsS)
+
+    if [[ "$FOEHNCAST_TF_CLOUD_RUN_ALLOW_UNAUTHENTICATED" != "true" ]]; then
+      echo "Cloud Run service requires authenticated invocation; requesting identity token..."
+      identity_token="$(gcloud auth print-identity-token --audiences="$service_url")"
+      curl_args+=(-H "Authorization: Bearer ${identity_token}")
+    fi
+
+    echo "Waiting for Cloud Run health at ${health_url}..."
+    curl "${curl_args[@]}" "$health_url" >/dev/null
+
+    echo "Checking Cloud Run spots endpoint at ${spots_url}..."
+    spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
+    require_payload_pattern \
+      "$spots_payload" \
+      '"id"[[:space:]]*:' \
+      'Cloud Run spots payload'
   }
 
   print_bootstrap_only_summary() {
@@ -828,8 +886,10 @@ else
     echo "Syncing local cloud identifiers into .env..."
     sync_env_from_terraform_outputs
     print_auth_summary
+    print_cloud_run_summary
     print_online_compose_summary
     print_feast_runtime_summary
+    verify_cloud_run_runtime
     verify_online_compose_runtime
   fi
 fi

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -253,6 +253,8 @@ The bootstrap script will:
 
 After bootstrap, run the Terraform workflow with `apply` if you want to provision the shared environment right away. After that, pushes to `main` keep it up to date automatically.
 
+If a normal apply provisions the inference-only Cloud Run target, `./scripts/bootstrap-gcp.sh` checks the Cloud Run `/health` endpoint and the `/spots` route. When the service does not allow unauthenticated access, the script requests an identity token from `gcloud` before calling it.
+
 If a normal apply creates the hosted online compose target and exposes port `8000`, `./scripts/bootstrap-gcp.sh` waits for the hosted `/health` endpoint and checks that `/metrics` contains the online compose sync metrics.
 
 The script writes `.env` and `terraform/terraform.tfvars` during setup. It also asks whether the next apply should enable the inference-only Cloud Run target or the full online compose host target.

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -671,6 +671,21 @@ def test_bootstrap_gcp_reports_online_compose_urls_when_hosted_vm_is_enabled() -
     assert 'echo "Online compose app URL: ${app_url}"' in bootstrap
 
 
+def test_bootstrap_gcp_reports_cloud_run_url_when_service_is_enabled() -> None:
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert "print_cloud_run_summary()" in bootstrap
+    assert (
+        'optional_terraform_output_value "$TERRAFORM_DIR" cloud_run_service_url'
+        in bootstrap
+    )
+    assert 'echo "Cloud Run service URL: ${service_url}"' in bootstrap
+    assert (
+        'echo "Cloud Run allows unauthenticated access: ${FOEHNCAST_TF_CLOUD_RUN_ALLOW_UNAUTHENTICATED}"'
+        in bootstrap
+    )
+
+
 def test_bootstrap_gcp_verifies_hosted_app_health_and_sync_metrics_after_apply() -> (
     None
 ):
@@ -694,6 +709,33 @@ def test_bootstrap_gcp_verifies_hosted_app_health_and_sync_metrics_after_apply()
     )
     assert bootstrap.index("print_feast_runtime_summary") < bootstrap.rindex(
         "verify_online_compose_runtime"
+    )
+
+
+def test_bootstrap_gcp_verifies_cloud_run_runtime_after_apply() -> None:
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert "verify_cloud_run_runtime()" in bootstrap
+    assert (
+        'service_url="$(optional_terraform_output_value "$TERRAFORM_DIR" cloud_run_service_url)"'
+        in bootstrap
+    )
+    assert 'health_url="${service_url%/}/health"' in bootstrap
+    assert 'spots_url="${service_url%/}/spots"' in bootstrap
+    assert 'echo "Waiting for Cloud Run health at ${health_url}..."' in bootstrap
+    assert 'echo "Checking Cloud Run spots endpoint at ${spots_url}..."' in bootstrap
+    assert 'gcloud auth print-identity-token --audiences="$service_url"' in bootstrap
+    assert (
+        'echo "Cloud Run service requires authenticated invocation; requesting identity token..."'
+        in bootstrap
+    )
+    assert '"id"[[:space:]]*:' in bootstrap
+    assert (
+        'echo "Cloud Run service URL is not available; skipping Cloud Run runtime verification."'
+        in bootstrap
+    )
+    assert bootstrap.index("print_feast_runtime_summary") < bootstrap.rindex(
+        "verify_cloud_run_runtime"
     )
 
 


### PR DESCRIPTION
## Summary
- report the Cloud Run service URL and auth mode in the GCP bootstrap summary
- verify the provisioned Cloud Run inference service after apply, including authenticated invocation when needed
- cover the new bootstrap behavior in the cloud operator contract tests and maintainer docs

## Testing
- uv run pytest tests/test_cloud_operator_contract.py -q
- bash -n scripts/bootstrap-gcp.sh

Closes #124