### PR TITLE
fix(cloud-run): smoke-check post-deploy runtime

### DIFF
--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -27,6 +27,7 @@ jobs:
       workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
       service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
       cloud_run_service: ${{ steps.repo_config.outputs.cloud_run_service }}
+      cloud_run_allow_unauthenticated: ${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}
       registry_host: ${{ steps.derived.outputs.registry_host }}
       image_repository: ${{ steps.derived.outputs.image_repository }}
       publish_ready: ${{ steps.derived.outputs.publish_ready }}
@@ -161,6 +162,7 @@ jobs:
       GCP_PROJECT_ID: ${{ needs.config.outputs.project_id }}
       GCP_LOCATION: ${{ needs.config.outputs.location }}
       CLOUD_RUN_SERVICE: ${{ needs.config.outputs.cloud_run_service }}
+      CLOUD_RUN_ALLOW_UNAUTHENTICATED: ${{ needs.config.outputs.cloud_run_allow_unauthenticated }}
       IMAGE_URI: ${{ needs.publish.outputs.image_uri }}
     steps:
       - uses: google-github-actions/auth@v2
@@ -189,6 +191,48 @@ jobs:
           service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
           echo "service_url=${service_url}" >> "$GITHUB_OUTPUT"
 
+      - id: verify
+        name: Verify deployed Cloud Run runtime
+        env:
+          SERVICE_URL: ${{ steps.deploy.outputs.service_url }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$SERVICE_URL" ]]; then
+            echo "Cloud Run service URL is empty after deploy." >&2
+            exit 1
+          fi
+
+          health_url="${SERVICE_URL%/}/health"
+          spots_url="${SERVICE_URL%/}/spots"
+          allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
+          curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
+          invocation_mode="anonymous"
+
+          if [[ "$allow_unauthenticated" != 'true' ]]; then
+            invocation_mode="identity-token"
+            identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
+            curl_args+=(-H "Authorization: Bearer ${identity_token}")
+          fi
+
+          echo "Waiting for Cloud Run health at ${health_url}..."
+          health_payload="$(curl "${curl_args[@]}" "$health_url")"
+          if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+            echo "Cloud Run health verification failed." >&2
+            printf '%s\n' "$health_payload" >&2
+            exit 1
+          fi
+
+          echo "Checking Cloud Run spots endpoint at ${spots_url}..."
+          spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
+          if ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
+            echo "Cloud Run spots verification failed." >&2
+            printf '%s\n' "$spots_payload" >&2
+            exit 1
+          fi
+
+          echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"
+
       - name: Summarize Cloud Run deployment
         run: |
           {
@@ -197,6 +241,8 @@ jobs:
             echo "- Service: $CLOUD_RUN_SERVICE"
             echo "- Image: $IMAGE_URI"
             echo "- URL: ${{ steps.deploy.outputs.service_url }}"
+            echo "- Smoke check: passed"
+            echo "- Invocation: ${{ steps.verify.outputs.invocation_mode }}"
           } >> "$GITHUB_STEP_SUMMARY"
 
   deploy_skipped:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -178,7 +178,7 @@ In normal operation you should not edit these variables by hand. The bootstrap p
 
 `GCP_CLOUD_RUN_SERVICE` stays unset until Terraform has actually provisioned the Cloud Run service. After that, publish automation can update the service with newly built images.
 
-When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag and then updates the existing Cloud Run service to that image. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.
+When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health` plus `/spots`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.
 
 ## GitHub Actions Terraform Path
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -408,6 +408,10 @@ def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> N
         config_job["outputs"]["cloud_run_service"]
         == "${{ steps.repo_config.outputs.cloud_run_service }}"
     )
+    assert (
+        config_job["outputs"]["cloud_run_allow_unauthenticated"]
+        == "${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}"
+    )
 
     derived_step = _workflow_step(workflow, "config", "derived")
     assert (
@@ -420,6 +424,42 @@ def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> N
     assert (
         deploy_job["env"]["CLOUD_RUN_SERVICE"]
         == "${{ needs.config.outputs.cloud_run_service }}"
+    )
+    assert (
+        deploy_job["env"]["CLOUD_RUN_ALLOW_UNAUTHENTICATED"]
+        == "${{ needs.config.outputs.cloud_run_allow_unauthenticated }}"
+    )
+
+    verify_step = _workflow_step(
+        workflow, "deploy", "Verify deployed Cloud Run runtime"
+    )
+    verify_script = verify_step["run"]
+
+    assert (
+        verify_step["env"]["SERVICE_URL"] == "${{ steps.deploy.outputs.service_url }}"
+    )
+    assert 'health_url="${SERVICE_URL%/}/health"' in verify_script
+    assert 'spots_url="${SERVICE_URL%/}/spots"' in verify_script
+    assert (
+        "allow_unauthenticated=\"$(printf '%s' \"${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}\" | tr '[:upper:]' '[:lower:]')\""
+        in verify_script
+    )
+    assert (
+        'gcloud auth print-identity-token --audiences="$SERVICE_URL"' in verify_script
+    )
+    assert (
+        'grep -Eq \x27"status"[[:space:]]*:[[:space:]]*"healthy"\x27' in verify_script
+    )
+    assert 'grep -Eq \x27"id"[[:space:]]*:\x27' in verify_script
+    assert (
+        'echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"' in verify_script
+    )
+
+    summary_step = _workflow_step(workflow, "deploy", "Summarize Cloud Run deployment")
+    assert 'echo "- Smoke check: passed"' in summary_step["run"]
+    assert (
+        'echo "- Invocation: ${{ steps.verify.outputs.invocation_mode }}"'
+        in summary_step["run"]
     )
 
 


### PR DESCRIPTION
## Summary
- propagate the Cloud Run unauthenticated-access contract into the app image publish workflow
- smoke-check the deployed Cloud Run service through /health and /spots after each automatic image update
- document and test the deploy-time verification behavior

## Testing
- uv run pytest tests/test_cloud_operator_contract.py -q

Closes #126