### PR TITLE
fix(airflow): trigger training pipeline from feature DAG

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ This is the default path for a fresh machine.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 The local bootstrap uses the bundled MinIO service for curated features and MLflow artifacts. It prepares Feast with the bundled Datastore-mode emulator and checks that Grafana loaded the checked-in dashboard and alerts before it reports the stack ready. If the default ports are busy, it moves to the next free ports and prints the resolved endpoints.
-On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically. It can continue into train, evaluate, and register steps in the same Airflow flow. The separate `training_pipeline` DAG stays manual for reruns.
+On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically. When the retraining gate passes, it triggers the separate `training_pipeline` DAG instead of embedding train, evaluate, and register steps inside the feature flow. The `training_pipeline` DAG itself stays unscheduled and paused by default for manual reruns.
 The optional `development_env` notebook container is not part of the default path. Start it only when you need notebook or dev-shell Makefile commands.
 
 After bootstrap completes, the main local endpoints are:

--- a/dags/feature_dag.py
+++ b/dags/feature_dag.py
@@ -10,22 +10,22 @@ try:
         PythonOperator,
         ShortCircuitOperator,
     )
+    from airflow.providers.standard.operators.trigger_dagrun import (
+        TriggerDagRunOperator,
+    )
     from airflow.sdk import DAG
 except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
     dag = None
 else:
     from foehncast.orchestration import (
         engineer_feature_pipeline_context,
-        evaluate_training_run,
         fetch_feature_pipeline_context,
-        register_training_run,
         resolve_auto_retraining_mode,
         resolve_airflow_schedule,
         store_feature_pipeline_job_context,
         should_auto_retrain,
         validate_feature_pipeline_context,
     )
-    from foehncast.training_pipeline.train import run_training_pipeline
 
     feature_dataset = os.getenv("AIRFLOW_FEATURE_DATASET", "train").strip() or "train"
     feature_schedule = resolve_airflow_schedule(
@@ -41,7 +41,7 @@ else:
         dag_id="feature_pipeline",
         description=(
             "Fetch forecasts, engineer features, validate them, persist curated "
-            "slices, and optionally continue into retraining."
+            "slices, and optionally trigger the separate retraining DAG."
         ),
         start_date=datetime(2024, 1, 1),
         schedule=feature_schedule,
@@ -83,23 +83,15 @@ else:
                 },
             )
 
-            train_model = PythonOperator(
-                task_id="train_model",
-                python_callable=run_training_pipeline,
-                op_kwargs={"dataset": feature_dataset},
-            )
-
-            evaluate_model_task = PythonOperator(
-                task_id="evaluate_model",
-                python_callable=evaluate_training_run,
-                op_args=[train_model.output],
-                op_kwargs={"dataset": feature_dataset},
-            )
-
-            register_model_task = PythonOperator(
-                task_id="register_model",
-                python_callable=register_training_run,
-                op_args=[train_model.output],
+            trigger_training_pipeline = TriggerDagRunOperator(
+                task_id="trigger_training_pipeline",
+                trigger_dag_id="training_pipeline",
+                conf={
+                    "dataset": feature_dataset,
+                    "source_dag_id": "feature_pipeline",
+                    "source_run_id": "{{ run_id }}",
+                },
+                wait_for_completion=False,
             )
 
             (
@@ -108,9 +100,7 @@ else:
                 >> validate_feature_set
                 >> store_feature_set
                 >> retraining_gate
-                >> train_model
-                >> evaluate_model_task
-                >> register_model_task
+                >> trigger_training_pipeline
             )
 
         else:

--- a/dags/training_dag.py
+++ b/dags/training_dag.py
@@ -15,27 +15,35 @@ else:
     from foehncast.training_pipeline.train import run_training_pipeline
 
     training_dataset = os.getenv("AIRFLOW_TRAINING_DATASET", "train").strip() or "train"
+    training_dataset_template = (
+        "{{ dag_run.conf.get('dataset') if dag_run and dag_run.conf and "
+        "dag_run.conf.get('dataset') else params.dataset }}"
+    )
 
     with DAG(
         dag_id="training_pipeline",
-        description="Train the model, log evaluation outputs, and register the new version.",
+        description=(
+            "Train the model, log evaluation outputs, and register the new version "
+            "when started manually or triggered from the feature DAG."
+        ),
         start_date=datetime(2024, 1, 1),
         schedule=None,
         catchup=False,
         is_paused_upon_creation=True,
+        params={"dataset": training_dataset},
         tags=["foehncast", "training"],
     ) as dag:
         train_model = PythonOperator(
             task_id="train_model",
             python_callable=run_training_pipeline,
-            op_kwargs={"dataset": training_dataset},
+            op_kwargs={"dataset": training_dataset_template},
         )
 
         evaluate_model_task = PythonOperator(
             task_id="evaluate_model",
             python_callable=evaluate_training_run,
             op_args=[train_model.output],
-            op_kwargs={"dataset": training_dataset},
+            op_kwargs={"dataset": training_dataset_template},
         )
 
         register_model_task = PythonOperator(

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -51,8 +51,12 @@ def _load_dag_module(
     operators_module = types.ModuleType("airflow.providers.standard.operators")
     operators_module.__path__ = []
     python_module = types.ModuleType("airflow.providers.standard.operators.python")
+    trigger_module = types.ModuleType(
+        "airflow.providers.standard.operators.trigger_dagrun"
+    )
     python_module.PythonOperator = FakePythonOperator
     python_module.ShortCircuitOperator = FakePythonOperator
+    trigger_module.TriggerDagRunOperator = FakePythonOperator
 
     monkeypatch.setitem(sys.modules, "airflow", airflow_module)
     monkeypatch.setitem(sys.modules, "airflow.sdk", sdk_module)
@@ -63,6 +67,11 @@ def _load_dag_module(
     )
     monkeypatch.setitem(
         sys.modules, "airflow.providers.standard.operators.python", python_module
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "airflow.providers.standard.operators.trigger_dagrun",
+        trigger_module,
     )
 
     for name in (
@@ -103,9 +112,7 @@ def test_feature_dag_defaults_to_airflow_schedule(
         "validate_feature_set",
         "store_feature_set",
         "check_retraining_trigger",
-        "train_model",
-        "evaluate_model",
-        "register_model",
+        "trigger_training_pipeline",
     ]
     assert operators[0].kwargs["op_kwargs"] == {
         "dataset": "train",
@@ -118,9 +125,13 @@ def test_feature_dag_defaults_to_airflow_schedule(
         "feature_result": "output:store_feature_set",
         "mode": "always",
     }
-    assert operators[5].kwargs["op_kwargs"] == {"dataset": "train"}
-    assert operators[6].kwargs["op_args"] == ["output:train_model"]
-    assert operators[6].kwargs["op_kwargs"] == {"dataset": "train"}
+    assert operators[5].kwargs["trigger_dag_id"] == "training_pipeline"
+    assert operators[5].kwargs["conf"] == {
+        "dataset": "train",
+        "source_dag_id": "feature_pipeline",
+        "source_run_id": "{{ run_id }}",
+    }
+    assert operators[5].kwargs["wait_for_completion"] is False
 
 
 def test_feature_dag_supports_manual_override_dataset_and_disabled_retraining(
@@ -157,23 +168,33 @@ def test_training_dag_stays_manual_and_paused_by_default(
     assert module.dag.kwargs["schedule"] is None
     assert module.dag.kwargs["catchup"] is False
     assert module.dag.kwargs["is_paused_upon_creation"] is True
+    assert module.dag.kwargs["params"] == {"dataset": "train"}
     assert [operator.kwargs["task_id"] for operator in operators] == [
         "train_model",
         "evaluate_model",
         "register_model",
     ]
-    assert operators[0].kwargs["op_kwargs"] == {"dataset": "train"}
-    assert operators[1].kwargs["op_kwargs"] == {"dataset": "train"}
+    expected_dataset_template = (
+        "{{ dag_run.conf.get('dataset') if dag_run and dag_run.conf and "
+        "dag_run.conf.get('dataset') else params.dataset }}"
+    )
+    assert operators[0].kwargs["op_kwargs"] == {"dataset": expected_dataset_template}
+    assert operators[1].kwargs["op_kwargs"] == {"dataset": expected_dataset_template}
 
 
 def test_training_dag_supports_dataset_override(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    _, operators = _load_dag_module(
+    module, operators = _load_dag_module(
         monkeypatch,
         "dags/training_dag.py",
         env={"AIRFLOW_TRAINING_DATASET": "validation"},
     )
 
-    assert operators[0].kwargs["op_kwargs"] == {"dataset": "validation"}
-    assert operators[1].kwargs["op_kwargs"] == {"dataset": "validation"}
+    assert module.dag.kwargs["params"] == {"dataset": "validation"}
+    expected_dataset_template = (
+        "{{ dag_run.conf.get('dataset') if dag_run and dag_run.conf and "
+        "dag_run.conf.get('dataset') else params.dataset }}"
+    )
+    assert operators[0].kwargs["op_kwargs"] == {"dataset": expected_dataset_template}
+    assert operators[1].kwargs["op_kwargs"] == {"dataset": expected_dataset_template}


### PR DESCRIPTION
What changed:
- stop feature_pipeline after feature storage and trigger training_pipeline instead of embedding train/evaluate/register
- let training_pipeline accept the dataset from dag_run.conf while staying manual by default
- update DAG wiring tests and README to match the new boundary

Why:
- keep the FTI boundary explicit and decouple feature refresh from training execution

Verification:
- uv run pytest tests/test_dags.py -q

Closes: #130