### PR TITLE
fix(mlflow): keep retrained models on candidate alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ flowchart LR
 | Area | Status | Summary |
 |------|--------|---------|
 | Feature pipeline | Working | Airflow ingests, engineers, validates, and stores curated weather features |
-| Training pipeline | Working | Airflow labels data, trains the model, evaluates it, and registers versions in MLflow |
+| Training pipeline | Working | Airflow labels data, trains the model, evaluates it, and registers fresh versions in MLflow under a candidate alias |
 | Inference pipeline | Working | FastAPI serves `/health`, `/spots`, `/predict`, `/rank`, and online-feature routes, and `ui/app.py` provides the Streamlit demo |
 | Hosted runtime | Working | The shared environment runs the hosted full-stack target on one GCP host; the inference-only Cloud Run target is available but not enabled there |
 | Automation | Working | GitHub Actions publishes images, validates infrastructure, and drives remote Terraform workflows |

--- a/config.yaml
+++ b/config.yaml
@@ -266,6 +266,7 @@ labeling:
 mlflow:
   experiment_name: "foehncast"
   model_name: "foehncast-quality"
+  candidate_alias: "candidate"
   champion_alias: "champion"
 
 # Inference settings

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -45,7 +45,7 @@ flowchart LR
 | Area | Status | Meaning |
 |------|--------|---------|
 | Feature pipeline | Working | The feature DAG ingests, engineers, validates, and stores curated weather features |
-| Training pipeline | Working | The training DAG labels data, trains the model, evaluates it, and registers versions in MLflow |
+| Training pipeline | Working | The training DAG labels data, trains the model, evaluates it, and registers fresh versions in MLflow under a candidate alias |
 | Inference pipeline | Working | The app serves the model-backed API routes used for health, prediction, and ranking |
 | Hosted runtime | Working | Terraform plus the online compose stack can run Airflow, MLflow, and the API on GCP |
 | CI/CD | Working | GitHub Actions validates docs and infrastructure and supports remote Terraform operations |

--- a/src/foehncast/orchestration.py
+++ b/src/foehncast/orchestration.py
@@ -809,8 +809,8 @@ def evaluate_training_run(training_run_id: str, dataset: str = "train") -> str:
         return generate_evaluation_report(metrics, str(report_path))
 
 
-def register_training_run(training_run_id: str, stage: str = "Production") -> str:
-    """Register and promote a training run's model, returning the new version."""
+def register_training_run(training_run_id: str, stage: str = "Candidate") -> str:
+    """Register a training run's model and assign the requested registry alias."""
     model_version = register_model(training_run_id)
     promote_model(None, model_version.version, stage=stage)
     return str(model_version.version)

--- a/src/foehncast/training_pipeline/register.py
+++ b/src/foehncast/training_pipeline/register.py
@@ -20,6 +20,8 @@ def _registry_alias(stage: str, mlflow_config: dict[str, Any]) -> str:
     normalized_stage = stage.strip().lower()
     if normalized_stage == "production":
         return mlflow_config.get("champion_alias", "champion")
+    if normalized_stage == "candidate":
+        return mlflow_config.get("candidate_alias", "candidate")
 
     return normalized_stage
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -40,6 +40,7 @@ def _write_config(path: Path) -> None:
                 "mlflow": {
                     "experiment_name": "foehncast",
                     "model_name": "foehncast-quality",
+                    "candidate_alias": "candidate",
                     "champion_alias": "champion",
                 },
             },
@@ -64,6 +65,7 @@ def _write_legacy_runtime_config(path: Path) -> None:
                     "tracking_uri": "http://legacy-mlflow:5001",
                     "experiment_name": "foehncast",
                     "model_name": "foehncast-quality",
+                    "candidate_alias": "candidate",
                     "champion_alias": "champion",
                 },
             },

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -600,7 +600,7 @@ def test_register_training_run_registers_and_promotes(
     monkeypatch.setattr(
         orchestration,
         "promote_model",
-        lambda model_name, version, stage="Production": logged.update(
+        lambda model_name, version, stage="Candidate": logged.update(
             {"promotion": (model_name, version, stage)}
         ),
     )
@@ -608,4 +608,4 @@ def test_register_training_run_registers_and_promotes(
     version = orchestration.register_training_run("run-456")
 
     assert version == "7"
-    assert logged["promotion"] == (None, "7", "Production")
+    assert logged["promotion"] == (None, "7", "Candidate")

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -19,6 +19,7 @@ def mlflow_config() -> dict[str, str]:
     return {
         "tracking_uri": "http://localhost:5001",
         "model_name": "foehncast-quality",
+        "candidate_alias": "candidate",
         "champion_alias": "champion",
     }
 
@@ -179,6 +180,36 @@ def test_promote_model_assigns_champion_alias_for_production(
 
     assert logged["tracking_uri"] == "http://localhost:5001"
     assert logged["alias"] == ("foehncast-quality", "champion", "7")
+
+
+def test_promote_model_assigns_candidate_alias_for_candidate_stage(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, object] = {}
+
+    class FakeClient:
+        def set_registered_model_alias(
+            self, model_name: str, alias: str, version: str
+        ) -> None:
+            logged["alias"] = (model_name, alias, version)
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
+
+    monkeypatch.setattr(register, "mlflow", FakeMlflow())
+    monkeypatch.setattr(register, "get_mlflow_config", lambda: mlflow_config)
+    monkeypatch.setattr(
+        register, "get_mlflow_tracking_uri", lambda: "http://localhost:5001"
+    )
+
+    register.promote_model(None, 11, stage="Candidate")
+
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["alias"] == ("foehncast-quality", "candidate", "11")
 
 
 def test_get_production_model_loads_model_from_champion_alias(


### PR DESCRIPTION
What changed:
- add an explicit MLflow candidate alias in config and use it when promoting Candidate versions
- make register_training_run default to Candidate instead of Production
- update focused tests and short project summaries to reflect that fresh training runs stay off the serving alias

Why:
- keep new training outputs off the live champion alias so later canary or manual promotion can happen safely

Verification:
- uv run pytest tests/test_register.py tests/test_orchestration.py tests/test_config.py -q

Closes: #132