### PR TITLE
fix(cloud-run): add candidate deploy mode

### DIFF
--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -11,6 +11,25 @@ on:
       - uv.lock
       - config.yaml
   workflow_dispatch:
+    inputs:
+      deploy_mode:
+        description: Cloud Run deploy mode (`live` or `candidate`)
+        required: false
+        default: live
+        type: choice
+        options:
+          - live
+          - candidate
+      candidate_revision_tag:
+        description: Tagged Cloud Run revision name when deploy_mode=`candidate`
+        required: false
+        default: candidate
+        type: string
+      serving_alias:
+        description: Serving alias override (blank defaults to champion for live and candidate for candidate mode)
+        required: false
+        default: ""
+        type: string
 
 permissions:
   contents: read
@@ -28,6 +47,9 @@ jobs:
       service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
       cloud_run_service: ${{ steps.repo_config.outputs.cloud_run_service }}
       cloud_run_allow_unauthenticated: ${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}
+      deploy_mode: ${{ steps.derived.outputs.deploy_mode }}
+      cloud_run_revision_tag: ${{ steps.derived.outputs.cloud_run_revision_tag }}
+      serving_alias: ${{ steps.derived.outputs.serving_alias }}
       registry_host: ${{ steps.derived.outputs.registry_host }}
       image_repository: ${{ steps.derived.outputs.image_repository }}
       publish_ready: ${{ steps.derived.outputs.publish_ready }}
@@ -65,6 +87,9 @@ jobs:
           WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
           SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
           CLOUD_RUN_SERVICE: ${{ steps.repo_config.outputs.cloud_run_service }}
+          DEPLOY_MODE_INPUT: ${{ github.event.inputs.deploy_mode }}
+          CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
+          SERVING_ALIAS_INPUT: ${{ github.event.inputs.serving_alias }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
           set -euo pipefail
@@ -89,7 +114,31 @@ jobs:
             deploy_ready=true
           fi
 
+          deploy_mode="$(printf '%s' "${DEPLOY_MODE_INPUT:-}" | tr '[:upper:]' '[:lower:]')"
+          if [[ "$deploy_mode" != 'candidate' ]]; then
+            deploy_mode='live'
+          fi
+
+          cloud_run_revision_tag="$(printf '%s' "${CANDIDATE_REVISION_TAG_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+          cloud_run_revision_tag="${cloud_run_revision_tag#-}"
+          cloud_run_revision_tag="${cloud_run_revision_tag%-}"
+          if [[ -z "$cloud_run_revision_tag" ]]; then
+            cloud_run_revision_tag='candidate'
+          fi
+
+          serving_alias="$(printf '%s' "${SERVING_ALIAS_INPUT:-}" | tr '[:upper:]' '[:lower:]')"
+          if [[ -z "$serving_alias" ]]; then
+            if [[ "$deploy_mode" == 'candidate' ]]; then
+              serving_alias='candidate'
+            else
+              serving_alias='champion'
+            fi
+          fi
+
           {
+            echo "deploy_mode=$deploy_mode"
+            echo "cloud_run_revision_tag=$cloud_run_revision_tag"
+            echo "serving_alias=$serving_alias"
             echo "registry_host=$registry_host"
             echo "image_repository=$image_repository"
             echo "publish_ready=$publish_ready"
@@ -163,6 +212,9 @@ jobs:
       GCP_LOCATION: ${{ needs.config.outputs.location }}
       CLOUD_RUN_SERVICE: ${{ needs.config.outputs.cloud_run_service }}
       CLOUD_RUN_ALLOW_UNAUTHENTICATED: ${{ needs.config.outputs.cloud_run_allow_unauthenticated }}
+      DEPLOY_MODE: ${{ needs.config.outputs.deploy_mode }}
+      CLOUD_RUN_REVISION_TAG: ${{ needs.config.outputs.cloud_run_revision_tag }}
+      SERVING_ALIAS: ${{ needs.config.outputs.serving_alias }}
       IMAGE_URI: ${{ needs.publish.outputs.image_uri }}
     steps:
       - uses: google-github-actions/auth@v2
@@ -182,14 +234,52 @@ jobs:
       - id: deploy
         name: Deploy published image to Cloud Run
         run: |
-          gcloud run services update "$CLOUD_RUN_SERVICE" \
-            --project "$GCP_PROJECT_ID" \
-            --region "$GCP_LOCATION" \
-            --image "$IMAGE_URI" \
-            --quiet
+          set -euo pipefail
 
-          service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
-          echo "service_url=${service_url}" >> "$GITHUB_OUTPUT"
+          if [[ "$DEPLOY_MODE" == 'candidate' ]]; then
+            gcloud run deploy "$CLOUD_RUN_SERVICE" \
+              --project "$GCP_PROJECT_ID" \
+              --region "$GCP_LOCATION" \
+              --image "$IMAGE_URI" \
+              --no-traffic \
+              --tag "$CLOUD_RUN_REVISION_TAG" \
+              --update-env-vars "FOEHNCAST_MLFLOW_SERVING_ALIAS=$SERVING_ALIAS" \
+              --quiet
+
+            service_description="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format=json)"
+            service_url="$(printf '%s' "$service_description" | jq -r --arg tag "$CLOUD_RUN_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .url' | head -n1)"
+            traffic_percent="$(printf '%s' "$service_description" | jq -r --arg tag "$CLOUD_RUN_REVISION_TAG" 'first(.status.traffic[] | select(.tag == $tag) | (.percent // 0))')"
+
+            if [[ -z "$service_url" || "$service_url" == 'null' ]]; then
+              echo "Candidate tagged revision URL is empty after deploy." >&2
+              exit 1
+            fi
+
+            if [[ -z "$traffic_percent" || "$traffic_percent" == 'null' ]]; then
+              traffic_percent='0'
+            fi
+
+            if [[ "$traffic_percent" != '0' ]]; then
+              echo "Candidate deployment must keep traffic at 0%." >&2
+              exit 1
+            fi
+          else
+            gcloud run services update "$CLOUD_RUN_SERVICE" \
+              --project "$GCP_PROJECT_ID" \
+              --region "$GCP_LOCATION" \
+              --image "$IMAGE_URI" \
+              --update-env-vars "FOEHNCAST_MLFLOW_SERVING_ALIAS=$SERVING_ALIAS" \
+              --quiet
+
+            service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
+            traffic_percent='100'
+          fi
+
+          {
+            echo "deploy_mode=$DEPLOY_MODE"
+            echo "service_url=${service_url}"
+            echo "traffic_percent=${traffic_percent}"
+          } >> "$GITHUB_OUTPUT"
 
       - id: verify
         name: Verify deployed Cloud Run runtime
@@ -222,6 +312,11 @@ jobs:
             printf '%s\n' "$health_payload" >&2
             exit 1
           fi
+          if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${SERVING_ALIAS}"'"'; then
+            echo "Cloud Run health verification did not report serving alias ${SERVING_ALIAS}." >&2
+            printf '%s\n' "$health_payload" >&2
+            exit 1
+          fi
 
           echo "Checking Cloud Run spots endpoint at ${spots_url}..."
           spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
@@ -238,9 +333,15 @@ jobs:
           {
             echo "## Cloud Run deployment"
             echo
+            echo "- Mode: $DEPLOY_MODE"
             echo "- Service: $CLOUD_RUN_SERVICE"
             echo "- Image: $IMAGE_URI"
             echo "- URL: ${{ steps.deploy.outputs.service_url }}"
+            echo "- Serving alias: $SERVING_ALIAS"
+            echo "- Traffic: ${{ steps.deploy.outputs.traffic_percent }}%"
+            if [[ "$DEPLOY_MODE" == 'candidate' ]]; then
+              echo "- Tagged revision: $CLOUD_RUN_REVISION_TAG"
+            fi
             echo "- Smoke check: passed"
             echo "- Invocation: ${{ steps.verify.outputs.invocation_mode }}"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/src/foehncast/inference_pipeline/predict.py
+++ b/src/foehncast/inference_pipeline/predict.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 from typing import Any
 
 import mlflow
@@ -16,7 +17,10 @@ from foehncast.config import (
 )
 from foehncast.feature_pipeline.engineer import engineer_features
 from foehncast.feature_pipeline.ingest import fetch_forecast
-from foehncast.training_pipeline.register import get_production_model
+from foehncast.training_pipeline.register import get_model_by_alias
+
+
+_DEFAULT_SERVING_ALIAS = "champion"
 
 
 def _spot_lookup() -> dict[str, dict[str, Any]]:
@@ -41,15 +45,30 @@ def list_available_spots() -> list[dict[str, Any]]:
     return [spot.copy() for spot in get_spots()]
 
 
-def get_serving_model_version(model_name: str | None = None) -> str:
+def get_serving_model_alias() -> str:
+    """Return the registry alias this runtime should serve."""
+    override = os.getenv("FOEHNCAST_MLFLOW_SERVING_ALIAS", "").strip()
+    if override:
+        return override
+
+    mlflow_config = get_mlflow_config()
+    configured_alias = str(mlflow_config.get("champion_alias", "")).strip()
+    return configured_alias or _DEFAULT_SERVING_ALIAS
+
+
+def get_serving_model_version(
+    model_name: str | None = None, alias: str | None = None
+) -> str:
     """Return the MLflow registry version currently assigned to the serving alias."""
     mlflow_config = get_mlflow_config()
     resolved_model_name = model_name or mlflow_config["model_name"]
-    alias = mlflow_config.get("champion_alias", "champion")
+    resolved_alias = alias or get_serving_model_alias()
 
     mlflow.set_tracking_uri(get_mlflow_tracking_uri())
     client = mlflow.MlflowClient()
-    model_version = client.get_model_version_by_alias(resolved_model_name, alias)
+    model_version = client.get_model_version_by_alias(
+        resolved_model_name, resolved_alias
+    )
     return str(model_version.version)
 
 
@@ -64,7 +83,8 @@ def _prepare_feature_frame(
 def predict_spots(spot_ids: list[str] | None = None) -> dict[str, Any]:
     """Fetch forecasts for the requested spots and return model predictions."""
     requested_spots = _resolve_spots(spot_ids)
-    model = get_production_model()
+    serving_alias = get_serving_model_alias()
+    model = get_model_by_alias(serving_alias)
     model_config = get_model_config()
     inference_config = get_inference_config()
     feature_columns = model_config["features"]
@@ -109,6 +129,6 @@ def predict_spots(spot_ids: list[str] | None = None) -> dict[str, Any]:
         )
 
     return {
-        "model_version": get_serving_model_version(),
+        "model_version": get_serving_model_version(alias=serving_alias),
         "predictions": predictions,
     }

--- a/src/foehncast/inference_pipeline/serve.py
+++ b/src/foehncast/inference_pipeline/serve.py
@@ -14,6 +14,7 @@ from foehncast.config import get_rider_config
 from foehncast.inference_pipeline.demo import render_online_features_demo
 from foehncast.inference_pipeline.online_features import get_online_spot_features
 from foehncast.inference_pipeline.predict import (
+    get_serving_model_alias,
     get_serving_model_version,
     list_available_spots,
     predict_spots,
@@ -124,6 +125,7 @@ def create_app() -> FastAPI:
         try:
             return {
                 "status": "healthy",
+                "model_alias": get_serving_model_alias(),
                 "model_version": get_serving_model_version(),
             }
         except Exception as exc:

--- a/src/foehncast/training_pipeline/register.py
+++ b/src/foehncast/training_pipeline/register.py
@@ -74,9 +74,21 @@ def promote_model(
 
 
 def get_production_model(model_name: str | None = None) -> Any:
-    """Load the currently deployed production model from the registry."""
+    """Load a registry model by alias, defaulting to the production alias."""
     mlflow_config = get_mlflow_config()
     resolved_model_name = _resolved_model_name(model_name, mlflow_config)
     alias = _registry_alias("Production", mlflow_config)
     mlflow.set_tracking_uri(get_mlflow_tracking_uri())
     return mlflow.pyfunc.load_model(f"models:/{resolved_model_name}@{alias}")
+
+
+def get_model_by_alias(alias: str, model_name: str | None = None) -> Any:
+    """Load a registry model from an explicit alias."""
+    normalized_alias = alias.strip()
+    if not normalized_alias:
+        raise ValueError("Model alias must be non-empty")
+
+    mlflow_config = get_mlflow_config()
+    resolved_model_name = _resolved_model_name(model_name, mlflow_config)
+    mlflow.set_tracking_uri(get_mlflow_tracking_uri())
+    return mlflow.pyfunc.load_model(f"models:/{resolved_model_name}@{normalized_alias}")

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -179,6 +179,7 @@ In normal operation you should not edit these variables by hand. The bootstrap p
 `GCP_CLOUD_RUN_SERVICE` stays unset until Terraform has actually provisioned the Cloud Run service. After that, publish automation can update the service with newly built images.
 
 When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health` plus `/spots`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.
+Manual workflow dispatch also supports `deploy_mode=candidate`. That path deploys a tagged no-traffic Cloud Run revision, sets `FOEHNCAST_MLFLOW_SERVING_ALIAS` for that revision, and smoke-checks the tagged URL before any later traffic shift.
 
 ## GitHub Actions Terraform Path
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -470,6 +470,12 @@ def test_remote_terraform_workflow_verifies_hosted_runtimes_after_apply() -> Non
 def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> None:
     workflow = _workflow_yaml(".github/workflows/publish-app-image.yml")
     config_job = workflow["jobs"]["config"]
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+
+    assert dispatch_inputs["deploy_mode"]["type"] == "choice"
+    assert dispatch_inputs["deploy_mode"]["options"] == ["live", "candidate"]
+    assert dispatch_inputs["candidate_revision_tag"]["default"] == "candidate"
+    assert dispatch_inputs["serving_alias"]["default"] == ""
 
     assert (
         config_job["outputs"]["cloud_run_service"]
@@ -479,13 +485,41 @@ def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> N
         config_job["outputs"]["cloud_run_allow_unauthenticated"]
         == "${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}"
     )
+    assert (
+        config_job["outputs"]["deploy_mode"]
+        == "${{ steps.derived.outputs.deploy_mode }}"
+    )
+    assert (
+        config_job["outputs"]["cloud_run_revision_tag"]
+        == "${{ steps.derived.outputs.cloud_run_revision_tag }}"
+    )
+    assert (
+        config_job["outputs"]["serving_alias"]
+        == "${{ steps.derived.outputs.serving_alias }}"
+    )
 
     derived_step = _workflow_step(workflow, "config", "derived")
     assert (
         derived_step["env"]["CLOUD_RUN_SERVICE"]
         == "${{ steps.repo_config.outputs.cloud_run_service }}"
     )
+    assert (
+        derived_step["env"]["DEPLOY_MODE_INPUT"]
+        == "${{ github.event.inputs.deploy_mode }}"
+    )
+    assert (
+        derived_step["env"]["CANDIDATE_REVISION_TAG_INPUT"]
+        == "${{ github.event.inputs.candidate_revision_tag }}"
+    )
+    assert (
+        derived_step["env"]["SERVING_ALIAS_INPUT"]
+        == "${{ github.event.inputs.serving_alias }}"
+    )
     assert '-n "$CLOUD_RUN_SERVICE"' in derived_step["run"]
+    assert "deploy_mode='live'" in derived_step["run"]
+    assert "cloud_run_revision_tag='candidate'" in derived_step["run"]
+    assert "serving_alias='candidate'" in derived_step["run"]
+    assert "serving_alias='champion'" in derived_step["run"]
 
     deploy_job = workflow["jobs"]["deploy"]
     assert (
@@ -496,6 +530,28 @@ def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> N
         deploy_job["env"]["CLOUD_RUN_ALLOW_UNAUTHENTICATED"]
         == "${{ needs.config.outputs.cloud_run_allow_unauthenticated }}"
     )
+    assert deploy_job["env"]["DEPLOY_MODE"] == "${{ needs.config.outputs.deploy_mode }}"
+    assert (
+        deploy_job["env"]["CLOUD_RUN_REVISION_TAG"]
+        == "${{ needs.config.outputs.cloud_run_revision_tag }}"
+    )
+    assert (
+        deploy_job["env"]["SERVING_ALIAS"]
+        == "${{ needs.config.outputs.serving_alias }}"
+    )
+
+    deploy_step = _workflow_step(
+        workflow, "deploy", "Deploy published image to Cloud Run"
+    )
+    deploy_script = deploy_step["run"]
+
+    assert "if [[ \"$DEPLOY_MODE\" == 'candidate' ]]; then" in deploy_script
+    assert 'gcloud run deploy "$CLOUD_RUN_SERVICE"' in deploy_script
+    assert "--no-traffic" in deploy_script
+    assert ' --tag "$CLOUD_RUN_REVISION_TAG"' in deploy_script
+    assert "FOEHNCAST_MLFLOW_SERVING_ALIAS=$SERVING_ALIAS" in deploy_script
+    assert "traffic_percent='100'" in deploy_script
+    assert 'echo "traffic_percent=${traffic_percent}"' in deploy_script
 
     verify_step = _workflow_step(
         workflow, "deploy", "Verify deployed Cloud Run runtime"
@@ -517,12 +573,24 @@ def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> N
     assert (
         'grep -Eq \x27"status"[[:space:]]*:[[:space:]]*"healthy"\x27' in verify_script
     )
+    assert '"model_alias"' in verify_script
+    assert (
+        "Cloud Run health verification did not report serving alias ${SERVING_ALIAS}."
+        in verify_script
+    )
     assert 'grep -Eq \x27"id"[[:space:]]*:\x27' in verify_script
     assert (
         'echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"' in verify_script
     )
 
     summary_step = _workflow_step(workflow, "deploy", "Summarize Cloud Run deployment")
+    assert 'echo "- Mode: $DEPLOY_MODE"' in summary_step["run"]
+    assert 'echo "- Serving alias: $SERVING_ALIAS"' in summary_step["run"]
+    assert (
+        'echo "- Traffic: ${{ steps.deploy.outputs.traffic_percent }}%"'
+        in summary_step["run"]
+    )
+    assert 'echo "- Tagged revision: $CLOUD_RUN_REVISION_TAG"' in summary_step["run"]
     assert 'echo "- Smoke check: passed"' in summary_step["run"]
     assert (
         'echo "- Invocation: ${{ steps.verify.outputs.invocation_mode }}"'

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -63,6 +63,7 @@ def test_get_serving_model_version_reads_alias(
 ) -> None:
     logged: dict[str, object] = {}
 
+    monkeypatch.delenv("FOEHNCAST_MLFLOW_SERVING_ALIAS", raising=False)
     monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
 
     class FakeClient:
@@ -84,6 +85,7 @@ def test_get_serving_model_version_reads_alias(
         lambda: {
             "tracking_uri": "http://localhost:5001",
             "model_name": "foehncast-quality",
+            "candidate_alias": "candidate",
             "champion_alias": "champion",
         },
     )
@@ -100,6 +102,50 @@ def test_get_serving_model_version_reads_alias(
     assert logged["lookup"] == ("foehncast-quality", "champion")
 
 
+def test_get_serving_model_version_prefers_env_alias_override(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: dict[str, object] = {}
+
+    monkeypatch.setenv("FOEHNCAST_MLFLOW_SERVING_ALIAS", "candidate")
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+
+    class FakeClient:
+        def get_model_version_by_alias(self, model_name: str, alias: str) -> object:
+            logged["lookup"] = (model_name, alias)
+            return SimpleNamespace(version="11")
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
+
+    monkeypatch.setattr(predict, "mlflow", FakeMlflow())
+    monkeypatch.setattr(
+        predict,
+        "get_mlflow_config",
+        lambda: {
+            "tracking_uri": "http://localhost:5001",
+            "model_name": "foehncast-quality",
+            "candidate_alias": "candidate",
+            "champion_alias": "champion",
+        },
+    )
+    monkeypatch.setattr(
+        predict,
+        "get_mlflow_tracking_uri",
+        lambda: "http://localhost:5001",
+    )
+
+    model_version = predict.get_serving_model_version()
+
+    assert model_version == "11"
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["lookup"] == ("foehncast-quality", "candidate")
+
+
 def test_predict_spots_returns_forecasts_for_requested_spots(
     monkeypatch: pytest.MonkeyPatch,
     model_config: dict[str, object],
@@ -111,14 +157,23 @@ def test_predict_spots_returns_forecasts_for_requested_spots(
             assert list(features_df.columns) == model_config["features"]
             return [2.1, 3.2]
 
-    monkeypatch.setattr(predict, "get_production_model", lambda: FakeModel())
+    monkeypatch.setattr(predict, "get_serving_model_alias", lambda: "champion")
+    monkeypatch.setattr(
+        predict,
+        "get_model_by_alias",
+        lambda alias: FakeModel() if alias == "champion" else None,
+    )
     monkeypatch.setattr(predict, "get_model_config", lambda: model_config)
     monkeypatch.setattr(
         predict, "get_inference_config", lambda: {"max_horizon_hours": 2}
     )
     monkeypatch.setattr(predict, "get_spots", lambda: [spot])
     monkeypatch.setattr(predict, "fetch_forecast", lambda lat, lon: forecast_df)
-    monkeypatch.setattr(predict, "get_serving_model_version", lambda: "7")
+    monkeypatch.setattr(
+        predict,
+        "get_serving_model_version",
+        lambda model_name=None, alias=None: "7",
+    )
 
     result = predict.predict_spots(["silvaplana"])
 
@@ -141,12 +196,17 @@ def test_predict_spots_rejects_unknown_spots(
 
 def test_health_endpoint_reports_model_version(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(serve, "get_serving_model_version", lambda: "9")
+    monkeypatch.setattr(serve, "get_serving_model_alias", lambda: "candidate")
     client = TestClient(serve.app)
 
     response = client.get("/health")
 
     assert response.status_code == 200
-    assert response.json() == {"status": "healthy", "model_version": "9"}
+    assert response.json() == {
+        "status": "healthy",
+        "model_alias": "candidate",
+        "model_version": "9",
+    }
 
 
 def test_spots_endpoint_lists_available_spots(

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -240,3 +240,33 @@ def test_get_production_model_loads_model_from_champion_alias(
     assert model is expected_model
     assert logged["tracking_uri"] == "http://localhost:5001"
     assert logged["model_uri"] == "models:/foehncast-quality@champion"
+
+
+def test_get_model_by_alias_loads_requested_alias(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, str] = {}
+    expected_model = object()
+
+    class FakePyfunc:
+        def load_model(self, model_uri: str) -> object:
+            logged["model_uri"] = model_uri
+            return expected_model
+
+    class FakeMlflow:
+        pyfunc = FakePyfunc()
+
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+    monkeypatch.setattr(register, "mlflow", FakeMlflow())
+    monkeypatch.setattr(register, "get_mlflow_config", lambda: mlflow_config)
+    monkeypatch.setattr(
+        register, "get_mlflow_tracking_uri", lambda: "http://localhost:5001"
+    )
+
+    model = register.get_model_by_alias("candidate")
+
+    assert model is expected_model
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["model_uri"] == "models:/foehncast-quality@candidate"


### PR DESCRIPTION
What changed:
- add a runtime MLflow serving-alias override and expose the active alias from /health
- add manual Cloud Run candidate deploy mode with tagged no-traffic revisions and alias-aware smoke checks
- extend the workflow contract tests and maintainer docs for the candidate path

Why:
- validate candidate revisions in parallel with the live champion service before any traffic shift

Verification:
- uv run pytest tests/test_predict.py tests/test_register.py tests/test_cloud_operator_contract.py -q

Closes: #134