### PR TITLE
fix(cloud-run): add candidate promotion workflow

### DIFF
--- a/.github/workflows/promote-candidate.yml
+++ b/.github/workflows/promote-candidate.yml
@@ -1,0 +1,365 @@
+name: Promote Candidate Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      candidate_revision_tag:
+        description: Tagged Cloud Run candidate revision to promote
+        required: false
+        default: candidate
+        type: string
+      candidate_alias:
+        description: MLflow alias expected on the tagged candidate revision
+        required: false
+        default: candidate
+        type: string
+      target_alias:
+        description: MLflow alias the live service should use after promotion
+        required: false
+        default: champion
+        type: string
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
+      project_id: ${{ steps.repo_config.outputs.project_id }}
+      location: ${{ steps.repo_config.outputs.location }}
+      cloud_run_service: ${{ steps.repo_config.outputs.cloud_run_service }}
+      cloud_run_allow_unauthenticated: ${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}
+      mlflow_tracking_uri: ${{ steps.repo_config.outputs.mlflow_tracking_uri }}
+      workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
+      service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
+      candidate_revision_tag: ${{ steps.derived.outputs.candidate_revision_tag }}
+      candidate_alias: ${{ steps.derived.outputs.candidate_alias }}
+      target_alias: ${{ steps.derived.outputs.target_alias }}
+      promote_ready: ${{ steps.derived.outputs.promote_ready }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - id: flags
+        env:
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          owner_allowed=false
+          if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
+            owner_allowed=true
+          fi
+
+          echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
+
+      - id: repo_config
+        uses: ./.github/actions/load-gcp-repo-config
+        with:
+          repo-vars-json: ${{ toJson(vars) }}
+
+      - id: derived
+        env:
+          CLOUD_RUN_SERVICE: ${{ steps.repo_config.outputs.cloud_run_service }}
+          MLFLOW_TRACKING_URI: ${{ steps.repo_config.outputs.mlflow_tracking_uri }}
+          WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
+          SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
+          CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
+          CANDIDATE_ALIAS_INPUT: ${{ github.event.inputs.candidate_alias }}
+          TARGET_ALIAS_INPUT: ${{ github.event.inputs.target_alias }}
+        run: |
+          set -euo pipefail
+
+          promote_ready=false
+          if [[ -n "$CLOUD_RUN_SERVICE" && -n "$MLFLOW_TRACKING_URI" && -n "$WORKLOAD_IDENTITY_PROVIDER" && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
+            promote_ready=true
+          fi
+
+          candidate_revision_tag="$(printf '%s' "${CANDIDATE_REVISION_TAG_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+          candidate_revision_tag="${candidate_revision_tag#-}"
+          candidate_revision_tag="${candidate_revision_tag%-}"
+          if [[ -z "$candidate_revision_tag" ]]; then
+            candidate_revision_tag='candidate'
+          fi
+
+          candidate_alias="$(printf '%s' "${CANDIDATE_ALIAS_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]')"
+          if [[ -z "$candidate_alias" ]]; then
+            candidate_alias='candidate'
+          fi
+
+          target_alias="$(printf '%s' "${TARGET_ALIAS_INPUT:-champion}" | tr '[:upper:]' '[:lower:]')"
+          if [[ -z "$target_alias" ]]; then
+            target_alias='champion'
+          fi
+
+          {
+            echo "candidate_revision_tag=$candidate_revision_tag"
+            echo "candidate_alias=$candidate_alias"
+            echo "target_alias=$target_alias"
+            echo "promote_ready=$promote_ready"
+          } >> "$GITHUB_OUTPUT"
+
+  promote:
+    needs: config
+    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.promote_ready == 'true' }}
+    runs-on: ubuntu-latest
+    environment: cloud-run-production
+    env:
+      GCP_PROJECT_ID: ${{ needs.config.outputs.project_id }}
+      GCP_LOCATION: ${{ needs.config.outputs.location }}
+      CLOUD_RUN_SERVICE: ${{ needs.config.outputs.cloud_run_service }}
+      CLOUD_RUN_ALLOW_UNAUTHENTICATED: ${{ needs.config.outputs.cloud_run_allow_unauthenticated }}
+      MLFLOW_TRACKING_URI: ${{ needs.config.outputs.mlflow_tracking_uri }}
+      CANDIDATE_REVISION_TAG: ${{ needs.config.outputs.candidate_revision_tag }}
+      CANDIDATE_ALIAS: ${{ needs.config.outputs.candidate_alias }}
+      TARGET_ALIAS: ${{ needs.config.outputs.target_alias }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
+          service_account: ${{ needs.config.outputs.service_account_email }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install runtime dependencies
+        run: uv sync --frozen --no-default-groups
+
+      - name: Confirm Cloud Run service exists
+        run: |
+          gcloud run services describe "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_LOCATION" \
+            --format='value(metadata.name)' >/dev/null
+
+      - id: resolve_candidate
+        name: Resolve candidate revision
+        run: |
+          set -euo pipefail
+
+          service_description="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format=json)"
+          candidate_revision_name="$(printf '%s' "$service_description" | jq -r --arg tag "$CANDIDATE_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .revisionName' | head -n1)"
+          candidate_url="$(printf '%s' "$service_description" | jq -r --arg tag "$CANDIDATE_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .url' | head -n1)"
+          candidate_traffic_percent="$(printf '%s' "$service_description" | jq -r --arg tag "$CANDIDATE_REVISION_TAG" 'first(.status.traffic[] | select(.tag == $tag) | (.percent // 0))')"
+
+          if [[ -z "$candidate_revision_name" || "$candidate_revision_name" == 'null' ]]; then
+            echo "Candidate revision tag ${CANDIDATE_REVISION_TAG} was not found on the Cloud Run service." >&2
+            exit 1
+          fi
+
+          if [[ -z "$candidate_url" || "$candidate_url" == 'null' ]]; then
+            echo "Candidate revision URL is empty for tag ${CANDIDATE_REVISION_TAG}." >&2
+            exit 1
+          fi
+
+          if [[ -z "$candidate_traffic_percent" || "$candidate_traffic_percent" == 'null' ]]; then
+            candidate_traffic_percent='0'
+          fi
+
+          if [[ "$candidate_traffic_percent" != '0' ]]; then
+            echo "Candidate revision must remain at 0% traffic before promotion." >&2
+            exit 1
+          fi
+
+          candidate_image="$(gcloud run revisions describe "$candidate_revision_name" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(spec.containers[0].image)')"
+          if [[ -z "$candidate_image" ]]; then
+            echo "Candidate revision image could not be resolved." >&2
+            exit 1
+          fi
+
+          {
+            echo "candidate_revision_name=${candidate_revision_name}"
+            echo "candidate_url=${candidate_url}"
+            echo "candidate_traffic_percent=${candidate_traffic_percent}"
+            echo "candidate_image=${candidate_image}"
+          } >> "$GITHUB_OUTPUT"
+
+      - id: verify_candidate
+        name: Verify candidate Cloud Run runtime
+        env:
+          SERVICE_URL: ${{ steps.resolve_candidate.outputs.candidate_url }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$SERVICE_URL" ]]; then
+            echo "Candidate service URL is empty." >&2
+            exit 1
+          fi
+
+          health_url="${SERVICE_URL%/}/health"
+          allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
+          curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
+          invocation_mode="anonymous"
+
+          if [[ "$allow_unauthenticated" != 'true' ]]; then
+            invocation_mode="identity-token"
+            identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
+            curl_args+=(-H "Authorization: Bearer ${identity_token}")
+          fi
+
+          echo "Waiting for candidate health at ${health_url}..."
+          health_payload="$(curl "${curl_args[@]}" "$health_url")"
+          if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+            echo "Candidate health verification failed." >&2
+            printf '%s\n' "$health_payload" >&2
+            exit 1
+          fi
+
+          if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${CANDIDATE_ALIAS}"'"'; then
+            echo "Candidate health verification did not report serving alias ${CANDIDATE_ALIAS}." >&2
+            printf '%s\n' "$health_payload" >&2
+            exit 1
+          fi
+
+          candidate_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
+          if [[ -z "$candidate_model_version" ]]; then
+            echo "Candidate health payload did not include model_version." >&2
+            printf '%s\n' "$health_payload" >&2
+            exit 1
+          fi
+
+          {
+            echo "candidate_model_version=${candidate_model_version}"
+            echo "candidate_invocation_mode=${invocation_mode}"
+          } >> "$GITHUB_OUTPUT"
+
+      - id: promote_model
+        name: Promote candidate model version to champion
+        env:
+          CANDIDATE_MODEL_VERSION: ${{ steps.verify_candidate.outputs.candidate_model_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$MLFLOW_TRACKING_URI" || -z "$CANDIDATE_MODEL_VERSION" ]]; then
+            echo "MLflow tracking URI and candidate model version are required for promotion." >&2
+            exit 1
+          fi
+
+          promoted_model_version="$(uv run python -m foehncast.training_pipeline.promote --version "$CANDIDATE_MODEL_VERSION" --target-stage Production)"
+          if [[ -z "$promoted_model_version" ]]; then
+            echo "Promoted model version output is empty." >&2
+            exit 1
+          fi
+
+          if [[ "$promoted_model_version" != "$CANDIDATE_MODEL_VERSION" ]]; then
+            echo "Promoted model version does not match the validated candidate model version." >&2
+            exit 1
+          fi
+
+          echo "promoted_model_version=${promoted_model_version}" >> "$GITHUB_OUTPUT"
+
+      - id: deploy_live
+        name: Deploy promoted image to live Cloud Run service
+        env:
+          CANDIDATE_IMAGE: ${{ steps.resolve_candidate.outputs.candidate_image }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$CANDIDATE_IMAGE" ]]; then
+            echo "Candidate image is empty." >&2
+            exit 1
+          fi
+
+          gcloud run services update "$CLOUD_RUN_SERVICE" \
+            --project "$GCP_PROJECT_ID" \
+            --region "$GCP_LOCATION" \
+            --image "$CANDIDATE_IMAGE" \
+            --update-env-vars "FOEHNCAST_MLFLOW_SERVING_ALIAS=$TARGET_ALIAS" \
+            --quiet
+
+          live_service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
+          if [[ -z "$live_service_url" ]]; then
+            echo "Live Cloud Run service URL is empty after promotion deploy." >&2
+            exit 1
+          fi
+
+          echo "service_url=${live_service_url}" >> "$GITHUB_OUTPUT"
+
+      - id: verify_live
+        name: Verify promoted live Cloud Run runtime
+        env:
+          SERVICE_URL: ${{ steps.deploy_live.outputs.service_url }}
+          PROMOTED_MODEL_VERSION: ${{ steps.promote_model.outputs.promoted_model_version }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "$SERVICE_URL" || -z "$PROMOTED_MODEL_VERSION" ]]; then
+            echo "Live service URL and promoted model version are required for verification." >&2
+            exit 1
+          fi
+
+          health_url="${SERVICE_URL%/}/health"
+          spots_url="${SERVICE_URL%/}/spots"
+          allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
+          curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
+          invocation_mode="anonymous"
+
+          if [[ "$allow_unauthenticated" != 'true' ]]; then
+            invocation_mode="identity-token"
+            identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
+            curl_args+=(-H "Authorization: Bearer ${identity_token}")
+          fi
+
+          echo "Waiting for live health at ${health_url}..."
+          health_payload="$(curl "${curl_args[@]}" "$health_url")"
+          if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+            echo "Live health verification failed." >&2
+            printf '%s\n' "$health_payload" >&2
+            exit 1
+          fi
+
+          if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${TARGET_ALIAS}"'"'; then
+            echo "Live health verification did not report serving alias ${TARGET_ALIAS}." >&2
+            printf '%s\n' "$health_payload" >&2
+            exit 1
+          fi
+
+          live_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
+          if [[ "$live_model_version" != "$PROMOTED_MODEL_VERSION" ]]; then
+            echo "Live service model version does not match the promoted model version." >&2
+            printf '%s\n' "$health_payload" >&2
+            exit 1
+          fi
+
+          echo "Checking live Cloud Run spots endpoint at ${spots_url}..."
+          spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
+          if ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
+            echo "Live Cloud Run spots verification failed." >&2
+            printf '%s\n' "$spots_payload" >&2
+            exit 1
+          fi
+
+          echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"
+
+      - name: Summarize promotion
+        run: |
+          {
+            echo "## Candidate promotion"
+            echo
+            echo "- Service: $CLOUD_RUN_SERVICE"
+            echo "- Candidate tag: $CANDIDATE_REVISION_TAG"
+            echo "- Candidate revision: ${{ steps.resolve_candidate.outputs.candidate_revision_name }}"
+            echo "- Candidate image: ${{ steps.resolve_candidate.outputs.candidate_image }}"
+            echo "- Promoted model version: ${{ steps.promote_model.outputs.promoted_model_version }}"
+            echo "- Live alias: $TARGET_ALIAS"
+            echo "- URL: ${{ steps.deploy_live.outputs.service_url }}"
+            echo "- Invocation: ${{ steps.verify_live.outputs.invocation_mode }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  blocked:
+    needs: config
+    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.promote_ready != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain blocked promotion workflow
+        run: |
+          set -euo pipefail
+          echo 'Candidate promotion requires GCP_CLOUD_RUN_SERVICE, GCP_MLFLOW_TRACKING_URI, GCP_WORKLOAD_IDENTITY_PROVIDER, and GCP_SERVICE_ACCOUNT_EMAIL repository variables.' >&2
+          exit 1

--- a/src/foehncast/training_pipeline/promote.py
+++ b/src/foehncast/training_pipeline/promote.py
@@ -1,0 +1,85 @@
+"""Promote validated model versions to the live serving alias."""
+
+from __future__ import annotations
+
+import argparse
+from typing import Any
+
+import mlflow
+
+from foehncast.config import get_mlflow_config, get_mlflow_tracking_uri
+from foehncast.training_pipeline.register import promote_model
+
+
+def _resolved_model_name(model_name: str | None, mlflow_config: dict[str, Any]) -> str:
+    return model_name or mlflow_config["model_name"]
+
+
+def resolve_model_version_by_alias(alias: str, model_name: str | None = None) -> str:
+    """Return the registered model version currently assigned to an alias."""
+    normalized_alias = alias.strip()
+    if not normalized_alias:
+        raise ValueError("Model alias must be non-empty")
+
+    mlflow_config = get_mlflow_config()
+    resolved_model_name = _resolved_model_name(model_name, mlflow_config)
+    mlflow.set_tracking_uri(get_mlflow_tracking_uri())
+    client = mlflow.MlflowClient()
+    model_version = client.get_model_version_by_alias(
+        resolved_model_name, normalized_alias
+    )
+    return str(model_version.version)
+
+
+def promote_model_version(
+    version: str | int, *, stage: str = "Production", model_name: str | None = None
+) -> str:
+    """Assign the target stage alias to an explicit registered model version."""
+    normalized_version = str(version).strip()
+    if not normalized_version:
+        raise ValueError("Model version must be non-empty")
+
+    promote_model(model_name, normalized_version, stage=stage)
+    return normalized_version
+
+
+def promote_model_alias(
+    source_alias: str = "candidate",
+    *,
+    stage: str = "Production",
+    model_name: str | None = None,
+) -> str:
+    """Promote the version currently behind a source alias."""
+    version = resolve_model_version_by_alias(source_alias, model_name=model_name)
+    return promote_model_version(version, stage=stage, model_name=model_name)
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-name", default=None)
+    parser.add_argument("--source-alias", default="candidate")
+    parser.add_argument("--version", default=None)
+    parser.add_argument("--target-stage", default="Production")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    if args.version is not None:
+        promoted_version = promote_model_version(
+            args.version,
+            stage=args.target_stage,
+            model_name=args.model_name,
+        )
+    else:
+        promoted_version = promote_model_alias(
+            args.source_alias,
+            stage=args.target_stage,
+            model_name=args.model_name,
+        )
+
+    print(promoted_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -180,6 +180,7 @@ In normal operation you should not edit these variables by hand. The bootstrap p
 
 When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health` plus `/spots`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.
 Manual workflow dispatch also supports `deploy_mode=candidate`. That path deploys a tagged no-traffic Cloud Run revision, sets `FOEHNCAST_MLFLOW_SERVING_ALIAS` for that revision, and smoke-checks the tagged URL before any later traffic shift.
+After a candidate revision has been validated, `.github/workflows/promote-candidate.yml` promotes the exact validated model version to the live `champion` alias, redeploys the live Cloud Run service with the validated candidate image, and verifies the live `/health` response reports `champion` plus the promoted model version.
 
 ## GitHub Actions Terraform Path
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -598,6 +598,182 @@ def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> N
     )
 
 
+def test_promote_candidate_workflow_reuses_validated_candidate_for_live_promotion() -> (
+    None
+):
+    workflow = _workflow_yaml(".github/workflows/promote-candidate.yml")
+    config_job = workflow["jobs"]["config"]
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+
+    assert dispatch_inputs["candidate_revision_tag"]["default"] == "candidate"
+    assert dispatch_inputs["candidate_alias"]["default"] == "candidate"
+    assert dispatch_inputs["target_alias"]["default"] == "champion"
+
+    assert (
+        config_job["outputs"]["cloud_run_service"]
+        == "${{ steps.repo_config.outputs.cloud_run_service }}"
+    )
+    assert (
+        config_job["outputs"]["mlflow_tracking_uri"]
+        == "${{ steps.repo_config.outputs.mlflow_tracking_uri }}"
+    )
+    assert (
+        config_job["outputs"]["candidate_revision_tag"]
+        == "${{ steps.derived.outputs.candidate_revision_tag }}"
+    )
+    assert (
+        config_job["outputs"]["candidate_alias"]
+        == "${{ steps.derived.outputs.candidate_alias }}"
+    )
+    assert (
+        config_job["outputs"]["target_alias"]
+        == "${{ steps.derived.outputs.target_alias }}"
+    )
+    assert (
+        config_job["outputs"]["promote_ready"]
+        == "${{ steps.derived.outputs.promote_ready }}"
+    )
+
+    derived_step = _workflow_step(workflow, "config", "derived")
+    assert (
+        derived_step["env"]["MLFLOW_TRACKING_URI"]
+        == "${{ steps.repo_config.outputs.mlflow_tracking_uri }}"
+    )
+    assert (
+        derived_step["env"]["CANDIDATE_REVISION_TAG_INPUT"]
+        == "${{ github.event.inputs.candidate_revision_tag }}"
+    )
+    assert (
+        derived_step["env"]["CANDIDATE_ALIAS_INPUT"]
+        == "${{ github.event.inputs.candidate_alias }}"
+    )
+    assert (
+        derived_step["env"]["TARGET_ALIAS_INPUT"]
+        == "${{ github.event.inputs.target_alias }}"
+    )
+    assert "promote_ready=true" in derived_step["run"]
+    assert "candidate_revision_tag='candidate'" in derived_step["run"]
+    assert "candidate_alias='candidate'" in derived_step["run"]
+    assert "target_alias='champion'" in derived_step["run"]
+
+    promote_job = workflow["jobs"]["promote"]
+    assert promote_job["environment"] == "cloud-run-production"
+    assert (
+        promote_job["env"]["MLFLOW_TRACKING_URI"]
+        == "${{ needs.config.outputs.mlflow_tracking_uri }}"
+    )
+    assert (
+        promote_job["env"]["CANDIDATE_REVISION_TAG"]
+        == "${{ needs.config.outputs.candidate_revision_tag }}"
+    )
+    assert (
+        promote_job["env"]["CANDIDATE_ALIAS"]
+        == "${{ needs.config.outputs.candidate_alias }}"
+    )
+    assert (
+        promote_job["env"]["TARGET_ALIAS"] == "${{ needs.config.outputs.target_alias }}"
+    )
+
+    install_step = _workflow_step(workflow, "promote", "Install runtime dependencies")
+    assert install_step["run"] == "uv sync --frozen --no-default-groups"
+
+    resolve_step = _workflow_step(workflow, "promote", "Resolve candidate revision")
+    resolve_script = resolve_step["run"]
+    assert 'gcloud run services describe "$CLOUD_RUN_SERVICE"' in resolve_script
+    assert 'gcloud run revisions describe "$candidate_revision_name"' in resolve_script
+    assert (
+        "Candidate revision must remain at 0% traffic before promotion."
+        in resolve_script
+    )
+    assert 'echo "candidate_image=${candidate_image}"' in resolve_script
+
+    verify_candidate_step = _workflow_step(
+        workflow, "promote", "Verify candidate Cloud Run runtime"
+    )
+    verify_candidate_script = verify_candidate_step["run"]
+    assert (
+        verify_candidate_step["env"]["SERVICE_URL"]
+        == "${{ steps.resolve_candidate.outputs.candidate_url }}"
+    )
+    assert (
+        'gcloud auth print-identity-token --audiences="$SERVICE_URL"'
+        in verify_candidate_script
+    )
+    assert (
+        "Candidate health verification did not report serving alias ${CANDIDATE_ALIAS}."
+        in verify_candidate_script
+    )
+    assert "candidate_model_version" in verify_candidate_script
+
+    promote_model_step = _workflow_step(
+        workflow, "promote", "Promote candidate model version to champion"
+    )
+    promote_model_script = promote_model_step["run"]
+    assert (
+        promote_model_step["env"]["CANDIDATE_MODEL_VERSION"]
+        == "${{ steps.verify_candidate.outputs.candidate_model_version }}"
+    )
+    assert (
+        'uv run python -m foehncast.training_pipeline.promote --version "$CANDIDATE_MODEL_VERSION" --target-stage Production'
+        in promote_model_script
+    )
+    assert (
+        "Promoted model version does not match the validated candidate model version."
+        in promote_model_script
+    )
+
+    deploy_live_step = _workflow_step(
+        workflow, "promote", "Deploy promoted image to live Cloud Run service"
+    )
+    deploy_live_script = deploy_live_step["run"]
+    assert (
+        deploy_live_step["env"]["CANDIDATE_IMAGE"]
+        == "${{ steps.resolve_candidate.outputs.candidate_image }}"
+    )
+    assert 'gcloud run services update "$CLOUD_RUN_SERVICE"' in deploy_live_script
+    assert ' --image "$CANDIDATE_IMAGE"' in deploy_live_script
+    assert "FOEHNCAST_MLFLOW_SERVING_ALIAS=$TARGET_ALIAS" in deploy_live_script
+
+    verify_live_step = _workflow_step(
+        workflow, "promote", "Verify promoted live Cloud Run runtime"
+    )
+    verify_live_script = verify_live_step["run"]
+    assert (
+        verify_live_step["env"]["SERVICE_URL"]
+        == "${{ steps.deploy_live.outputs.service_url }}"
+    )
+    assert (
+        verify_live_step["env"]["PROMOTED_MODEL_VERSION"]
+        == "${{ steps.promote_model.outputs.promoted_model_version }}"
+    )
+    assert (
+        "Live health verification did not report serving alias ${TARGET_ALIAS}."
+        in verify_live_script
+    )
+    assert (
+        "Live service model version does not match the promoted model version."
+        in verify_live_script
+    )
+    assert (
+        'echo "Checking live Cloud Run spots endpoint at ${spots_url}..."'
+        in verify_live_script
+    )
+
+    summary_step = _workflow_step(workflow, "promote", "Summarize promotion")
+    assert 'echo "## Candidate promotion"' in summary_step["run"]
+    assert 'echo "- Candidate tag: $CANDIDATE_REVISION_TAG"' in summary_step["run"]
+    assert (
+        'echo "- Promoted model version: ${{ steps.promote_model.outputs.promoted_model_version }}"'
+        in summary_step["run"]
+    )
+
+    blocked_step = _workflow_step(
+        workflow, "blocked", "Explain blocked promotion workflow"
+    )
+    assert "GCP_CLOUD_RUN_SERVICE" in blocked_step["run"]
+    assert "GCP_MLFLOW_TRACKING_URI" in blocked_step["run"]
+
+
 def test_publish_runtime_images_excludes_local_only_development_env() -> None:
     workflow = _workflow_yaml(".github/workflows/publish-runtime-images.yml")
     push_paths = workflow["on"]["push"]["paths"]

--- a/tests/test_promote.py
+++ b/tests/test_promote.py
@@ -1,0 +1,95 @@
+"""Tests for model promotion helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from foehncast.training_pipeline import promote
+
+
+@pytest.fixture(autouse=True)
+def _clear_tracking_uri(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("MLFLOW_TRACKING_URI", raising=False)
+
+
+@pytest.fixture()
+def mlflow_config() -> dict[str, str]:
+    return {
+        "tracking_uri": "http://localhost:5001",
+        "model_name": "foehncast-quality",
+        "candidate_alias": "candidate",
+        "champion_alias": "champion",
+    }
+
+
+def test_resolve_model_version_by_alias_reads_registered_model_version(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, object] = {}
+
+    class FakeClient:
+        def get_model_version_by_alias(self, model_name: str, alias: str) -> object:
+            logged["lookup"] = (model_name, alias)
+            return type("FakeVersion", (), {"version": "11"})()
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
+
+    monkeypatch.setattr(promote, "mlflow", FakeMlflow())
+    monkeypatch.setattr(promote, "get_mlflow_config", lambda: mlflow_config)
+    monkeypatch.setattr(
+        promote, "get_mlflow_tracking_uri", lambda: "http://localhost:5001"
+    )
+
+    version = promote.resolve_model_version_by_alias("candidate")
+
+    assert version == "11"
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["lookup"] == ("foehncast-quality", "candidate")
+
+
+def test_promote_model_version_assigns_stage_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        promote,
+        "promote_model",
+        lambda model_name, version, stage="Production": logged.update(
+            {"promotion": (model_name, version, stage)}
+        ),
+    )
+
+    version = promote.promote_model_version("7")
+
+    assert version == "7"
+    assert logged["promotion"] == (None, "7", "Production")
+
+
+def test_promote_model_alias_promotes_resolved_alias_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        promote,
+        "resolve_model_version_by_alias",
+        lambda alias, model_name=None: "19",
+    )
+    monkeypatch.setattr(
+        promote,
+        "promote_model",
+        lambda model_name, version, stage="Production": logged.update(
+            {"promotion": (model_name, version, stage)}
+        ),
+    )
+
+    version = promote.promote_model_alias("candidate")
+
+    assert version == "19"
+    assert logged["promotion"] == (None, "19", "Production")


### PR DESCRIPTION
What changed:
- add a dedicated promote-candidate workflow for moving a validated candidate release to live traffic
- add a small MLflow promotion helper module that promotes an explicit validated model version to the champion alias
- verify the candidate tagged revision before promotion and verify the live /health model alias and model version after promotion
- extend the workflow contract tests and operator docs for the new promotion path

Why:
- keep candidate smoke validation separate from the live promotion step while reusing the exact validated candidate image and model version

Verification:
- uv run pytest tests/test_promote.py tests/test_cloud_operator_contract.py -q

Closes: #136