### PR TITLE
fix(cloud-run): add live rollback workflow

### DIFF
--- a/.github/workflows/rollback-live-release.yml
+++ b/.github/workflows/rollback-live-release.yml
@@ -1,0 +1,360 @@
+name: Roll Back Live Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            rollback_revision:
+                description: Exact Cloud Run revision to restore live traffic to
+                required: true
+                type: string
+            rollback_model_version:
+                description: Exact MLflow model version to restore to the live alias
+                required: true
+                type: string
+            rollback_revision_tag:
+                description: Temporary tag used to verify the rollback target before traffic is restored
+                required: false
+                default: rollback
+                type: string
+            target_alias:
+                description: MLflow alias the live service should use after rollback
+                required: false
+                default: champion
+                type: string
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    config:
+        runs-on: ubuntu-latest
+        outputs:
+            owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
+            project_id: ${{ steps.repo_config.outputs.project_id }}
+            location: ${{ steps.repo_config.outputs.location }}
+            cloud_run_service: ${{ steps.repo_config.outputs.cloud_run_service }}
+            cloud_run_allow_unauthenticated: ${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}
+            mlflow_tracking_uri: ${{ steps.repo_config.outputs.mlflow_tracking_uri }}
+            workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
+            service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
+            rollback_revision: ${{ steps.derived.outputs.rollback_revision }}
+            rollback_model_version: ${{ steps.derived.outputs.rollback_model_version }}
+            rollback_revision_tag: ${{ steps.derived.outputs.rollback_revision_tag }}
+            target_alias: ${{ steps.derived.outputs.target_alias }}
+            rollback_ready: ${{ steps.derived.outputs.rollback_ready }}
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            - id: flags
+              env:
+                  ACTOR: ${{ github.actor }}
+                  TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+                  REPOSITORY_OWNER: ${{ github.repository_owner }}
+              run: |
+                  set -euo pipefail
+
+                  owner_allowed=false
+                  if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
+                    owner_allowed=true
+                  fi
+
+                  echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
+
+            - id: repo_config
+              uses: ./.github/actions/load-gcp-repo-config
+              with:
+                  repo-vars-json: ${{ toJson(vars) }}
+
+            - id: derived
+              env:
+                  CLOUD_RUN_SERVICE: ${{ steps.repo_config.outputs.cloud_run_service }}
+                  MLFLOW_TRACKING_URI: ${{ steps.repo_config.outputs.mlflow_tracking_uri }}
+                  WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
+                  SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
+                  ROLLBACK_REVISION_INPUT: ${{ github.event.inputs.rollback_revision }}
+                  ROLLBACK_MODEL_VERSION_INPUT: ${{ github.event.inputs.rollback_model_version }}
+                  ROLLBACK_REVISION_TAG_INPUT: ${{ github.event.inputs.rollback_revision_tag }}
+                  TARGET_ALIAS_INPUT: ${{ github.event.inputs.target_alias }}
+              run: |
+                  set -euo pipefail
+
+                  rollback_ready=false
+                  if [[ -n "$CLOUD_RUN_SERVICE" && -n "$MLFLOW_TRACKING_URI" && -n "$WORKLOAD_IDENTITY_PROVIDER" && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
+                    rollback_ready=true
+                  fi
+
+                  rollback_revision="$(printf '%s' "${ROLLBACK_REVISION_INPUT:-}" | tr -d '[:space:]')"
+                  if [[ -z "$rollback_revision" ]]; then
+                    echo "rollback_revision is required." >&2
+                    exit 1
+                  fi
+
+                  rollback_model_version="$(printf '%s' "${ROLLBACK_MODEL_VERSION_INPUT:-}" | tr -d '[:space:]')"
+                  if [[ -z "$rollback_model_version" ]]; then
+                    echo "rollback_model_version is required." >&2
+                    exit 1
+                  fi
+
+                  rollback_revision_tag="$(printf '%s' "${ROLLBACK_REVISION_TAG_INPUT:-rollback}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+                  rollback_revision_tag="${rollback_revision_tag#-}"
+                  rollback_revision_tag="${rollback_revision_tag%-}"
+                  if [[ -z "$rollback_revision_tag" ]]; then
+                    rollback_revision_tag='rollback'
+                  fi
+
+                  target_alias="$(printf '%s' "${TARGET_ALIAS_INPUT:-champion}" | tr '[:upper:]' '[:lower:]')"
+                  if [[ -z "$target_alias" ]]; then
+                    target_alias='champion'
+                  fi
+
+                  {
+                    echo "rollback_revision=$rollback_revision"
+                    echo "rollback_model_version=$rollback_model_version"
+                    echo "rollback_revision_tag=$rollback_revision_tag"
+                    echo "target_alias=$target_alias"
+                    echo "rollback_ready=$rollback_ready"
+                  } >> "$GITHUB_OUTPUT"
+
+    rollback:
+        needs: config
+        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.rollback_ready == 'true' }}
+        runs-on: ubuntu-latest
+        environment: cloud-run-production
+        env:
+            GCP_PROJECT_ID: ${{ needs.config.outputs.project_id }}
+            GCP_LOCATION: ${{ needs.config.outputs.location }}
+            CLOUD_RUN_SERVICE: ${{ needs.config.outputs.cloud_run_service }}
+            CLOUD_RUN_ALLOW_UNAUTHENTICATED: ${{ needs.config.outputs.cloud_run_allow_unauthenticated }}
+            MLFLOW_TRACKING_URI: ${{ needs.config.outputs.mlflow_tracking_uri }}
+            ROLLBACK_REVISION: ${{ needs.config.outputs.rollback_revision }}
+            ROLLBACK_MODEL_VERSION: ${{ needs.config.outputs.rollback_model_version }}
+            ROLLBACK_REVISION_TAG: ${{ needs.config.outputs.rollback_revision_tag }}
+            TARGET_ALIAS: ${{ needs.config.outputs.target_alias }}
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            - uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
+                  service_account: ${{ needs.config.outputs.service_account_email }}
+
+            - uses: google-github-actions/setup-gcloud@v2
+
+            - uses: astral-sh/setup-uv@v8.1.0
+
+            - name: Install runtime dependencies
+              run: uv sync --frozen --no-default-groups
+
+            - name: Confirm Cloud Run service exists
+              run: |
+                  gcloud run services describe "$CLOUD_RUN_SERVICE" \
+                    --project "$GCP_PROJECT_ID" \
+                    --region "$GCP_LOCATION" \
+                    --format='value(metadata.name)' >/dev/null
+
+            - id: resolve_rollback
+              name: Resolve rollback revision
+              run: |
+                  set -euo pipefail
+
+                  rollback_revision_name="$(gcloud run revisions describe "$ROLLBACK_REVISION" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(metadata.name)')"
+                  if [[ -z "$rollback_revision_name" ]]; then
+                    echo "Rollback revision ${ROLLBACK_REVISION} could not be resolved." >&2
+                    exit 1
+                  fi
+
+                  rollback_image="$(gcloud run revisions describe "$ROLLBACK_REVISION" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(spec.containers[0].image)')"
+                  if [[ -z "$rollback_image" ]]; then
+                    echo "Rollback revision image could not be resolved." >&2
+                    exit 1
+                  fi
+
+                  gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+                    --project "$GCP_PROJECT_ID" \
+                    --region "$GCP_LOCATION" \
+                    --update-tags "$ROLLBACK_REVISION_TAG=$ROLLBACK_REVISION" \
+                    --quiet
+
+                  service_description="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format=json)"
+                  rollback_tag_url="$(printf '%s' "$service_description" | jq -r --arg tag "$ROLLBACK_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .url' | head -n1)"
+                  rollback_tag_revision="$(printf '%s' "$service_description" | jq -r --arg tag "$ROLLBACK_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .revisionName' | head -n1)"
+
+                  if [[ -z "$rollback_tag_url" || "$rollback_tag_url" == 'null' ]]; then
+                    echo "Rollback tag URL is empty after tagging revision ${ROLLBACK_REVISION}." >&2
+                    exit 1
+                  fi
+
+                  if [[ "$rollback_tag_revision" != "$ROLLBACK_REVISION" ]]; then
+                    echo "Rollback tag does not point at the requested revision." >&2
+                    exit 1
+                  fi
+
+                  {
+                    echo "rollback_revision_name=${rollback_revision_name}"
+                    echo "rollback_image=${rollback_image}"
+                    echo "rollback_tag_url=${rollback_tag_url}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - id: verify_rollback_target
+              name: Verify rollback target runtime
+              env:
+                  SERVICE_URL: ${{ steps.resolve_rollback.outputs.rollback_tag_url }}
+              run: |
+                  set -euo pipefail
+
+                  if [[ -z "$SERVICE_URL" ]]; then
+                    echo "Rollback target service URL is empty." >&2
+                    exit 1
+                  fi
+
+                  health_url="${SERVICE_URL%/}/health"
+                  allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
+                  curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
+                  invocation_mode="anonymous"
+
+                  if [[ "$allow_unauthenticated" != 'true' ]]; then
+                    invocation_mode="identity-token"
+                    identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
+                    curl_args+=(-H "Authorization: Bearer ${identity_token}")
+                  fi
+
+                  echo "Waiting for rollback target health at ${health_url}..."
+                  health_payload="$(curl "${curl_args[@]}" "$health_url")"
+                  if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+                    echo "Rollback target health verification failed." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
+                  rollback_target_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
+                  if [[ -z "$rollback_target_model_version" ]]; then
+                    echo "Rollback target health payload did not include model_version." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
+                  {
+                    echo "rollback_target_model_version=${rollback_target_model_version}"
+                    echo "rollback_target_invocation_mode=${invocation_mode}"
+                  } >> "$GITHUB_OUTPUT"
+
+            - id: restore_model
+              name: Restore champion alias to rollback model version
+              run: |
+                  set -euo pipefail
+
+                  restored_model_version="$(uv run python -m foehncast.training_pipeline.rollback --version "$ROLLBACK_MODEL_VERSION" --target-alias "$TARGET_ALIAS")"
+                  if [[ -z "$restored_model_version" ]]; then
+                    echo "Rollback helper returned an empty model version." >&2
+                    exit 1
+                  fi
+
+                  if [[ "$restored_model_version" != "$ROLLBACK_MODEL_VERSION" ]]; then
+                    echo "Rollback helper did not restore the requested model version." >&2
+                    exit 1
+                  fi
+
+                  echo "restored_model_version=${restored_model_version}" >> "$GITHUB_OUTPUT"
+
+            - id: shift_traffic
+              name: Restore live traffic to rollback revision
+              run: |
+                  set -euo pipefail
+
+                  gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
+                    --project "$GCP_PROJECT_ID" \
+                    --region "$GCP_LOCATION" \
+                    --update-tags "$ROLLBACK_REVISION_TAG=$ROLLBACK_REVISION" \
+                    --to-revisions "$ROLLBACK_REVISION=100" \
+                    --quiet
+
+                  service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
+                  if [[ -z "$service_url" ]]; then
+                    echo "Live Cloud Run service URL is empty after rollback." >&2
+                    exit 1
+                  fi
+
+                  echo "service_url=${service_url}" >> "$GITHUB_OUTPUT"
+
+            - id: verify_live
+              name: Verify rolled back live runtime
+              env:
+                  SERVICE_URL: ${{ steps.shift_traffic.outputs.service_url }}
+                  RESTORED_MODEL_VERSION: ${{ steps.restore_model.outputs.restored_model_version }}
+              run: |
+                  set -euo pipefail
+
+                  if [[ -z "$SERVICE_URL" || -z "$RESTORED_MODEL_VERSION" ]]; then
+                    echo "Live service URL and restored model version are required for rollback verification." >&2
+                    exit 1
+                  fi
+
+                  health_url="${SERVICE_URL%/}/health"
+                  spots_url="${SERVICE_URL%/}/spots"
+                  allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
+                  curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
+                  invocation_mode="anonymous"
+
+                  if [[ "$allow_unauthenticated" != 'true' ]]; then
+                    invocation_mode="identity-token"
+                    identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
+                    curl_args+=(-H "Authorization: Bearer ${identity_token}")
+                  fi
+
+                  echo "Waiting for live rollback health at ${health_url}..."
+                  health_payload="$(curl "${curl_args[@]}" "$health_url")"
+                  if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+                    echo "Live rollback health verification failed." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
+                  if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${TARGET_ALIAS}"'"'; then
+                    echo "Live rollback health verification did not report serving alias ${TARGET_ALIAS}." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
+                  live_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
+                  if [[ "$live_model_version" != "$RESTORED_MODEL_VERSION" ]]; then
+                    echo "Live rollback model version does not match the restored model version." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
+                  echo "Checking live Cloud Run spots endpoint at ${spots_url}..."
+                  spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
+                  if ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
+                    echo "Live Cloud Run spots verification failed after rollback." >&2
+                    printf '%s\n' "$spots_payload" >&2
+                    exit 1
+                  fi
+
+                  echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"
+
+            - name: Summarize rollback
+              run: |
+                  {
+                    echo "## Live rollback"
+                    echo
+                    echo "- Service: $CLOUD_RUN_SERVICE"
+                    echo "- Rollback revision: $ROLLBACK_REVISION"
+                    echo "- Rollback tag: $ROLLBACK_REVISION_TAG"
+                    echo "- Rollback image: ${{ steps.resolve_rollback.outputs.rollback_image }}"
+                    echo "- Restored model version: ${{ steps.restore_model.outputs.restored_model_version }}"
+                    echo "- Live alias: $TARGET_ALIAS"
+                    echo "- URL: ${{ steps.shift_traffic.outputs.service_url }}"
+                    echo "- Invocation: ${{ steps.verify_live.outputs.invocation_mode }}"
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+    blocked:
+        needs: config
+        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.rollback_ready != 'true' }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Explain blocked rollback workflow
+              run: |
+                  set -euo pipefail
+                  echo 'Live rollback requires GCP_CLOUD_RUN_SERVICE, GCP_MLFLOW_TRACKING_URI, GCP_WORKLOAD_IDENTITY_PROVIDER, and GCP_SERVICE_ACCOUNT_EMAIL repository variables.' >&2
+                  exit 1

--- a/src/foehncast/training_pipeline/register.py
+++ b/src/foehncast/training_pipeline/register.py
@@ -73,6 +73,32 @@ def promote_model(
     )
 
 
+def assign_model_alias(
+    alias: str,
+    version: str | int,
+    model_name: str | None = None,
+) -> None:
+    """Assign an explicit alias to a registered model version."""
+    normalized_alias = alias.strip()
+    if not normalized_alias:
+        raise ValueError("Model alias must be non-empty")
+
+    normalized_version = str(version).strip()
+    if not normalized_version:
+        raise ValueError("Model version must be non-empty")
+
+    mlflow_config = get_mlflow_config()
+    resolved_model_name = _resolved_model_name(model_name, mlflow_config)
+    mlflow.set_tracking_uri(get_mlflow_tracking_uri())
+
+    client = mlflow.MlflowClient()
+    client.set_registered_model_alias(
+        resolved_model_name,
+        normalized_alias,
+        normalized_version,
+    )
+
+
 def get_production_model(model_name: str | None = None) -> Any:
     """Load a registry model by alias, defaulting to the production alias."""
     mlflow_config = get_mlflow_config()

--- a/src/foehncast/training_pipeline/rollback.py
+++ b/src/foehncast/training_pipeline/rollback.py
@@ -1,0 +1,48 @@
+"""Restore a previously validated model version to the live serving alias."""
+
+from __future__ import annotations
+
+import argparse
+
+from foehncast.training_pipeline.register import assign_model_alias
+
+
+def rollback_model_version(
+    version: str | int,
+    *,
+    target_alias: str = "champion",
+    model_name: str | None = None,
+) -> str:
+    """Reassign the live alias to an explicit previous model version."""
+    normalized_version = str(version).strip()
+    if not normalized_version:
+        raise ValueError("Model version must be non-empty")
+
+    normalized_alias = target_alias.strip()
+    if not normalized_alias:
+        raise ValueError("Target alias must be non-empty")
+
+    assign_model_alias(normalized_alias, normalized_version, model_name=model_name)
+    return normalized_version
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--model-name", default=None)
+    parser.add_argument("--version", required=True)
+    parser.add_argument("--target-alias", default="champion")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    restored_version = rollback_model_version(
+        args.version,
+        target_alias=args.target_alias,
+        model_name=args.model_name,
+    )
+    print(restored_version)
+
+
+if __name__ == "__main__":
+    main()

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -181,6 +181,7 @@ In normal operation you should not edit these variables by hand. The bootstrap p
 When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health` plus `/spots`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.
 Manual workflow dispatch also supports `deploy_mode=candidate`. That path deploys a tagged no-traffic Cloud Run revision, sets `FOEHNCAST_MLFLOW_SERVING_ALIAS` for that revision, and smoke-checks the tagged URL before any later traffic shift.
 After a candidate revision has been validated, `.github/workflows/promote-candidate.yml` promotes the exact validated model version to the live `champion` alias, redeploys the live Cloud Run service with the validated candidate image, and verifies the live `/health` response reports `champion` plus the promoted model version.
+If a live release needs to be reversed, `.github/workflows/rollback-live-release.yml` restores a specific previous Cloud Run revision and a specific previous `champion` model version, verifies the tagged rollback target first, then restores live traffic and confirms the live `/health` response reports the requested rollback version.
 
 ## GitHub Actions Terraform Path
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -774,6 +774,176 @@ def test_promote_candidate_workflow_reuses_validated_candidate_for_live_promotio
     assert "GCP_MLFLOW_TRACKING_URI" in blocked_step["run"]
 
 
+def test_rollback_live_release_workflow_restores_explicit_revision_and_model_version() -> (
+    None
+):
+    workflow = _workflow_yaml(".github/workflows/rollback-live-release.yml")
+    config_job = workflow["jobs"]["config"]
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+
+    assert dispatch_inputs["rollback_revision"]["required"] is True
+    assert dispatch_inputs["rollback_model_version"]["required"] is True
+    assert dispatch_inputs["rollback_revision_tag"]["default"] == "rollback"
+    assert dispatch_inputs["target_alias"]["default"] == "champion"
+
+    assert (
+        config_job["outputs"]["cloud_run_service"]
+        == "${{ steps.repo_config.outputs.cloud_run_service }}"
+    )
+    assert (
+        config_job["outputs"]["mlflow_tracking_uri"]
+        == "${{ steps.repo_config.outputs.mlflow_tracking_uri }}"
+    )
+    assert (
+        config_job["outputs"]["rollback_revision"]
+        == "${{ steps.derived.outputs.rollback_revision }}"
+    )
+    assert (
+        config_job["outputs"]["rollback_model_version"]
+        == "${{ steps.derived.outputs.rollback_model_version }}"
+    )
+    assert (
+        config_job["outputs"]["rollback_revision_tag"]
+        == "${{ steps.derived.outputs.rollback_revision_tag }}"
+    )
+    assert (
+        config_job["outputs"]["target_alias"]
+        == "${{ steps.derived.outputs.target_alias }}"
+    )
+    assert (
+        config_job["outputs"]["rollback_ready"]
+        == "${{ steps.derived.outputs.rollback_ready }}"
+    )
+
+    derived_step = _workflow_step(workflow, "config", "derived")
+    assert (
+        derived_step["env"]["ROLLBACK_REVISION_INPUT"]
+        == "${{ github.event.inputs.rollback_revision }}"
+    )
+    assert (
+        derived_step["env"]["ROLLBACK_MODEL_VERSION_INPUT"]
+        == "${{ github.event.inputs.rollback_model_version }}"
+    )
+    assert (
+        derived_step["env"]["ROLLBACK_REVISION_TAG_INPUT"]
+        == "${{ github.event.inputs.rollback_revision_tag }}"
+    )
+    assert (
+        derived_step["env"]["TARGET_ALIAS_INPUT"]
+        == "${{ github.event.inputs.target_alias }}"
+    )
+    assert 'echo "rollback_revision=$rollback_revision"' in derived_step["run"]
+    assert (
+        'echo "rollback_model_version=$rollback_model_version"' in derived_step["run"]
+    )
+    assert "rollback_revision_tag='rollback'" in derived_step["run"]
+    assert "target_alias='champion'" in derived_step["run"]
+
+    rollback_job = workflow["jobs"]["rollback"]
+    assert rollback_job["environment"] == "cloud-run-production"
+    assert (
+        rollback_job["env"]["ROLLBACK_REVISION"]
+        == "${{ needs.config.outputs.rollback_revision }}"
+    )
+    assert (
+        rollback_job["env"]["ROLLBACK_MODEL_VERSION"]
+        == "${{ needs.config.outputs.rollback_model_version }}"
+    )
+    assert (
+        rollback_job["env"]["ROLLBACK_REVISION_TAG"]
+        == "${{ needs.config.outputs.rollback_revision_tag }}"
+    )
+    assert (
+        rollback_job["env"]["TARGET_ALIAS"]
+        == "${{ needs.config.outputs.target_alias }}"
+    )
+
+    resolve_step = _workflow_step(workflow, "rollback", "Resolve rollback revision")
+    resolve_script = resolve_step["run"]
+    assert 'gcloud run revisions describe "$ROLLBACK_REVISION"' in resolve_script
+    assert 'gcloud run services update-traffic "$CLOUD_RUN_SERVICE"' in resolve_script
+    assert (
+        ' --update-tags "$ROLLBACK_REVISION_TAG=$ROLLBACK_REVISION"' in resolve_script
+    )
+    assert "Rollback tag does not point at the requested revision." in resolve_script
+
+    verify_target_step = _workflow_step(
+        workflow, "rollback", "Verify rollback target runtime"
+    )
+    verify_target_script = verify_target_step["run"]
+    assert (
+        verify_target_step["env"]["SERVICE_URL"]
+        == "${{ steps.resolve_rollback.outputs.rollback_tag_url }}"
+    )
+    assert (
+        'gcloud auth print-identity-token --audiences="$SERVICE_URL"'
+        in verify_target_script
+    )
+    assert "rollback_target_model_version" in verify_target_script
+
+    restore_model_step = _workflow_step(
+        workflow, "rollback", "Restore champion alias to rollback model version"
+    )
+    restore_model_script = restore_model_step["run"]
+    assert (
+        'uv run python -m foehncast.training_pipeline.rollback --version "$ROLLBACK_MODEL_VERSION" --target-alias "$TARGET_ALIAS"'
+        in restore_model_script
+    )
+    assert (
+        "Rollback helper did not restore the requested model version."
+        in restore_model_script
+    )
+
+    shift_traffic_step = _workflow_step(
+        workflow, "rollback", "Restore live traffic to rollback revision"
+    )
+    shift_traffic_script = shift_traffic_step["run"]
+    assert (
+        'gcloud run services update-traffic "$CLOUD_RUN_SERVICE"'
+        in shift_traffic_script
+    )
+    assert ' --to-revisions "$ROLLBACK_REVISION=100"' in shift_traffic_script
+
+    verify_live_step = _workflow_step(
+        workflow, "rollback", "Verify rolled back live runtime"
+    )
+    verify_live_script = verify_live_step["run"]
+    assert (
+        verify_live_step["env"]["SERVICE_URL"]
+        == "${{ steps.shift_traffic.outputs.service_url }}"
+    )
+    assert (
+        verify_live_step["env"]["RESTORED_MODEL_VERSION"]
+        == "${{ steps.restore_model.outputs.restored_model_version }}"
+    )
+    assert (
+        "Live rollback health verification did not report serving alias ${TARGET_ALIAS}."
+        in verify_live_script
+    )
+    assert (
+        "Live rollback model version does not match the restored model version."
+        in verify_live_script
+    )
+    assert (
+        'echo "Checking live Cloud Run spots endpoint at ${spots_url}..."'
+        in verify_live_script
+    )
+
+    summary_step = _workflow_step(workflow, "rollback", "Summarize rollback")
+    assert 'echo "## Live rollback"' in summary_step["run"]
+    assert 'echo "- Rollback revision: $ROLLBACK_REVISION"' in summary_step["run"]
+    assert (
+        'echo "- Restored model version: ${{ steps.restore_model.outputs.restored_model_version }}"'
+        in summary_step["run"]
+    )
+
+    blocked_step = _workflow_step(
+        workflow, "blocked", "Explain blocked rollback workflow"
+    )
+    assert "GCP_CLOUD_RUN_SERVICE" in blocked_step["run"]
+    assert "GCP_MLFLOW_TRACKING_URI" in blocked_step["run"]
+
+
 def test_publish_runtime_images_excludes_local_only_development_env() -> None:
     workflow = _workflow_yaml(".github/workflows/publish-runtime-images.yml")
     push_paths = workflow["on"]["push"]["paths"]

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -270,3 +270,33 @@ def test_get_model_by_alias_loads_requested_alias(
     assert model is expected_model
     assert logged["tracking_uri"] == "http://localhost:5001"
     assert logged["model_uri"] == "models:/foehncast-quality@candidate"
+
+
+def test_assign_model_alias_sets_explicit_alias(
+    monkeypatch: pytest.MonkeyPatch, mlflow_config: dict[str, str]
+) -> None:
+    logged: dict[str, object] = {}
+
+    class FakeClient:
+        def set_registered_model_alias(
+            self, model_name: str, alias: str, version: str
+        ) -> None:
+            logged["alias"] = (model_name, alias, version)
+
+    class FakeMlflow:
+        def set_tracking_uri(self, tracking_uri: str) -> None:
+            logged["tracking_uri"] = tracking_uri
+
+        def MlflowClient(self) -> FakeClient:
+            return FakeClient()
+
+    monkeypatch.setattr(register, "mlflow", FakeMlflow())
+    monkeypatch.setattr(register, "get_mlflow_config", lambda: mlflow_config)
+    monkeypatch.setattr(
+        register, "get_mlflow_tracking_uri", lambda: "http://localhost:5001"
+    )
+
+    register.assign_model_alias("champion", 13)
+
+    assert logged["tracking_uri"] == "http://localhost:5001"
+    assert logged["alias"] == ("foehncast-quality", "champion", "13")

--- a/tests/test_rollback.py
+++ b/tests/test_rollback.py
@@ -1,0 +1,36 @@
+"""Tests for rollback helpers."""
+
+from __future__ import annotations
+
+import pytest
+
+from foehncast.training_pipeline import rollback
+
+
+def test_rollback_model_version_restores_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    logged: dict[str, object] = {}
+
+    monkeypatch.setattr(
+        rollback,
+        "assign_model_alias",
+        lambda alias, version, model_name=None: logged.update(
+            {"rollback": (alias, version, model_name)}
+        ),
+    )
+
+    version = rollback.rollback_model_version("17")
+
+    assert version == "17"
+    assert logged["rollback"] == ("champion", "17", None)
+
+
+def test_rollback_model_version_rejects_empty_version() -> None:
+    with pytest.raises(ValueError, match="Model version must be non-empty"):
+        rollback.rollback_model_version("  ")
+
+
+def test_rollback_model_version_rejects_empty_alias() -> None:
+    with pytest.raises(ValueError, match="Target alias must be non-empty"):
+        rollback.rollback_model_version("17", target_alias="  ")


### PR DESCRIPTION
What changed:
- add a dedicated rollback-live-release workflow for restoring a specific Cloud Run revision and model version
- add a small rollback helper and explicit alias assignment helper for MLflow registry writes
- verify the tagged rollback target before traffic is restored and verify live /health plus /spots after rollback
- extend the workflow contract coverage and operator docs for the rollback path

Why:
- keep rollback explicit and operator-driven while restoring both the serving revision and the champion model version

Verification:
- uv run pytest tests/test_promote.py tests/test_rollback.py tests/test_register.py tests/test_cloud_operator_contract.py -q

Closes:
- Closes #138