### PR TITLE
fix(cloud-run): reverify rollback target before traffic shift

### DIFF
--- a/.github/workflows/rollback-live-release.yml
+++ b/.github/workflows/rollback-live-release.yml
@@ -227,6 +227,12 @@ jobs:
                     exit 1
                   fi
 
+                  if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${TARGET_ALIAS}"'"'; then
+                    echo "Rollback target health verification did not report serving alias ${TARGET_ALIAS}." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
                   rollback_target_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
                   if [[ -z "$rollback_target_model_version" ]]; then
                     echo "Rollback target health payload did not include model_version." >&2
@@ -256,6 +262,53 @@ jobs:
                   fi
 
                   echo "restored_model_version=${restored_model_version}" >> "$GITHUB_OUTPUT"
+
+            - id: reverify_rollback_target
+              name: Reverify rollback target with restored model version
+              env:
+                  SERVICE_URL: ${{ steps.resolve_rollback.outputs.rollback_tag_url }}
+                  RESTORED_MODEL_VERSION: ${{ steps.restore_model.outputs.restored_model_version }}
+              run: |
+                  set -euo pipefail
+
+                  if [[ -z "$SERVICE_URL" || -z "$RESTORED_MODEL_VERSION" ]]; then
+                    echo "Rollback target service URL and restored model version are required for pre-traffic revalidation." >&2
+                    exit 1
+                  fi
+
+                  health_url="${SERVICE_URL%/}/health"
+                  allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
+                  curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
+                  invocation_mode="anonymous"
+
+                  if [[ "$allow_unauthenticated" != 'true' ]]; then
+                    invocation_mode="identity-token"
+                    identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
+                    curl_args+=(-H "Authorization: Bearer ${identity_token}")
+                  fi
+
+                  echo "Waiting for rollback target health after alias restore at ${health_url}..."
+                  health_payload="$(curl "${curl_args[@]}" "$health_url")"
+                  if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+                    echo "Rollback target health revalidation failed after alias restore." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
+                  if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${TARGET_ALIAS}"'"'; then
+                    echo "Rollback target revalidation did not report serving alias ${TARGET_ALIAS}." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
+                  rollback_target_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
+                  if [[ "$rollback_target_model_version" != "$RESTORED_MODEL_VERSION" ]]; then
+                    echo "Rollback target revalidation did not report the restored model version." >&2
+                    printf '%s\n' "$health_payload" >&2
+                    exit 1
+                  fi
+
+                  echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"
 
             - id: shift_traffic
               name: Restore live traffic to rollback revision
@@ -345,6 +398,7 @@ jobs:
                     echo "- Restored model version: ${{ steps.restore_model.outputs.restored_model_version }}"
                     echo "- Live alias: $TARGET_ALIAS"
                     echo "- URL: ${{ steps.shift_traffic.outputs.service_url }}"
+                    echo "- Tagged revalidation: passed"
                     echo "- Invocation: ${{ steps.verify_live.outputs.invocation_mode }}"
                   } >> "$GITHUB_STEP_SUMMARY"
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -182,7 +182,7 @@ When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow
 Manual workflow dispatch also supports `deploy_mode=candidate`. That path deploys a tagged no-traffic Cloud Run revision, sets `FOEHNCAST_MLFLOW_SERVING_ALIAS` for that revision, and smoke-checks the tagged URL before any later traffic shift.
 After a candidate revision has been validated, `.github/workflows/promote-candidate.yml` promotes the exact validated model version to the live `champion` alias, redeploys the live Cloud Run service with the validated candidate image, and verifies the live `/health` response reports `champion` plus the promoted model version.
 That promotion summary also records the pre-promotion live revision and model version so operators can feed those exact values into `.github/workflows/rollback-live-release.yml` if the release needs to be reversed later.
-If a live release needs to be reversed, `.github/workflows/rollback-live-release.yml` restores a specific previous Cloud Run revision and a specific previous `champion` model version, verifies the tagged rollback target first, then restores live traffic and confirms the live `/health` response reports the requested rollback version.
+If a live release needs to be reversed, `.github/workflows/rollback-live-release.yml` restores a specific previous Cloud Run revision and a specific previous `champion` model version, verifies the tagged rollback target first, rechecks that tagged target after the alias restore, then restores live traffic and confirms the live `/health` response reports the requested rollback version.
 
 ## GitHub Actions Terraform Path
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -904,6 +904,10 @@ def test_rollback_live_release_workflow_restores_explicit_revision_and_model_ver
         'gcloud auth print-identity-token --audiences="$SERVICE_URL"'
         in verify_target_script
     )
+    assert (
+        "Rollback target health verification did not report serving alias ${TARGET_ALIAS}."
+        in verify_target_script
+    )
     assert "rollback_target_model_version" in verify_target_script
 
     restore_model_step = _workflow_step(
@@ -917,6 +921,31 @@ def test_rollback_live_release_workflow_restores_explicit_revision_and_model_ver
     assert (
         "Rollback helper did not restore the requested model version."
         in restore_model_script
+    )
+
+    reverify_target_step = _workflow_step(
+        workflow, "rollback", "Reverify rollback target with restored model version"
+    )
+    reverify_target_script = reverify_target_step["run"]
+    assert (
+        reverify_target_step["env"]["SERVICE_URL"]
+        == "${{ steps.resolve_rollback.outputs.rollback_tag_url }}"
+    )
+    assert (
+        reverify_target_step["env"]["RESTORED_MODEL_VERSION"]
+        == "${{ steps.restore_model.outputs.restored_model_version }}"
+    )
+    assert (
+        'gcloud auth print-identity-token --audiences="$SERVICE_URL"'
+        in reverify_target_script
+    )
+    assert (
+        "Rollback target revalidation did not report serving alias ${TARGET_ALIAS}."
+        in reverify_target_script
+    )
+    assert (
+        "Rollback target revalidation did not report the restored model version."
+        in reverify_target_script
     )
 
     shift_traffic_step = _workflow_step(
@@ -961,6 +990,7 @@ def test_rollback_live_release_workflow_restores_explicit_revision_and_model_ver
         'echo "- Restored model version: ${{ steps.restore_model.outputs.restored_model_version }}"'
         in summary_step["run"]
     )
+    assert 'echo "- Tagged revalidation: passed"' in summary_step["run"]
 
     blocked_step = _workflow_step(
         workflow, "blocked", "Explain blocked rollback workflow"


### PR DESCRIPTION
What changed:
- recheck the tagged rollback target after restoring the live alias and before shifting traffic back to it
- fail rollback before the traffic change if the tagged revision does not report the requested alias and restored model version
- extend the workflow contract coverage and operator docs for the stronger rollback check

Why:
- avoid shifting live traffic to a rollback revision before proving it sees the restored model state

Verification:
- uv run pytest tests/test_cloud_operator_contract.py -q

Closes:
- Closes #142