### PR TITLE
fix(runtime): reconcile local bootstrap and monitoring state

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ flowchart LR
 | Area | Status | Summary |
 |------|--------|---------|
 | Feature pipeline | Working | Airflow ingests, engineers, validates, and stores curated weather features |
-| Training pipeline | Working | Airflow labels data, trains the model, evaluates it, and registers fresh versions in MLflow under a candidate alias |
+| Training pipeline | Working | Airflow labels data, trains the model, evaluates it, and registers fresh versions in MLflow under the requested registry alias |
 | Inference pipeline | Working | FastAPI serves `/health`, `/spots`, `/predict`, `/rank`, and online-feature routes, and `ui/app.py` provides the Streamlit demo |
 | Hosted runtime | Working | The shared environment runs the hosted full-stack target on one GCP host; the inference-only Cloud Run target is available but not enabled there |
 | Automation | Working | GitHub Actions publishes images, validates infrastructure, and drives remote Terraform workflows |
-| Monitoring | Working | Docker Compose runs Prometheus, a StatsD exporter, and Grafana; the app exposes `/metrics`; and Grafana loads starter dashboards and alert rules from checked-in config |
+| Monitoring | Working | Docker Compose runs Prometheus, a StatsD exporter, and Grafana; the app exposes `/metrics`; feature panels are derived from persisted Airflow report summaries; and Grafana loads starter dashboards and alert rules from checked-in config |
 
 ## Default Setup
 
@@ -53,7 +53,7 @@ This is the default path for a fresh machine.
 3. Run `./scripts/bootstrap-local.sh`.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
-The local bootstrap uses the bundled MinIO service for curated features and MLflow artifacts. It prepares Feast with the bundled Datastore-mode emulator and checks that Grafana loaded the checked-in dashboard and alerts before it reports the stack ready. If the default ports are busy, it moves to the next free ports and prints the resolved endpoints.
+The local bootstrap uses the bundled MinIO service for curated features and MLflow artifacts. It prepares Feast with the bundled Datastore-mode emulator, runs the training DAG with the serving alias path so the app comes up healthy on a real registry version, and checks that Grafana loaded the checked-in dashboard and alerts before it reports the stack ready. If the default ports are busy, it moves to the next free ports and prints the resolved endpoints.
 On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically. When the retraining gate passes, it triggers the separate `training_pipeline` DAG instead of embedding train, evaluate, and register steps inside the feature flow. The `training_pipeline` DAG itself stays unscheduled and paused by default for manual reruns.
 The optional `development_env` notebook container is not part of the default path. Start it only when you need notebook or dev-shell Makefile commands.
 
@@ -70,11 +70,13 @@ After bootstrap completes, the main local endpoints are:
 
 The bootstrap summary also prints the resolved objectstore and Feast online-store emulator endpoints.
 
+Feature-pipeline Grafana panels are backed by the latest summary JSON written under `airflow/reports/`. The app mounts that directory and republishes the summary as Prometheus metrics through `/metrics`, so local dashboard plots and Prometheus queries follow the same contract.
+
 Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl`. That log lets the monitoring layer compare recent model outputs with earlier outputs from the same model version without mixing temporary service state into `data/`.
 
 Grafana also creates a starter email contact point for the checked-in alert rules. In the local Docker path, that route uses the built-in placeholder address.
 
-The local bootstrap resets Docker volumes and temporary runtime artifacts, then checks the live `/features/online` route and the Grafana provisioning API before it reports the stack ready.
+The local bootstrap resets Docker volumes, local Airflow metadata, and temporary runtime artifacts, then checks the live `/features/online` route and the Grafana provisioning API before it reports the stack ready.
 
 Example check:
 

--- a/containers/app/docker-compose.yml
+++ b/containers/app/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       UVICORN_HOST: 0.0.0.0
       UVICORN_PORT: 8000
     volumes:
+      - ../../airflow/reports:/workspace/airflow/reports
       - ../../data:/workspace/data
       - ../../.state:/workspace/.state
     ports:

--- a/dags/feature_dag.py
+++ b/dags/feature_dag.py
@@ -88,6 +88,7 @@ else:
                 trigger_dag_id="training_pipeline",
                 conf={
                     "dataset": feature_dataset,
+                    "stage": "Production",
                     "source_dag_id": "feature_pipeline",
                     "source_run_id": "{{ run_id }}",
                 },

--- a/dags/training_dag.py
+++ b/dags/training_dag.py
@@ -19,6 +19,10 @@ else:
         "{{ dag_run.conf.get('dataset') if dag_run and dag_run.conf and "
         "dag_run.conf.get('dataset') else params.dataset }}"
     )
+    registration_stage_template = (
+        "{{ dag_run.conf.get('stage') if dag_run and dag_run.conf and "
+        "dag_run.conf.get('stage') else 'Candidate' }}"
+    )
 
     with DAG(
         dag_id="training_pipeline",
@@ -50,6 +54,7 @@ else:
             task_id="register_model",
             python_callable=register_training_run,
             op_args=[train_model.output],
+            op_kwargs={"stage": registration_stage_template},
         )
 
         train_model >> evaluate_model_task >> register_model_task

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -12,10 +12,14 @@ This is the default path for a fresh machine.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 
-The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. The same local stack now includes Prometheus, a StatsD exporter, and Grafana from checked-in monitoring config, and the bootstrap helper verifies that Grafana loaded its starter resources before reporting success. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
+The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. The same local stack now includes Prometheus, a StatsD exporter, and Grafana from checked-in monitoring config, the bootstrap helper runs the training DAG with the serving-alias path so the API comes up healthy on a real registry version, and it verifies that Grafana loaded its starter resources before reporting success. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
 The optional `development_env` notebook container stays off by default and only starts when you explicitly target the notebook or dev-shell Makefile commands.
 
 Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl`, so the monitoring layer can compare recent model outputs against earlier outputs from the same model version without mixing runtime state into `data/`.
+
+Feature-pipeline dashboard panels are driven from the latest summary JSON under `airflow/reports/`. The app republishes that summary through `/metrics`, so Prometheus and Grafana read the same persisted run summary that the bootstrap path produces.
+
+The bootstrap reset also removes the local Airflow metadata database and logs, so the UI reflects the current DAG boundary instead of older task graphs from previous local runs.
 
 After bootstrap completes, the main local endpoints are:
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -45,7 +45,7 @@ flowchart LR
 | Area | Status | Meaning |
 |------|--------|---------|
 | Feature pipeline | Working | The feature DAG ingests, engineers, validates, and stores curated weather features |
-| Training pipeline | Working | The training DAG labels data, trains the model, evaluates it, and registers fresh versions in MLflow under a candidate alias |
+| Training pipeline | Working | The training DAG labels data, trains the model, evaluates it, and registers fresh versions in MLflow under the requested registry alias |
 | Inference pipeline | Working | The app serves the model-backed API routes used for health, prediction, and ranking |
 | Hosted runtime | Working | Terraform plus the online compose stack can run Airflow, MLflow, and the API on GCP |
 | CI/CD | Working | GitHub Actions validates docs and infrastructure and supports remote Terraform operations |

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -35,6 +35,8 @@ docs/
 
 One local workload data root lives under `data/`, while local runtime state stays separate. For example, curated feature rows and Feast offline parquet belong under `data/`, but local Feast registry, rendered runtime config, and inference prediction logs belong under `.state/` instead of mixing service state into the workload dataset tree.
 
+Airflow also writes operator-facing artifacts under `airflow/reports/`. That directory now includes the latest feature-pipeline run summary JSON and evaluation markdown outputs, and the local app mounts it so Prometheus and Grafana can expose the latest feature-pipeline monitoring panels.
+
 ## Why The Layout Matters
 
 The runtime code lives under one package, while orchestration, operator scripts, infrastructure, tests, and docs stay beside it instead of being mixed into the same folder tree. That makes it easier to explain which parts define the model pipeline, which parts schedule it, which parts provision hosted environments, and which parts document the result.
@@ -53,6 +55,7 @@ There is currently no separate product UI package in the repository. The optiona
 - `feature_repo/feature_store*.yaml`: checked-in Feast reference configs that stay separate from the base application config.
 - `.state/feast/feature_store.runtime.yaml`: the rendered runtime Feast binding generated from environment and used by the app and host-side Feast CLI commands.
 - `.state/monitoring/prediction-log.jsonl`: the local inference monitoring log used to compare current model outputs against earlier outputs from the same model version.
+- `airflow/reports/feature-pipeline-*-latest.json`: the persisted feature-pipeline summary files that the local monitoring path republishes through the app `/metrics` endpoint.
 
 The supported curated-storage backends are intentionally narrow: `s3` for the local MinIO-backed baseline and `bigquery` for the hosted analytical surface. The older file-backed curated-store compatibility path is no longer part of the runtime contract.
 

--- a/scripts/bootstrap-local.sh
+++ b/scripts/bootstrap-local.sh
@@ -187,10 +187,16 @@ next_available_port() {
 cleanup_local_runtime_state() {
   local dataset="$1"
 
+  rm -f "$ROOT_DIR/airflow/.init-complete"
+  rm -f "$ROOT_DIR/airflow/airflow.db"
+  rm -f "$ROOT_DIR/airflow/airflow.db-shm"
+  rm -f "$ROOT_DIR/airflow/airflow.db-wal"
   rm -f "$ROOT_DIR/airflow/airflow.cfg"
+  rm -f "$ROOT_DIR/airflow"/*.log
   rm -f "$ROOT_DIR/airflow/simple_auth_manager_passwords.json"
   rm -f "$ROOT_DIR/airflow/simple_auth_manager_passwords.json.generated"
   rm -f "$ROOT_DIR/airflow/webserver_config.py"
+  rm -rf "$ROOT_DIR/airflow/logs"
   rm -rf "$ROOT_DIR/airflow/reports"
   rm -rf "$ROOT_DIR/.state/feast"
   rm -rf "$ROOT_DIR/.state/monitoring"
@@ -400,6 +406,7 @@ FEAST_DATASTORE_EMULATOR_RESET_URL="http://${DATASTORE_EMULATOR_HOST}/reset"
 
 FEAST_DATASET="${FEAST_DATASET:-$(env_file_value AIRFLOW_FEATURE_DATASET)}"
 FEAST_DATASET="${FEAST_DATASET:-train}"
+TRAINING_DAG_CONF="$(printf '{"dataset":"%s","stage":"Production"}' "$FEAST_DATASET")"
 
 echo "Resetting local stack state for a clean run..."
 compose down -v --remove-orphans >/dev/null 2>&1 || true
@@ -423,7 +430,7 @@ echo "Running feature pipeline for ${FEATURE_DATE}..."
 compose exec -T airflow-webserver airflow dags test feature_pipeline "$FEATURE_DATE"
 
 echo "Running training pipeline for ${TRAINING_DATE}..."
-compose exec -T airflow-webserver airflow dags test training_pipeline "$TRAINING_DATE"
+compose exec -T airflow-webserver airflow dags test training_pipeline "$TRAINING_DATE" -c "$TRAINING_DAG_CONF"
 
 echo "Preparing Feast serving state for ${FEAST_DATASET}..."
 "${ROOT_DIR}/scripts/prepare-feast-local.sh" --reset-state "$FEAST_DATASET"
@@ -447,7 +454,7 @@ echo "MLflow:   http://127.0.0.1:5001"
 echo "Grafana:  ${GRAFANA_BASE_URL}"
 echo "Feast:    /features/online verified"
 echo "Airflow UI/API and MLflow open directly in local mode."
-echo "This bootstrap path resets local Docker volumes and disposable local runtime artifacts so each run starts clean."
+echo "This bootstrap path resets local Docker volumes, Airflow metadata, and disposable runtime artifacts so each run starts clean."
 echo "Curated features and MLflow artifacts are using the MinIO-backed local objectstore baseline for this run."
 echo "This keeps the local object-access layer aligned with the hosted GCS-facing architecture while Feast uses the local Datastore-mode emulator for online serving."
 echo "Objectstore API: ${OBJECTSTORE_ENDPOINT}"

--- a/src/foehncast/feature_pipeline/engineer.py
+++ b/src/foehncast/feature_pipeline/engineer.py
@@ -109,9 +109,9 @@ def gust_excess_10m(df: pd.DataFrame) -> pd.Series:
         df: DataFrame with ``wind_gusts_10m`` and ``wind_speed_10m``.
 
     Returns:
-        Series of gust-minus-sustained wind in km/h.
+        Series of nonnegative gust-minus-sustained wind in km/h.
     """
-    values = df["wind_gusts_10m"] - df["wind_speed_10m"]
+    values = (df["wind_gusts_10m"] - df["wind_speed_10m"]).clip(lower=0.0)
     return pd.Series(values, index=df.index, name="gust_excess_10m")
 
 

--- a/src/foehncast/orchestration.py
+++ b/src/foehncast/orchestration.py
@@ -82,6 +82,25 @@ def _read_optional_feature_pipeline_frame(source: Path) -> pd.DataFrame:
     return _read_feature_pipeline_frame(source)
 
 
+def _json_safe_feature_pipeline_value(value: Any) -> Any:
+    if isinstance(value, (pd.Timestamp, datetime)):
+        return None if pd.isna(value) else value.isoformat()
+
+    if hasattr(value, "item") and callable(value.item):
+        try:
+            return _json_safe_feature_pipeline_value(value.item())
+        except (TypeError, ValueError):
+            pass
+
+    try:
+        if pd.isna(value):
+            return None
+    except (TypeError, ValueError):
+        pass
+
+    return value
+
+
 def _write_feature_pipeline_validation(
     destination: Path,
     validation: Any,
@@ -91,9 +110,20 @@ def _write_feature_pipeline_validation(
     payload = {
         "is_valid": bool(getattr(validation, "is_valid", False)),
         "missing_columns": list(getattr(validation, "missing_columns", []) or []),
-        "null_fractions": dict(getattr(validation, "null_fractions", {}) or {}),
+        "null_fractions": {
+            str(column): _json_safe_feature_pipeline_value(null_fraction)
+            for column, null_fraction in dict(
+                getattr(validation, "null_fractions", {}) or {}
+            ).items()
+        },
         "range_violations": (
-            range_violations.to_dict(orient="records")
+            [
+                {
+                    str(key): _json_safe_feature_pipeline_value(value)
+                    for key, value in record.items()
+                }
+                for record in range_violations.to_dict(orient="records")
+            ]
             if isinstance(range_violations, pd.DataFrame)
             else []
         ),

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -128,6 +128,7 @@ def test_feature_dag_defaults_to_airflow_schedule(
     assert operators[5].kwargs["trigger_dag_id"] == "training_pipeline"
     assert operators[5].kwargs["conf"] == {
         "dataset": "train",
+        "stage": "Production",
         "source_dag_id": "feature_pipeline",
         "source_run_id": "{{ run_id }}",
     }
@@ -178,8 +179,13 @@ def test_training_dag_stays_manual_and_paused_by_default(
         "{{ dag_run.conf.get('dataset') if dag_run and dag_run.conf and "
         "dag_run.conf.get('dataset') else params.dataset }}"
     )
+    expected_stage_template = (
+        "{{ dag_run.conf.get('stage') if dag_run and dag_run.conf and "
+        "dag_run.conf.get('stage') else 'Candidate' }}"
+    )
     assert operators[0].kwargs["op_kwargs"] == {"dataset": expected_dataset_template}
     assert operators[1].kwargs["op_kwargs"] == {"dataset": expected_dataset_template}
+    assert operators[2].kwargs["op_kwargs"] == {"stage": expected_stage_template}
 
 
 def test_training_dag_supports_dataset_override(

--- a/tests/test_engineer.py
+++ b/tests/test_engineer.py
@@ -63,6 +63,19 @@ class TestGustExcess:
         expected = sample_df["wind_gusts_10m"] - sample_df["wind_speed_10m"]
         pd.testing.assert_series_equal(result, expected.rename("gust_excess_10m"))
 
+    def test_clips_negative_surplus_to_zero(self):
+        df = pd.DataFrame(
+            {
+                "wind_gusts_10m": [11.6, 9.0],
+                "wind_speed_10m": [12.0, 8.0],
+            }
+        )
+
+        result = gust_excess_10m(df)
+
+        expected = pd.Series([0.0, 1.0], name="gust_excess_10m")
+        pd.testing.assert_series_equal(result.reset_index(drop=True), expected)
+
 
 class TestShoreAlignment:
     def test_perpendicular_scores_one(self):

--- a/tests/test_monitoring_stack.py
+++ b/tests/test_monitoring_stack.py
@@ -324,7 +324,9 @@ def test_local_bootstrap_verifies_grafana_provisioning() -> None:
 
 def test_app_compose_routes_monitoring_metrics_to_statsd_service() -> None:
     compose = _read_yaml("containers/app/docker-compose.yml")
+    app_service = compose["services"]["app"]
     environment = compose["services"]["app"]["environment"]
+    volumes = app_service["volumes"]
 
     assert environment["FOEHNCAST_STATSD_HOST"] == "statsd"
     assert environment["FOEHNCAST_STATSD_PORT"] == 8125
@@ -332,6 +334,7 @@ def test_app_compose_routes_monitoring_metrics_to_statsd_service() -> None:
         environment["FOEHNCAST_STATSD_PREFIX"]
         == "${FOEHNCAST_STATSD_PREFIX:-drift_metrics}"
     )
+    assert "../../airflow/reports:/workspace/airflow/reports" in volumes
 
 
 def test_local_bootstrap_verifies_grafana_before_pipeline_runs() -> None:

--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import json
 from pathlib import Path
 from types import SimpleNamespace
 
@@ -262,6 +263,72 @@ def test_run_feature_pipeline_raises_on_validation_failure(
     assert emitted["summary"]["failed_spot_count"] == 1
     assert emitted["summary"]["stage_failure_counts"]["validate"] == 1
     assert emitted["summary"]["spots"][0]["validation"]["is_valid"] is False
+
+
+def test_validate_feature_pipeline_context_serializes_timestamp_range_violations(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    emitted: dict[str, object] = {}
+    feature_df = pd.DataFrame(
+        {
+            "wind_speed_10m": [14.0],
+            "wind_gusts_10m": [18.0],
+            "wind_direction_10m": [220.0],
+        },
+        index=pd.to_datetime(["2026-05-12T09:38:51Z"]),
+    )
+
+    monkeypatch.setattr(
+        orchestration,
+        "get_spots",
+        lambda: [{"id": "silvaplana", "shore_orientation_deg": 225}],
+    )
+
+    feature_context = orchestration._feature_pipeline_context(run_key="timestamp-test")
+    feature_context["engineered_spots"] = ["silvaplana"]
+    run_dir = Path(str(feature_context["run_dir"]))
+    orchestration._write_feature_pipeline_frame(
+        orchestration._feature_pipeline_stage_path(run_dir, "feature", "silvaplana"),
+        feature_df,
+    )
+
+    monkeypatch.setattr(
+        orchestration,
+        "run_validation",
+        lambda df, spot_id: SimpleNamespace(
+            is_valid=False,
+            missing_columns=[],
+            null_fractions={"wind_speed_10m": 0.0},
+            range_violations=pd.DataFrame(
+                [
+                    {
+                        "column": "wind_speed_10m",
+                        "index": pd.Timestamp("2026-05-12T09:38:51Z"),
+                        "value": 300.0,
+                        "min": 0.0,
+                        "max": 200.0,
+                    }
+                ]
+            ),
+        ),
+    )
+    monkeypatch.setattr(
+        orchestration,
+        "emit_feature_pipeline_run_summary",
+        lambda summary: emitted.update({"summary": summary}),
+    )
+
+    with pytest.raises(ValueError, match="Feature validation failed"):
+        orchestration.validate_feature_pipeline_context(feature_context)
+
+    validation_path = orchestration._feature_pipeline_validation_path(
+        run_dir, "silvaplana"
+    )
+    payload = json.loads(validation_path.read_text())
+
+    assert payload["range_violations"][0]["index"] == "2026-05-12T09:38:51+00:00"
+    assert emitted["summary"]["run_status"] == "failed"
+    assert emitted["summary"]["stage_failure_counts"]["validate"] == 1
 
 
 def test_run_feature_pipeline_emits_failed_summary_on_ingest_contract_error(

--- a/tests/test_runtime_stack.py
+++ b/tests/test_runtime_stack.py
@@ -54,6 +54,14 @@ def test_local_bootstrap_uses_runtime_service_subset_and_api_health() -> None:
 
     assert "http://127.0.0.1:8080/api/v2/monitor/health" in bootstrap
     assert "Waiting for Airflow API server health" in bootstrap
+    assert 'rm -f "$ROOT_DIR/airflow/airflow.db"' in bootstrap
+    assert 'rm -rf "$ROOT_DIR/airflow/logs"' in bootstrap
+    assert 'TRAINING_DAG_CONF="$(printf ' in bootstrap
+    assert '"stage":"Production"' in bootstrap
+    assert (
+        'airflow dags test training_pipeline "$TRAINING_DATE" -c "$TRAINING_DAG_CONF"'
+        in bootstrap
+    )
     assert (
         'compose up --build -d --remove-orphans "${BOOTSTRAP_SERVICES[@]}"' in bootstrap
     )


### PR DESCRIPTION
- What changed: cleared stale host-mounted Airflow metadata during local bootstrap, aligned local training registration with the serving alias expected by app health, mounted persisted feature summary reports into the app monitoring path, and updated the affected docs and tests for the staged feature-pipeline contract.
- Why: a clean local reset should reflect the current feature and training DAG boundary, the local serving path should come up healthy after bootstrap, and Prometheus and Grafana should expose the latest feature-pipeline run state instead of stale or empty data.
- Verification: `./scripts/bootstrap-local.sh`; `uv run pytest tests/test_orchestration.py tests/test_engineer.py tests/test_dags.py tests/test_monitoring_stack.py tests/test_runtime_stack.py -q`; `uv run ruff check dags/feature_dag.py dags/training_dag.py src/foehncast/orchestration.py src/foehncast/feature_pipeline/engineer.py tests/test_orchestration.py tests/test_engineer.py tests/test_dags.py tests/test_monitoring_stack.py tests/test_runtime_stack.py`; `uv run mkdocs build -f docs/mkdocs.yml --strict`
- Closes: #144
