### PR TITLE
refactor(monitoring): separate durable and ephemeral metrics

### DIFF
--- a/src/foehncast/inference_pipeline/serve.py
+++ b/src/foehncast/inference_pipeline/serve.py
@@ -110,10 +110,12 @@ def _rank_response(prediction_payload: dict[str, Any]) -> dict[str, Any]:
 
 def _metrics_payload() -> bytes:
     return (
+        # Durable metrics: rendered from retained files and survive restarts.
         render_feature_pipeline_prometheus_metrics()
         + render_training_pipeline_prometheus_metrics()
         + render_prediction_log_prometheus_metrics()
         + render_online_compose_sync_prometheus_metrics()
+        # Ephemeral metrics: rendered from in-memory counters and reset on restart.
         + render_prediction_monitoring_prometheus_metrics()
     )
 

--- a/src/foehncast/monitoring/prediction_monitoring_prometheus.py
+++ b/src/foehncast/monitoring/prediction_monitoring_prometheus.py
@@ -1,4 +1,10 @@
-"""Prometheus export helpers for in-process prediction-monitoring runtime signals."""
+"""Prometheus export helpers for in-process prediction-monitoring runtime signals.
+
+All metrics in this module are process-local and ephemeral: they are rendered
+from in-memory counters that reset whenever the serving process restarts.
+Operators should treat them as runtime diagnostics, not durable historical
+truth.
+"""
 
 from __future__ import annotations
 
@@ -57,31 +63,35 @@ def _reset_prediction_monitoring_state() -> None:
         _execution_timestamps.clear()
 
 
+EPHEMERAL_METRIC_PREFIX = "foehncast_prediction_monitoring_"
+"""Common prefix for process-local metrics that reset on process restart."""
+
+
 def build_prediction_monitoring_prometheus_registry() -> CollectorRegistry:
     """Render in-process prediction-monitoring state into a scrapeable registry."""
     registry = CollectorRegistry()
 
     schedule_total = Counter(
         "foehncast_prediction_monitoring_schedule_total",
-        "Total prediction-monitoring background task scheduling attempts by endpoint and result.",
+        "Process-local ephemeral (resets on restart). Total prediction-monitoring background task scheduling attempts by endpoint and result.",
         labelnames=("endpoint", "result"),
         registry=registry,
     )
     execution_total = Counter(
         "foehncast_prediction_monitoring_execution_total",
-        "Total prediction-monitoring background task executions by endpoint and result.",
+        "Process-local ephemeral (resets on restart). Total prediction-monitoring background task executions by endpoint and result.",
         labelnames=("endpoint", "result"),
         registry=registry,
     )
     last_schedule_timestamp = Gauge(
         "foehncast_prediction_monitoring_last_schedule_timestamp_seconds",
-        "Unix timestamp of the latest prediction-monitoring scheduling event by endpoint and result.",
+        "Process-local ephemeral (resets on restart). Unix timestamp of the latest prediction-monitoring scheduling event by endpoint and result.",
         labelnames=("endpoint", "result"),
         registry=registry,
     )
     last_execution_timestamp = Gauge(
         "foehncast_prediction_monitoring_last_execution_timestamp_seconds",
-        "Unix timestamp of the latest prediction-monitoring execution event by endpoint and result.",
+        "Process-local ephemeral (resets on restart). Unix timestamp of the latest prediction-monitoring execution event by endpoint and result.",
         labelnames=("endpoint", "result"),
         registry=registry,
     )
@@ -111,6 +121,7 @@ def render_prediction_monitoring_prometheus_metrics() -> bytes:
 
 
 __all__ = [
+    "EPHEMERAL_METRIC_PREFIX",
     "build_prediction_monitoring_prometheus_registry",
     "record_prediction_monitoring_execution",
     "record_prediction_monitoring_schedule",

--- a/src/foehncast/monitoring/prediction_prometheus.py
+++ b/src/foehncast/monitoring/prediction_prometheus.py
@@ -1,4 +1,8 @@
-"""Prometheus export helpers for persisted prediction-log monitoring state."""
+"""Prometheus export helpers for retained file-backed prediction-log state.
+
+These metrics are durable relative to process-local counters because they are
+rendered from persisted JSONL state that survives serving-process restarts.
+"""
 
 from __future__ import annotations
 
@@ -8,10 +12,14 @@ from prometheus_client import CollectorRegistry, Gauge, generate_latest
 from foehncast.monitoring.prediction_log import read_prediction_log
 
 
+DURABLE_METRIC_PREFIX = "foehncast_prediction_log_"
+"""Common prefix for retained file-backed metrics that survive restarts."""
+
+
 def build_prediction_log_prometheus_registry(
     predictions_log: pd.DataFrame | None = None,
 ) -> CollectorRegistry:
-    """Render the retained prediction log into a scrapeable registry."""
+    """Render the retained file-backed prediction log into a scrapeable registry."""
     resolved_log = (
         read_prediction_log() if predictions_log is None else predictions_log.copy()
     )
@@ -19,29 +27,29 @@ def build_prediction_log_prometheus_registry(
 
     total_rows = Gauge(
         "foehncast_prediction_log_total_row_count",
-        "Number of retained prediction-log rows available for inference monitoring.",
+        "Retained file-backed prediction-log rows available for inference monitoring.",
         registry=registry,
     )
     model_count = Gauge(
         "foehncast_prediction_log_model_count",
-        "Number of retained model versions present in the prediction log.",
+        "Number of retained model versions present in the file-backed prediction log.",
         registry=registry,
     )
     row_count = Gauge(
         "foehncast_prediction_log_row_count",
-        "Retained prediction-log row count for one model version.",
+        "Retained file-backed prediction-log row count for one model version.",
         labelnames=("model_version",),
         registry=registry,
     )
     latest_prediction_timestamp = Gauge(
         "foehncast_prediction_log_latest_prediction_timestamp_seconds",
-        "Unix timestamp of the latest retained prediction-log write for one model version.",
+        "Unix timestamp of the latest retained file-backed prediction-log write for one model version.",
         labelnames=("model_version",),
         registry=registry,
     )
     latest_forecast_timestamp = Gauge(
         "foehncast_prediction_log_latest_forecast_timestamp_seconds",
-        "Unix timestamp of the latest retained forecast timestamp for one model version.",
+        "Unix timestamp of the latest retained forecast timestamp in the file-backed prediction log for one model version.",
         labelnames=("model_version",),
         registry=registry,
     )
@@ -89,12 +97,13 @@ def build_prediction_log_prometheus_registry(
 def render_prediction_log_prometheus_metrics(
     predictions_log: pd.DataFrame | None = None,
 ) -> bytes:
-    """Return Prometheus exposition text for the retained prediction log."""
+    """Return Prometheus exposition text for the retained file-backed prediction log."""
     registry = build_prediction_log_prometheus_registry(predictions_log=predictions_log)
     return generate_latest(registry)
 
 
 __all__ = [
     "build_prediction_log_prometheus_registry",
+    "DURABLE_METRIC_PREFIX",
     "render_prediction_log_prometheus_metrics",
 ]

--- a/tests/test_prediction_monitoring_prometheus.py
+++ b/tests/test_prediction_monitoring_prometheus.py
@@ -84,3 +84,45 @@ def test_render_prediction_monitoring_prometheus_metrics_handles_empty_state() -
 
     assert "foehncast_prediction_monitoring_schedule_total" in payload
     assert "foehncast_prediction_monitoring_execution_total" in payload
+
+
+def test_ephemeral_metric_prefix_constant_covers_all_rendered_metric_names() -> None:
+    prediction_monitoring_prometheus.record_prediction_monitoring_schedule(
+        "predict",
+        "scheduled",
+    )
+    prediction_monitoring_prometheus.record_prediction_monitoring_execution(
+        "predict",
+        "succeeded",
+    )
+
+    payload = prediction_monitoring_prometheus.render_prediction_monitoring_prometheus_metrics().decode(
+        "utf-8"
+    )
+    metric_lines = [
+        line for line in payload.splitlines() if line and not line.startswith("#")
+    ]
+
+    assert metric_lines, "Expected at least one metric line in the ephemeral render"
+    prefix = prediction_monitoring_prometheus.EPHEMERAL_METRIC_PREFIX
+    assert all(line.startswith(prefix) for line in metric_lines), (
+        f"All metric lines must start with {prefix!r}; got: {metric_lines}"
+    )
+
+
+def test_ephemeral_help_text_states_process_local_reset() -> None:
+    prediction_monitoring_prometheus.record_prediction_monitoring_schedule(
+        "predict",
+        "scheduled",
+    )
+
+    payload = prediction_monitoring_prometheus.render_prediction_monitoring_prometheus_metrics().decode(
+        "utf-8"
+    )
+    help_lines = [line for line in payload.splitlines() if line.startswith("# HELP")]
+
+    assert help_lines, "Expected HELP lines in the ephemeral render"
+    assert all(
+        "process-local ephemeral" in line.lower() or "resets on restart" in line.lower()
+        for line in help_lines
+    ), f"All HELP lines must state process-local/ephemeral nature; got: {help_lines}"

--- a/tests/test_prediction_prometheus.py
+++ b/tests/test_prediction_prometheus.py
@@ -64,3 +64,45 @@ def test_render_prediction_log_prometheus_metrics_handles_empty_log() -> None:
 
     assert "foehncast_prediction_log_total_row_count 0.0" in payload
     assert "foehncast_prediction_log_model_count 0.0" in payload
+
+
+def test_durable_metric_prefix_constant_covers_all_rendered_metric_names() -> None:
+    predictions_log = pd.DataFrame(
+        {
+            "model_version": ["9"],
+            "prediction_timestamp": pd.to_datetime(
+                ["2026-05-11T10:00:00+00:00"],
+                utc=True,
+            ),
+            "forecast_time": pd.to_datetime(
+                ["2025-01-01T00:00:00+00:00"],
+                utc=True,
+            ),
+            "quality_index": [3.5],
+        }
+    )
+
+    payload = prediction_prometheus.render_prediction_log_prometheus_metrics(
+        predictions_log=predictions_log,
+    ).decode("utf-8")
+    metric_lines = [
+        line for line in payload.splitlines() if line and not line.startswith("#")
+    ]
+
+    assert metric_lines, "Expected at least one metric line in the durable render"
+    prefix = prediction_prometheus.DURABLE_METRIC_PREFIX
+    assert all(line.startswith(prefix) for line in metric_lines), (
+        f"All metric lines must start with {prefix!r}; got: {metric_lines}"
+    )
+
+
+def test_durable_help_text_states_file_backed_contract() -> None:
+    payload = prediction_prometheus.render_prediction_log_prometheus_metrics(
+        predictions_log=pd.DataFrame(),
+    ).decode("utf-8")
+    help_lines = [line for line in payload.splitlines() if line.startswith("# HELP")]
+
+    assert help_lines, "Expected HELP lines in the durable render"
+    assert all("file-backed" in line.lower() for line in help_lines), (
+        f"All HELP lines must state file-backed durability; got: {help_lines}"
+    )


### PR DESCRIPTION
### What Changed
- Mark the in-process prediction-monitoring metrics as explicitly ephemeral in exporter docs and HELP text.
- Add explicit durable versus ephemeral metric prefix contracts for the prediction exporters.
- Add focused tests that lock the rendered metric names and HELP text to those boundaries.

### Why
- Make restart-sensitive runtime counters distinguishable from retained file-backed monitoring metrics.

### Verification
- uv run ruff check src/foehncast/inference_pipeline/serve.py src/foehncast/monitoring/prediction_monitoring_prometheus.py src/foehncast/monitoring/prediction_prometheus.py tests/test_prediction_monitoring_prometheus.py tests/test_prediction_prometheus.py
- uv run ruff format --check src/foehncast/inference_pipeline/serve.py src/foehncast/monitoring/prediction_monitoring_prometheus.py src/foehncast/monitoring/prediction_prometheus.py tests/test_prediction_monitoring_prometheus.py tests/test_prediction_prometheus.py
- uv run pytest tests/test_prediction_monitoring_prometheus.py tests/test_prediction_prometheus.py -q

### Closes
- Closes #150