### PR TITLE
feat(monitoring): add durable prediction event storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,10 @@ STATSD_EXPORTER_BIND_HOST=127.0.0.1
 STATSD_EXPORTER_PORT=9102
 GRAFANA_BIND_HOST=127.0.0.1
 GRAFANA_PORT=3000
+# Optional durable prediction-event history path. Leave blank to use the
+# repo-local default, or point this at shared storage when multiple runtimes
+# should contribute to the same retained monitoring history.
+FOEHNCAST_PREDICTION_EVENT_LOG_PATH=
 # Leave these blank for deployable defaults. `./scripts/bootstrap-local.sh` applies
 # its own local-only Grafana access overrides when these values are not set.
 FOEHNCAST_GRAFANA_ADMIN_USER=

--- a/src/foehncast/monitoring/__init__.py
+++ b/src/foehncast/monitoring/__init__.py
@@ -25,8 +25,12 @@ from foehncast.monitoring.pipeline_metrics import (
     training_pipeline_summary_path,
 )
 from foehncast.monitoring.prediction_log import (
+    PREDICTION_EVENT_FIELDS,
     append_prediction_log,
     emit_prediction_drift_metrics,
+    prediction_event_log_path,
+    read_prediction_event_log,
+    read_prediction_history,
     read_prediction_log,
 )
 from foehncast.monitoring.prediction_prometheus import (
@@ -38,6 +42,7 @@ __all__ = [
     "DriftMetric",
     "DriftReport",
     "FEATURE_PIPELINE_METRIC_CONTRACT",
+    "PREDICTION_EVENT_FIELDS",
     "TRAINING_PIPELINE_METRIC_CONTRACT",
     "append_prediction_log",
     "build_prediction_log_prometheus_registry",
@@ -49,8 +54,11 @@ __all__ = [
     "emit_training_pipeline_run_summary",
     "feature_pipeline_stage_overview",
     "feature_pipeline_summary_path",
+    "prediction_event_log_path",
     "push_drift_metrics",
     "read_online_compose_sync_status",
+    "read_prediction_event_log",
+    "read_prediction_history",
     "read_prediction_log",
     "read_feature_pipeline_run_summary",
     "read_training_pipeline_run_summary",

--- a/src/foehncast/monitoring/prediction_log.py
+++ b/src/foehncast/monitoring/prediction_log.py
@@ -1,4 +1,12 @@
-"""Prediction log persistence and model-side drift monitoring helpers."""
+"""Prediction-event persistence and model-side drift monitoring helpers.
+
+The monitoring stack uses two related JSONL contracts:
+
+- ``prediction-log.jsonl`` is a bounded local working set used for request-side
+    drift evaluation.
+- ``prediction-events.jsonl`` is the durable event history contract used by
+    monitoring readers and can be redirected to shared storage with an env var.
+"""
 
 from __future__ import annotations
 
@@ -21,12 +29,40 @@ from foehncast.paths import project_root
 
 logger = logging.getLogger(__name__)
 
+PREDICTION_EVENT_FIELDS = (
+    "prediction_timestamp",
+    "forecast_time",
+    "quality_index",
+    "endpoint",
+    "model_version",
+    "spot_id",
+    "spot_name",
+    "requested_spot_ids",
+)
 _DEFAULT_PREDICTION_LOG_MAX_ROWS = 2048
 _DEFAULT_PREDICTION_LOG_RETENTION_DAYS = 60
 
 
 def _default_prediction_log_path() -> Path:
     return project_root() / ".state" / "monitoring" / "prediction-log.jsonl"
+
+
+def prediction_event_log_path(
+    path: Path | None = None,
+    *,
+    fallback_log_path: Path | None = None,
+) -> Path:
+    if path is not None:
+        return path
+
+    raw_value = os.getenv("FOEHNCAST_PREDICTION_EVENT_LOG_PATH", "").strip()
+    if raw_value:
+        return Path(raw_value).expanduser()
+
+    if fallback_log_path is not None:
+        return fallback_log_path.with_name("prediction-events.jsonl")
+
+    return project_root() / ".state" / "monitoring" / "prediction-events.jsonl"
 
 
 def _prediction_log_max_rows(configured: int | None = None) -> int:
@@ -54,6 +90,14 @@ def _prediction_log_lines(source: Path) -> list[str]:
     return [
         line for line in source.read_text(encoding="utf-8").splitlines() if line.strip()
     ]
+
+
+def _append_prediction_rows(destination: Path, rows: list[dict[str, Any]]) -> None:
+    destination.parent.mkdir(parents=True, exist_ok=True)
+
+    with destination.open("a", encoding="utf-8") as handle:
+        for row in rows:
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
 
 
 def _prediction_log_retention_days(configured: int | None = None) -> int:
@@ -173,65 +217,28 @@ def _flatten_prediction_payload(
 
     for prediction in prediction_payload.get("predictions", []):
         for forecast in prediction.get("forecast", []):
-            rows.append(
-                {
-                    "prediction_timestamp": resolved_timestamp,
-                    "forecast_time": forecast.get("time"),
-                    "quality_index": float(forecast["quality_index"]),
-                    "endpoint": endpoint,
-                    "model_version": model_version,
-                    "spot_id": prediction.get("spot_id"),
-                    "spot_name": prediction.get("spot_name"),
-                    "requested_spot_ids": requested_spot_ids,
-                }
-            )
+            row = {
+                "prediction_timestamp": resolved_timestamp,
+                "forecast_time": forecast.get("time"),
+                "quality_index": float(forecast["quality_index"]),
+                "endpoint": endpoint,
+                "model_version": model_version,
+                "spot_id": prediction.get("spot_id"),
+                "spot_name": prediction.get("spot_name"),
+                "requested_spot_ids": requested_spot_ids,
+            }
+            rows.append({field: row[field] for field in PREDICTION_EVENT_FIELDS})
 
     return rows
 
 
-def append_prediction_log(
-    prediction_payload: dict[str, Any],
-    *,
-    endpoint: str,
-    spot_ids: list[str] | None = None,
-    path: Path | None = None,
-    logged_at: datetime | None = None,
-    max_rows: int | None = None,
-    retention_days: int | None = None,
-) -> Path | None:
-    rows = _flatten_prediction_payload(
-        prediction_payload,
-        endpoint=endpoint,
-        spot_ids=spot_ids,
-        logged_at=logged_at,
-    )
-    if not rows:
-        return None
-
-    destination = path or _default_prediction_log_path()
-    destination.parent.mkdir(parents=True, exist_ok=True)
-
-    with destination.open("a", encoding="utf-8") as handle:
-        for row in rows:
-            handle.write(json.dumps(row, sort_keys=True) + "\n")
-
-    _trim_prediction_log(
-        destination,
-        max_rows=_prediction_log_max_rows(max_rows),
-        retention_days=_prediction_log_retention_days(retention_days),
-    )
-
-    return destination
-
-
-def read_prediction_log(
-    path: Path | None = None,
+def _read_prediction_rows(
+    source: Path,
     *,
     max_rows: int | None = None,
     model_version: str | None = None,
     retention_days: int | None = None,
 ) -> pd.DataFrame:
-    source = path or _default_prediction_log_path()
     if not source.exists():
         return pd.DataFrame()
 
@@ -254,12 +261,120 @@ def read_prediction_log(
     return frame
 
 
+def append_prediction_log(
+    prediction_payload: dict[str, Any],
+    *,
+    endpoint: str,
+    spot_ids: list[str] | None = None,
+    path: Path | None = None,
+    event_path: Path | None = None,
+    logged_at: datetime | None = None,
+    max_rows: int | None = None,
+    retention_days: int | None = None,
+) -> Path | None:
+    rows = _flatten_prediction_payload(
+        prediction_payload,
+        endpoint=endpoint,
+        spot_ids=spot_ids,
+        logged_at=logged_at,
+    )
+    if not rows:
+        return None
+
+    destination = path or _default_prediction_log_path()
+    durable_destination = prediction_event_log_path(
+        event_path,
+        fallback_log_path=destination,
+    )
+
+    if durable_destination == destination:
+        logger.warning(
+            "Prediction event history path %s matches the retained working log; "
+            "using a sibling prediction-events.jsonl file instead.",
+            durable_destination,
+        )
+        durable_destination = destination.with_name("prediction-events.jsonl")
+
+    _append_prediction_rows(durable_destination, rows)
+    _append_prediction_rows(destination, rows)
+
+    _trim_prediction_log(
+        destination,
+        max_rows=_prediction_log_max_rows(max_rows),
+        retention_days=_prediction_log_retention_days(retention_days),
+    )
+
+    return destination
+
+
+def read_prediction_log(
+    path: Path | None = None,
+    *,
+    max_rows: int | None = None,
+    model_version: str | None = None,
+    retention_days: int | None = None,
+) -> pd.DataFrame:
+    source = path or _default_prediction_log_path()
+    return _read_prediction_rows(
+        source,
+        max_rows=max_rows,
+        model_version=model_version,
+        retention_days=retention_days,
+    )
+
+
+def read_prediction_event_log(
+    path: Path | None = None,
+    *,
+    fallback_log_path: Path | None = None,
+    max_rows: int | None = None,
+    model_version: str | None = None,
+    retention_days: int | None = None,
+) -> pd.DataFrame:
+    source = prediction_event_log_path(path, fallback_log_path=fallback_log_path)
+    return _read_prediction_rows(
+        source,
+        max_rows=max_rows,
+        model_version=model_version,
+        retention_days=retention_days,
+    )
+
+
+def read_prediction_history(
+    event_path: Path | None = None,
+    *,
+    fallback_log_path: Path | None = None,
+    max_rows: int | None = None,
+    model_version: str | None = None,
+    retention_days: int | None = None,
+) -> pd.DataFrame:
+    source = prediction_event_log_path(
+        event_path,
+        fallback_log_path=fallback_log_path,
+    )
+    if source.exists():
+        return _read_prediction_rows(
+            source,
+            max_rows=max_rows,
+            model_version=model_version,
+            retention_days=retention_days,
+        )
+
+    return read_prediction_log(
+        fallback_log_path,
+        max_rows=max_rows,
+        model_version=model_version,
+        retention_days=retention_days,
+    )
+
+
 def emit_prediction_drift_metrics(
     prediction_payload: dict[str, Any],
     *,
     endpoint: str,
     spot_ids: list[str] | None = None,
     path: Path | None = None,
+    event_path: Path | None = None,
     max_rows: int | None = None,
     retention_days: int | None = None,
 ) -> DriftReport | None:
@@ -272,14 +387,16 @@ def emit_prediction_drift_metrics(
             endpoint=endpoint,
             spot_ids=spot_ids,
             path=path,
+            event_path=event_path,
             max_rows=max_rows,
             retention_days=retention_days,
         )
         if log_path is None:
             return None
 
-        predictions_log = read_prediction_log(
-            log_path,
+        predictions_log = read_prediction_history(
+            event_path,
+            fallback_log_path=log_path,
             max_rows=max_rows,
             model_version=model_version,
             retention_days=retention_days,
@@ -307,7 +424,11 @@ def emit_prediction_drift_metrics(
 
 
 __all__ = [
+    "PREDICTION_EVENT_FIELDS",
     "append_prediction_log",
     "emit_prediction_drift_metrics",
+    "prediction_event_log_path",
+    "read_prediction_event_log",
+    "read_prediction_history",
     "read_prediction_log",
 ]

--- a/src/foehncast/monitoring/prediction_prometheus.py
+++ b/src/foehncast/monitoring/prediction_prometheus.py
@@ -1,15 +1,11 @@
-"""Prometheus export helpers for retained file-backed prediction-log state.
-
-These metrics are durable relative to process-local counters because they are
-rendered from persisted JSONL state that survives serving-process restarts.
-"""
+"""Prometheus export helpers for durable prediction-event monitoring state."""
 
 from __future__ import annotations
 
 import pandas as pd
 from prometheus_client import CollectorRegistry, Gauge, generate_latest
 
-from foehncast.monitoring.prediction_log import read_prediction_log
+from foehncast.monitoring.prediction_log import read_prediction_history
 
 
 DURABLE_METRIC_PREFIX = "foehncast_prediction_log_"
@@ -19,37 +15,37 @@ DURABLE_METRIC_PREFIX = "foehncast_prediction_log_"
 def build_prediction_log_prometheus_registry(
     predictions_log: pd.DataFrame | None = None,
 ) -> CollectorRegistry:
-    """Render the retained file-backed prediction log into a scrapeable registry."""
+    """Render durable prediction-event history into a scrapeable registry."""
     resolved_log = (
-        read_prediction_log() if predictions_log is None else predictions_log.copy()
+        read_prediction_history() if predictions_log is None else predictions_log.copy()
     )
     registry = CollectorRegistry()
 
     total_rows = Gauge(
         "foehncast_prediction_log_total_row_count",
-        "Retained file-backed prediction-log rows available for inference monitoring.",
+        "Number of retained durable prediction-event rows available for inference monitoring.",
         registry=registry,
     )
     model_count = Gauge(
         "foehncast_prediction_log_model_count",
-        "Number of retained model versions present in the file-backed prediction log.",
+        "Number of retained model versions present in durable prediction-event history.",
         registry=registry,
     )
     row_count = Gauge(
         "foehncast_prediction_log_row_count",
-        "Retained file-backed prediction-log row count for one model version.",
+        "Retained durable prediction-event row count for one model version.",
         labelnames=("model_version",),
         registry=registry,
     )
     latest_prediction_timestamp = Gauge(
         "foehncast_prediction_log_latest_prediction_timestamp_seconds",
-        "Unix timestamp of the latest retained file-backed prediction-log write for one model version.",
+        "Unix timestamp of the latest retained durable prediction-event write for one model version.",
         labelnames=("model_version",),
         registry=registry,
     )
     latest_forecast_timestamp = Gauge(
         "foehncast_prediction_log_latest_forecast_timestamp_seconds",
-        "Unix timestamp of the latest retained forecast timestamp in the file-backed prediction log for one model version.",
+        "Unix timestamp of the latest retained forecast timestamp in durable prediction-event history for one model version.",
         labelnames=("model_version",),
         registry=registry,
     )
@@ -97,7 +93,7 @@ def build_prediction_log_prometheus_registry(
 def render_prediction_log_prometheus_metrics(
     predictions_log: pd.DataFrame | None = None,
 ) -> bytes:
-    """Return Prometheus exposition text for the retained file-backed prediction log."""
+    """Return Prometheus exposition text for durable prediction-event history."""
     registry = build_prediction_log_prometheus_registry(predictions_log=predictions_log)
     return generate_latest(registry)
 

--- a/tests/test_prediction_log.py
+++ b/tests/test_prediction_log.py
@@ -51,6 +51,131 @@ def test_append_prediction_log_and_read_prediction_log_round_trip(
     )
 
 
+def test_append_prediction_log_writes_durable_event_history_by_default(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+    event_path = tmp_path / "prediction-events.jsonl"
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.4},
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.8},
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        logged_at=datetime(2026, 5, 11, 10, 0, tzinfo=UTC),
+    )
+
+    frame = prediction_log.read_prediction_event_log(event_path)
+
+    assert event_path.exists()
+    assert len(frame) == 2
+    assert list(frame["quality_index"]) == [2.4, 2.8]
+
+
+def test_read_prediction_history_prefers_durable_event_store_when_available(
+    tmp_path: Path,
+) -> None:
+    shared_event_path = tmp_path / "shared" / "prediction-events.jsonl"
+    local_log_path = tmp_path / "instance-a" / "prediction-log.jsonl"
+    remote_log_path = tmp_path / "instance-b" / "prediction-log.jsonl"
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.1}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=remote_log_path,
+        event_path=shared_event_path,
+        logged_at=datetime(2026, 5, 11, 9, 0, tzinfo=UTC),
+    )
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.3}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=local_log_path,
+        event_path=shared_event_path,
+        logged_at=datetime(2026, 5, 11, 10, 0, tzinfo=UTC),
+    )
+
+    local_frame = prediction_log.read_prediction_log(local_log_path, max_rows=10)
+    history_frame = prediction_log.read_prediction_history(
+        event_path=shared_event_path,
+        fallback_log_path=local_log_path,
+        max_rows=10,
+    )
+
+    assert len(local_frame) == 1
+    assert list(local_frame["quality_index"]) == [2.3]
+    assert len(history_frame) == 2
+    assert list(history_frame["quality_index"]) == [2.1, 2.3]
+
+
+def test_read_prediction_history_falls_back_to_local_log_when_durable_store_missing(
+    tmp_path: Path,
+) -> None:
+    log_path = tmp_path / "prediction-log.jsonl"
+    event_path = tmp_path / "shared" / "prediction-events.jsonl"
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.4},
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.8},
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=log_path,
+        event_path=log_path.with_name("other-events.jsonl"),
+        logged_at=datetime(2026, 5, 11, 10, 0, tzinfo=UTC),
+    )
+
+    history_frame = prediction_log.read_prediction_history(
+        event_path=event_path,
+        fallback_log_path=log_path,
+        max_rows=10,
+    )
+
+    assert len(history_frame) == 2
+    assert list(history_frame["quality_index"]) == [2.4, 2.8]
+
+
 def test_append_prediction_log_trims_to_recent_rows(
     tmp_path: Path,
 ) -> None:
@@ -450,6 +575,78 @@ def test_emit_prediction_drift_metrics_uses_recent_rows_for_current_model_versio
     assert captured["rows"] == 2
     assert captured["versions"] == ["7", "7"]
     assert captured["quality_index"] == [2.1, 2.2]
+
+
+def test_emit_prediction_drift_metrics_prefers_durable_event_history_when_available(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    shared_event_path = tmp_path / "shared" / "prediction-events.jsonl"
+    local_log_path = tmp_path / "instance-a" / "prediction-log.jsonl"
+    remote_log_path = tmp_path / "instance-b" / "prediction-log.jsonl"
+    captured: dict[str, object] = {}
+
+    prediction_log.append_prediction_log(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T00:00:00+00:00", "quality_index": 2.1}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=remote_log_path,
+        event_path=shared_event_path,
+        logged_at=datetime(2026, 5, 11, 9, 0, tzinfo=UTC),
+    )
+
+    def fake_detect_prediction_drift(predictions_log: pd.DataFrame) -> SimpleNamespace:
+        captured["rows"] = len(predictions_log)
+        captured["quality_index"] = list(predictions_log["quality_index"])
+        return SimpleNamespace(
+            dataset_name=predictions_log.attrs["dataset_name"],
+            dataset_version=predictions_log.attrs["dataset_version"],
+        )
+
+    monkeypatch.setattr(
+        prediction_log,
+        "detect_prediction_drift",
+        fake_detect_prediction_drift,
+    )
+    monkeypatch.setattr(
+        prediction_log,
+        "push_drift_metrics",
+        lambda report: captured.update({"pushed": report}),
+    )
+
+    report = prediction_log.emit_prediction_drift_metrics(
+        {
+            "model_version": "7",
+            "predictions": [
+                {
+                    "spot_id": "silvaplana",
+                    "spot_name": "Silvaplana",
+                    "forecast": [
+                        {"time": "2025-01-01T01:00:00+00:00", "quality_index": 2.4}
+                    ],
+                }
+            ],
+        },
+        endpoint="predict",
+        path=local_log_path,
+        event_path=shared_event_path,
+        max_rows=10,
+    )
+
+    assert report is not None
+    assert captured["rows"] == 2
+    assert captured["quality_index"] == [2.1, 2.4]
+    assert captured["pushed"].dataset_version == "7"
 
 
 def test_emit_prediction_drift_metrics_returns_none_when_no_forecast_rows(

--- a/tests/test_prediction_prometheus.py
+++ b/tests/test_prediction_prometheus.py
@@ -103,6 +103,37 @@ def test_durable_help_text_states_file_backed_contract() -> None:
     help_lines = [line for line in payload.splitlines() if line.startswith("# HELP")]
 
     assert help_lines, "Expected HELP lines in the durable render"
-    assert all("file-backed" in line.lower() for line in help_lines), (
-        f"All HELP lines must state file-backed durability; got: {help_lines}"
+    assert all("durable" in line.lower() for line in help_lines), (
+        f"All HELP lines must state durable history semantics; got: {help_lines}"
     )
+
+
+def test_render_prediction_log_prometheus_metrics_reads_durable_history_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    predictions_log = pd.DataFrame(
+        {
+            "model_version": ["9"],
+            "prediction_timestamp": pd.to_datetime(
+                ["2026-05-11T10:00:00+00:00"],
+                utc=True,
+            ),
+            "forecast_time": pd.to_datetime(
+                ["2025-01-01T00:00:00+00:00"],
+                utc=True,
+            ),
+            "quality_index": [3.5],
+        }
+    )
+    monkeypatch.setattr(
+        prediction_prometheus,
+        "read_prediction_history",
+        lambda: predictions_log,
+    )
+
+    payload = prediction_prometheus.render_prediction_log_prometheus_metrics().decode(
+        "utf-8"
+    )
+
+    assert "foehncast_prediction_log_total_row_count 1.0" in payload
+    assert 'foehncast_prediction_log_row_count{model_version="9"} 1.0' in payload


### PR DESCRIPTION
### What Changed
- Add a durable `prediction-events.jsonl` history contract alongside the bounded local prediction log.
- Allow the durable history path to be redirected with `FOEHNCAST_PREDICTION_EVENT_LOG_PATH` while keeping local defaults intact.
- Teach drift and Prometheus readers to prefer the durable history and fall back to the local log when it is absent.

### Why
- Let inference monitoring survive process restarts and combine history across runtime instances without breaking local development.

### Verification
- uv run ruff check src/foehncast/monitoring/__init__.py src/foehncast/monitoring/prediction_log.py src/foehncast/monitoring/prediction_prometheus.py tests/test_prediction_log.py tests/test_prediction_prometheus.py
- uv run ruff format --check src/foehncast/monitoring/__init__.py src/foehncast/monitoring/prediction_log.py src/foehncast/monitoring/prediction_prometheus.py tests/test_prediction_log.py tests/test_prediction_prometheus.py
- uv run pytest tests/test_prediction_log.py tests/test_prediction_prometheus.py -q

### Closes
- Closes #151