### PR TITLE
feat(storage): define warehouse contracts

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -108,6 +108,29 @@ spots:
 storage:
   backend: "s3" # s3 local baseline | bigquery cloud
 
+# BigQuery is the offline warehouse layer when enabled. Curated features are
+# stored under the storage.bigquery_* table binding; retained monitoring facts
+# belong in separate warehouse tables instead of being inferred from live API or
+# /metrics responses.
+warehouse:
+  curated_features:
+    partition_field: forecast_time
+    partition_granularity: day
+    cluster_fields:
+      - dataset_name
+      - spot_id
+    retention_days: 730
+  prediction_events:
+    dataset: foehncast_monitoring
+    table: prediction_events
+    partition_field: prediction_timestamp
+    partition_granularity: day
+    cluster_fields:
+      - model_version
+      - endpoint
+      - spot_id
+    retention_days: 180
+
 # Deployment wiring such as regions, buckets, Cloud Run names, and GitHub OIDC
 # lives outside the package config in .env, Terraform inputs, and CI variables.
 

--- a/src/foehncast/config.py
+++ b/src/foehncast/config.py
@@ -17,6 +17,11 @@ _DEFAULT_STORAGE_BACKEND = "s3"
 _DEFAULT_STORAGE_S3_BUCKET = "foehncast-data"
 _DEFAULT_BIGQUERY_DATASET = "foehncast"
 _DEFAULT_BIGQUERY_TABLE = "forecast_features"
+_DEFAULT_BIGQUERY_PARTITION_GRANULARITY = "DAY"
+_DEFAULT_CURATED_FEATURE_RETENTION_DAYS = 730
+_DEFAULT_PREDICTION_EVENT_DATASET = "foehncast_monitoring"
+_DEFAULT_PREDICTION_EVENT_TABLE = "prediction_events"
+_DEFAULT_PREDICTION_EVENT_RETENTION_DAYS = 180
 _DEFAULT_MLFLOW_TRACKING_URI = "http://localhost:5001"
 
 
@@ -36,6 +41,58 @@ def _resolved_dict_section(name: str) -> dict[str, Any]:
     if not isinstance(section, dict):
         return {}
     return copy.deepcopy(section)
+
+
+def _resolved_string_list(value: Any) -> list[str]:
+    if isinstance(value, str):
+        candidates = value.split(",")
+    elif isinstance(value, (list, tuple)):
+        candidates = value
+    else:
+        candidates = []
+
+    return [str(item).strip() for item in candidates if str(item).strip()]
+
+
+def _positive_int(value: Any, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return default
+    return max(parsed, 1)
+
+
+def _resolved_warehouse_contract(
+    raw_contract: Any,
+    *,
+    default_dataset: str,
+    default_table: str,
+    default_partition_field: str,
+    default_cluster_fields: tuple[str, ...],
+    default_retention_days: int,
+) -> dict[str, Any]:
+    contract = raw_contract if isinstance(raw_contract, dict) else {}
+
+    cluster_fields = _resolved_string_list(contract.get("cluster_fields"))
+    if not cluster_fields:
+        cluster_fields = list(default_cluster_fields)
+
+    return {
+        "dataset": str(contract.get("dataset", "")).strip() or default_dataset,
+        "table": str(contract.get("table", "")).strip() or default_table,
+        "partition_field": (
+            str(contract.get("partition_field", "")).strip() or default_partition_field
+        ),
+        "partition_granularity": (
+            str(contract.get("partition_granularity", "")).strip().upper()
+            or _DEFAULT_BIGQUERY_PARTITION_GRANULARITY
+        ),
+        "cluster_fields": cluster_fields,
+        "retention_days": _positive_int(
+            contract.get("retention_days"),
+            default_retention_days,
+        ),
+    }
 
 
 def _config_path() -> Path:
@@ -84,6 +141,7 @@ def get_labeling_config() -> dict[str, Any]:
 def get_storage_config() -> dict[str, Any]:
     """Return storage mode plus runtime-bound storage wiring."""
     storage = _resolved_dict_section("storage")
+    warehouse = _resolved_dict_section("warehouse")
 
     storage["backend"] = (
         _env_value("STORAGE_BACKEND")
@@ -132,6 +190,25 @@ def get_storage_config() -> dict[str, Any]:
         or str(storage.get("bigquery_table", "")).strip()
         or _DEFAULT_BIGQUERY_TABLE
     )
+
+    storage["warehouse_contracts"] = {
+        "curated_features": _resolved_warehouse_contract(
+            warehouse.get("curated_features"),
+            default_dataset=storage["bigquery_dataset"],
+            default_table=storage["bigquery_table"],
+            default_partition_field="forecast_time",
+            default_cluster_fields=("dataset_name", "spot_id"),
+            default_retention_days=_DEFAULT_CURATED_FEATURE_RETENTION_DAYS,
+        ),
+        "prediction_events": _resolved_warehouse_contract(
+            warehouse.get("prediction_events"),
+            default_dataset=_DEFAULT_PREDICTION_EVENT_DATASET,
+            default_table=_DEFAULT_PREDICTION_EVENT_TABLE,
+            default_partition_field="prediction_timestamp",
+            default_cluster_fields=("model_version", "endpoint", "spot_id"),
+            default_retention_days=_DEFAULT_PREDICTION_EVENT_RETENTION_DAYS,
+        ),
+    }
 
     return storage
 

--- a/src/foehncast/feature_pipeline/store.py
+++ b/src/foehncast/feature_pipeline/store.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from abc import ABC, abstractmethod
 import importlib
 import os
+import types
 from typing import Any
 
 import pandas as pd
@@ -14,6 +15,9 @@ from foehncast.config import get_storage_config
 _BQ_TIME_COLUMN = "forecast_time"
 _BQ_DATASET_COLUMN = "dataset_name"
 _BQ_SPOT_COLUMN = "spot_id"
+_DEFAULT_BIGQUERY_PARTITION_GRANULARITY = "DAY"
+_DEFAULT_BIGQUERY_RETENTION_DAYS = 730
+_DEFAULT_BIGQUERY_CLUSTER_FIELDS = (_BQ_DATASET_COLUMN, _BQ_SPOT_COLUMN)
 
 
 class FeatureStoreBackend(ABC):
@@ -177,6 +181,93 @@ def _bigquery_client(storage_config: dict[str, Any]) -> Any:
     return _bigquery_module().Client(project=_bigquery_project_id(storage_config))
 
 
+def _bigquery_curated_feature_contract(
+    storage_config: dict[str, Any],
+) -> dict[str, Any]:
+    warehouse_contracts = storage_config.get("warehouse_contracts", {})
+    raw_contract = {}
+    if isinstance(warehouse_contracts, dict):
+        candidate = warehouse_contracts.get("curated_features", {})
+        if isinstance(candidate, dict):
+            raw_contract = candidate
+
+    cluster_fields = raw_contract.get(
+        "cluster_fields",
+        _DEFAULT_BIGQUERY_CLUSTER_FIELDS,
+    )
+    resolved_cluster_fields = [
+        str(field).strip() for field in cluster_fields if str(field).strip()
+    ]
+    if not resolved_cluster_fields:
+        resolved_cluster_fields = list(_DEFAULT_BIGQUERY_CLUSTER_FIELDS)
+
+    retention_days = raw_contract.get(
+        "retention_days",
+        _DEFAULT_BIGQUERY_RETENTION_DAYS,
+    )
+    try:
+        resolved_retention_days = max(int(retention_days), 1)
+    except (TypeError, ValueError):
+        resolved_retention_days = _DEFAULT_BIGQUERY_RETENTION_DAYS
+
+    return {
+        "partition_field": (
+            str(raw_contract.get("partition_field", "")).strip() or _BQ_TIME_COLUMN
+        ),
+        "partition_granularity": (
+            str(raw_contract.get("partition_granularity", "")).strip().upper()
+            or _DEFAULT_BIGQUERY_PARTITION_GRANULARITY
+        ),
+        "cluster_fields": resolved_cluster_fields,
+        "retention_days": resolved_retention_days,
+    }
+
+
+def _bigquery_time_partitioning(bigquery: Any, contract: dict[str, Any]) -> Any:
+    partition_type = contract["partition_granularity"]
+    enum = getattr(bigquery, "TimePartitioningType", None)
+    if enum is not None:
+        partition_type = getattr(enum, partition_type, partition_type)
+
+    time_partitioning = getattr(bigquery, "TimePartitioning", None)
+    expiration_ms = contract["retention_days"] * 24 * 60 * 60 * 1000
+    if time_partitioning is None:
+        return types.SimpleNamespace(
+            type_=partition_type,
+            field=contract["partition_field"],
+            expiration_ms=expiration_ms,
+            require_partition_filter=False,
+        )
+
+    return time_partitioning(
+        type_=partition_type,
+        field=contract["partition_field"],
+        expiration_ms=expiration_ms,
+        require_partition_filter=False,
+    )
+
+
+def _validate_bigquery_contract_frame(
+    frame: pd.DataFrame,
+    contract: dict[str, Any],
+) -> None:
+    partition_field = contract["partition_field"]
+    if partition_field not in frame.columns:
+        raise ValueError(
+            f"Curated BigQuery contract requires partition field '{partition_field}'"
+        )
+
+    missing_cluster_fields = [
+        field for field in contract["cluster_fields"] if field not in frame.columns
+    ]
+    if missing_cluster_fields:
+        missing = ", ".join(missing_cluster_fields)
+        raise ValueError(
+            "Curated BigQuery contract requires cluster fields present in the write frame: "
+            f"{missing}"
+        )
+
+
 def _bigquery_not_found(storage_config: dict[str, Any]) -> bool:
     client = _bigquery_client(storage_config)
     table_id = _bigquery_table_id(storage_config)
@@ -239,8 +330,14 @@ def _write_features_bigquery(
     bigquery = _bigquery_module()
     client = _bigquery_client(storage_config)
     write_frame = _bigquery_write_frame(df, spot_id=spot_id, dataset=dataset)
+    contract = _bigquery_curated_feature_contract(storage_config)
+    _validate_bigquery_contract_frame(write_frame, contract)
     _delete_features_bigquery(storage_config, spot_id=spot_id, dataset=dataset)
-    job_config = bigquery.LoadJobConfig(write_disposition="WRITE_APPEND")
+    job_config = bigquery.LoadJobConfig(
+        write_disposition="WRITE_APPEND",
+        time_partitioning=_bigquery_time_partitioning(bigquery, contract),
+        clustering_fields=contract["cluster_fields"],
+    )
     client.load_table_from_dataframe(
         write_frame,
         _bigquery_table_id(storage_config),

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -158,6 +158,82 @@ def test_legacy_runtime_fields_still_resolve_without_env(
     assert config.get_mlflow_tracking_uri() == "http://legacy-mlflow:5001"
 
 
+def test_storage_config_exposes_default_warehouse_contracts(tmp_path: Path) -> None:
+    config_path = tmp_path / "config.yaml"
+    _write_config(config_path)
+
+    config.load_config(config_path)
+    storage_config = config.get_storage_config()
+
+    assert storage_config["warehouse_contracts"]["curated_features"] == {
+        "dataset": "foehncast",
+        "table": "forecast_features",
+        "partition_field": "forecast_time",
+        "partition_granularity": "DAY",
+        "cluster_fields": ["dataset_name", "spot_id"],
+        "retention_days": 730,
+    }
+    assert storage_config["warehouse_contracts"]["prediction_events"] == {
+        "dataset": "foehncast_monitoring",
+        "table": "prediction_events",
+        "partition_field": "prediction_timestamp",
+        "partition_granularity": "DAY",
+        "cluster_fields": ["model_version", "endpoint", "spot_id"],
+        "retention_days": 180,
+    }
+
+
+def test_storage_config_resolves_custom_warehouse_contracts_from_yaml(
+    tmp_path: Path,
+) -> None:
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(
+        yaml.safe_dump(
+            {
+                "storage": {
+                    "backend": "bigquery",
+                    "bigquery_dataset": "curated_features",
+                    "bigquery_table": "feature_rows",
+                },
+                "warehouse": {
+                    "curated_features": {
+                        "partition_granularity": "day",
+                        "cluster_fields": ["spot_id", "dataset_name"],
+                        "retention_days": 365,
+                    },
+                    "prediction_events": {
+                        "dataset": "monitoring_ops",
+                        "table": "prediction_history",
+                        "cluster_fields": ["endpoint", "model_version"],
+                        "retention_days": 45,
+                    },
+                },
+            },
+            sort_keys=False,
+        )
+    )
+
+    config.load_config(config_path)
+    storage_config = config.get_storage_config()
+
+    assert storage_config["warehouse_contracts"]["curated_features"] == {
+        "dataset": "curated_features",
+        "table": "feature_rows",
+        "partition_field": "forecast_time",
+        "partition_granularity": "DAY",
+        "cluster_fields": ["spot_id", "dataset_name"],
+        "retention_days": 365,
+    }
+    assert storage_config["warehouse_contracts"]["prediction_events"] == {
+        "dataset": "monitoring_ops",
+        "table": "prediction_history",
+        "partition_field": "prediction_timestamp",
+        "partition_granularity": "DAY",
+        "cluster_fields": ["endpoint", "model_version"],
+        "retention_days": 45,
+    }
+
+
 def test_project_root_env_resolves_default_config_path(
     monkeypatch: pytest.MonkeyPatch, tmp_path: Path
 ) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -244,6 +244,8 @@ def test_write_features_bigquery_uses_load_job(
             captured["table_id"] = table_id
             captured["frame"] = frame.copy()
             captured["write_disposition"] = job_config.write_disposition
+            captured["time_partitioning"] = job_config.time_partitioning
+            captured["clustering_fields"] = job_config.clustering_fields
             return FakeLoadJob()
 
         def query(self, query: str, job_config: object | None = None) -> FakeDeleteJob:
@@ -252,8 +254,24 @@ def test_write_features_bigquery_uses_load_job(
             return FakeDeleteJob()
 
     class FakeLoadJobConfig:
-        def __init__(self, write_disposition: str) -> None:
+        def __init__(self, write_disposition: str, **kwargs: object) -> None:
             self.write_disposition = write_disposition
+            for name, value in kwargs.items():
+                setattr(self, name, value)
+
+    class FakeTimePartitioning:
+        def __init__(
+            self,
+            *,
+            type_: object,
+            field: str,
+            expiration_ms: int,
+            require_partition_filter: bool,
+        ) -> None:
+            self.type_ = type_
+            self.field = field
+            self.expiration_ms = expiration_ms
+            self.require_partition_filter = require_partition_filter
 
     class FakeScalarQueryParameter:
         def __init__(self, name: str, param_type: str, value: str) -> None:
@@ -273,6 +291,8 @@ def test_write_features_bigquery_uses_load_job(
             LoadJobConfig=FakeLoadJobConfig,
             QueryJobConfig=FakeQueryJobConfig,
             ScalarQueryParameter=FakeScalarQueryParameter,
+            TimePartitioning=FakeTimePartitioning,
+            TimePartitioningType=types.SimpleNamespace(DAY="DAY"),
         ),
     )
     monkeypatch.setattr(
@@ -302,6 +322,11 @@ def test_write_features_bigquery_uses_load_job(
     assert captured["project"] == "demo-project"
     assert captured["table_id"] == "demo-project.foehncast.forecast_features"
     assert captured["write_disposition"] == "WRITE_APPEND"
+    assert captured["time_partitioning"].field == "forecast_time"
+    assert captured["time_partitioning"].type_ == "DAY"
+    assert captured["time_partitioning"].expiration_ms == 63072000000
+    assert captured["time_partitioning"].require_partition_filter is False
+    assert captured["clustering_fields"] == ["dataset_name", "spot_id"]
     assert captured["delete_completed"] is True
     assert captured["job_completed"] is True
     assert (
@@ -450,8 +475,10 @@ def test_bigquery_round_trip_restores_original_feature_schema(
             self.query_parameters = query_parameters
 
     class FakeLoadJobConfig:
-        def __init__(self, write_disposition: str) -> None:
+        def __init__(self, write_disposition: str, **kwargs: object) -> None:
             self.write_disposition = write_disposition
+            for name, value in kwargs.items():
+                setattr(self, name, value)
 
     class FakeClient:
         def __init__(self, project: str) -> None:
@@ -555,8 +582,10 @@ def test_write_features_bigquery_replaces_existing_slice_on_repeated_writes(
             self.query_parameters = query_parameters
 
     class FakeLoadJobConfig:
-        def __init__(self, write_disposition: str) -> None:
+        def __init__(self, write_disposition: str, **kwargs: object) -> None:
             self.write_disposition = write_disposition
+            for name, value in kwargs.items():
+                setattr(self, name, value)
 
     class FakeClient:
         def __init__(self, project: str) -> None:


### PR DESCRIPTION
### What Changed
- Add explicit warehouse contracts for curated features and prediction events in `config.yaml` and the resolved storage config.
- Apply the curated-feature BigQuery contract to partitioning, clustering, and retention wiring during writes.
- Add focused tests for warehouse-contract resolution and the BigQuery load job contract.

### Why
- Make telemetry and curated-feature warehouse ownership explicit instead of relying on implicit table behavior.

### Verification
- uv run ruff check src/foehncast/config.py src/foehncast/feature_pipeline/store.py tests/test_config.py tests/test_store.py
- uv run ruff format --check src/foehncast/config.py src/foehncast/feature_pipeline/store.py tests/test_config.py tests/test_store.py
- uv run pytest tests/test_config.py tests/test_store.py -q

### Closes
- Closes #152