### PR TITLE
docs: clarify public and operator surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,10 @@ This is the default path for a fresh machine.
 3. Run `./scripts/bootstrap-local.sh`.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
-The local bootstrap uses the bundled MinIO service for curated features and MLflow artifacts. It prepares Feast with the bundled Datastore-mode emulator, runs the training DAG with the serving alias path so the app comes up healthy on a real registry version, and checks that Grafana loaded the checked-in dashboard and alerts before it reports the stack ready. If the default ports are busy, it moves to the next free ports and prints the resolved endpoints.
-On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically. When the retraining gate passes, it triggers the separate `training_pipeline` DAG instead of embedding train, evaluate, and register steps inside the feature flow. The `training_pipeline` DAG itself stays unscheduled and paused by default for manual reruns.
+The local bootstrap uses the bundled MinIO service for curated features and MLflow artifacts. It prepares Feast with the bundled Datastore-mode emulator, runs Airflow against a bundled Postgres metadata database, waits for the feature pipeline to publish a real training-request asset, waits for the resulting asset-triggered training run to finish on a real registry version, and checks that Grafana loaded the checked-in dashboard and alerts before it reports the stack ready. If the default ports are busy, it moves to the next free ports and prints the resolved endpoints.
+The checked-in Grafana configuration disables anonymous access, public dashboard sharing, and embedding by default. The local bootstrap applies local-only access overrides so a fresh local run can still verify Grafana provisioning without extra manual setup.
+The Streamlit demo and the FastAPI prediction and ranking routes are the rider-facing and service-facing surfaces. Airflow, MLflow, Prometheus, and Grafana are operator surfaces used for validation and monitoring, not the primary product UI.
+On a fresh local Airflow state, the scheduled `feature_pipeline` DAG starts unpaused so recurring ingest and preprocessing can run automatically. When the retraining gate passes, it publishes a training-request asset instead of embedding train, evaluate, and register steps inside the feature flow. The `training_pipeline` DAG is scheduled from that asset, so the Airflow Assets view exposes the curated-feature, Feast-sync, training-request, MLflow training, evaluation, and registry hand-offs directly.
 The optional `development_env` notebook container is not part of the default path. Start it only when you need notebook or dev-shell Makefile commands.
 
 After bootstrap completes, the main local endpoints are:
@@ -70,13 +72,16 @@ After bootstrap completes, the main local endpoints are:
 
 The bootstrap summary also prints the resolved objectstore and Feast online-store emulator endpoints.
 
-Feature-pipeline Grafana panels are backed by the latest summary JSON written under `airflow/reports/`. The app mounts that directory and republishes the summary as Prometheus metrics through `/metrics`, so local dashboard plots and Prometheus queries follow the same contract.
+Feature-pipeline Grafana panels are backed by the latest summary JSON written under `airflow/reports/`. The app mounts that directory and republishes the summary as Prometheus metrics through `/metrics`, so local dashboard plots and Prometheus queries follow the same contract. The bootstrap also validates the Airflow health payload itself, not just the HTTP status code returned by the webserver.
 
-Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl`. That log lets the monitoring layer compare recent model outputs with earlier outputs from the same model version without mixing temporary service state into `data/`.
+Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl` as a bounded working set and to `.state/monitoring/prediction-events.jsonl` as the retained history contract. The retained history path can be redirected with `FOEHNCAST_PREDICTION_EVENT_LOG_PATH` when multiple runtimes should contribute to one shared monitoring history.
+Public docs should prefer rendered screenshots or exported evidence over live embeds of private operator dashboards.
+
+When the feature-storage backend is BigQuery, FoehnCast treats it as the offline warehouse layer rather than a live serving shortcut. Curated features are written with an explicit table contract: day partitioning on `forecast_time`, clustering on `dataset_name` and `spot_id`, and a retained table lifecycle policy. Longer-horizon monitoring facts belong in retained event history and warehouse tables, not in request handlers or restart-sensitive `/metrics` counters.
 
 Grafana also creates a starter email contact point for the checked-in alert rules. In the local Docker path, that route uses the built-in placeholder address.
 
-The local bootstrap resets Docker volumes, local Airflow metadata, and temporary runtime artifacts, then checks the live `/features/online` route and the Grafana provisioning API before it reports the stack ready.
+The local bootstrap resets Docker volumes, local Airflow metadata, and temporary runtime artifacts, then checks the live `/features/online` route, waits for the asset-triggered training run to succeed, and verifies the Grafana provisioning API before it reports the stack ready.
 
 Example check:
 

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -12,14 +12,25 @@ This is the default path for a fresh machine.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 
-The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. The same local stack now includes Prometheus, a StatsD exporter, and Grafana from checked-in monitoring config, the bootstrap helper runs the training DAG with the serving-alias path so the API comes up healthy on a real registry version, and it verifies that Grafana loaded its starter resources before reporting success. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
+The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. The same local stack now includes Prometheus, a StatsD exporter, and Grafana from checked-in monitoring config, Airflow uses a bundled Postgres metadata database instead of a host-mounted SQLite file, the bootstrap helper waits for the feature DAG to publish a training-request asset and for the resulting asset-triggered training run to finish on a real registry version, and it verifies that Grafana loaded its starter resources before reporting success. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
 The optional `development_env` notebook container stays off by default and only starts when you explicitly target the notebook or dev-shell Makefile commands.
 
-Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl`, so the monitoring layer can compare recent model outputs against earlier outputs from the same model version without mixing runtime state into `data/`.
+## Surface Roles
 
-Feature-pipeline dashboard panels are driven from the latest summary JSON under `airflow/reports/`. The app republishes that summary through `/metrics`, so Prometheus and Grafana read the same persisted run summary that the bootstrap path produces.
+| Surface | Use it for | Do not treat it as |
+|------|------------|--------------------|
+| Streamlit demo and prediction responses | rider-facing evaluation and public-safe screenshots | an operator dashboard |
+| FastAPI routes such as `/predict`, `/rank`, and `/features/online` | service integration, smoke checks, and demo calls | a documentation publishing surface |
+| `/metrics`, Prometheus, Grafana, Airflow, and MLflow | operator validation, monitoring, and debugging | the product UI or a public embed target |
+| Docs pages and rendered evidence | public-safe explanation and review material | a live runtime control plane |
 
-The bootstrap reset also removes the local Airflow metadata database and logs, so the UI reflects the current DAG boundary instead of older task graphs from previous local runs.
+Prediction requests also append flattened local inference rows to `.state/monitoring/prediction-log.jsonl` as a bounded working set and to `.state/monitoring/prediction-events.jsonl` as the retained history contract. That keeps restart-sensitive runtime counters separate from the retained monitoring history and keeps both out of `data/`.
+
+Feature-pipeline dashboard panels are driven from the latest summary JSON under `airflow/reports/`. The app republishes that summary through `/metrics`, so Prometheus and Grafana read the same persisted run summary that the bootstrap path produces. The Airflow Assets view also shows the current local hand-off graph: curated feature rows, Feast synchronization, the training request, the MLflow training run, the evaluation report, and the registry update.
+
+Grafana is present in the local stack so the bootstrap can verify provisioning and so operators can inspect metrics and alert rules. It is not the primary rider-facing interface, and the docs site should prefer screenshots or rendered artifacts over live Grafana embeds.
+
+The bootstrap reset also removes stale local Airflow metadata files and logs, and the bootstrap verifies the Airflow health payload itself instead of treating a `200 OK` response from `/api/v2/monitor/health` as sufficient.
 
 After bootstrap completes, the main local endpoints are:
 
@@ -31,6 +42,8 @@ After bootstrap completes, the main local endpoints are:
 - Grafana: `http://127.0.0.1:3000`
 - Objectstore UI: printed by the bootstrap helper when the stack comes up
 - Feast online store emulator: printed by the bootstrap helper when the stack comes up
+
+The app and app-metrics routes are service surfaces. Airflow, MLflow, Prometheus, and Grafana are operator surfaces in this local evaluator path.
 
 Example check:
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -2,6 +2,8 @@
 
 FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live weather forecasts, engineered wind features, drive-time information, and a trained quality model. Use the repository README for the short summary. Use this site for setup help, system notes, and operator guidance.
 
+This site keeps rider-facing demo surfaces, service APIs, operator dashboards, and public-safe rendered evidence separate on purpose. Grafana belongs to the operator layer here. It is not the primary product UI and the public docs do not depend on live private dashboard embeds.
+
 ## Start Here
 
 | Need | Read this |
@@ -21,6 +23,17 @@ FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live
 | GitHub automation | Repository maintainer or fork owner | Image publishing, Terraform workflows, and docs publishing |
 
 Public images are convenience artifacts, not a shared hosting promise. If you want a running online environment, deploy it in infrastructure you control.
+
+## Surface Guide
+
+| Surface | Primary audience | Exposure | Current examples |
+|------|------------------|----------|------------------|
+| Rider-facing demo surfaces | rider, reviewer, contributor | public-safe when shown as screenshots or rendered outputs | Streamlit demo, ranking examples, and the online-features demo page |
+| Service APIs | clients, smoke tests, support services | service-only | `/health`, `/spots`, `/predict`, `/rank`, `/features/online`, and `/metrics` |
+| Operator dashboards and control planes | maintainer or deployment operator | internal-only by default | Airflow, MLflow, Prometheus, and Grafana |
+| Public-safe docs and evidence | reviewer, course audience, fork reader | public-safe | docs pages, rendered evaluation markdown, summary JSON-derived charts, and screenshots |
+
+Use the rider demo or API examples to explain the product surface. Use rendered artifacts or screenshots to explain operations in public docs. Keep live operator dashboards private unless you are intentionally running your own environment.
 
 ## System In One View
 

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -6,6 +6,7 @@ FoehnCast keeps the same Feature-Training-Inference split in every runtime mode.
 
     The validated baseline is the local Compose stack.
     The hosted paths use the same feature, training, and inference modules, but move storage, auth, and runtime services onto GCP in different ways.
+    The rider-facing demo and prediction outputs are not the same thing as operator dashboards, and Grafana is not treated as the main product UI.
 
 ## System In One View
 
@@ -41,6 +42,17 @@ flowchart LR
     FEAST --> API
 </div>
 
+## Surface Boundaries
+
+| Surface class | Primary audience | Exposure | Current examples |
+|------|------------------|----------|------------------|
+| Rider-facing demo surface | rider, reviewer, contributor | public-safe when shown as screenshots or rendered examples | Streamlit rider console and the online-features demo page |
+| Service endpoints | clients, smoke tests, support services | service-only | `/health`, `/spots`, `/predict`, `/rank`, `/features/online`, and `/metrics` |
+| Operator dashboards and control planes | maintainer or deployment operator | internal-only by default | Airflow, MLflow, Prometheus, and Grafana |
+| Public docs and rendered evidence | course reviewer, fork reader, maintainer | public-safe | docs pages, evaluation markdown, summary JSON-derived charts, and screenshots |
+
+Grafana stays on the operator side of that boundary. The rider-facing experience is the ranking and demo surface served from the application layer. Public docs should therefore show rendered evidence or screenshots rather than live iframe embeds of private operational dashboards.
+
 ## Stable Pipeline Boundaries
 
 | Layer | Responsibility | Current runtime surface |
@@ -48,8 +60,10 @@ flowchart LR
 | Feature pipeline | Collect data, engineer curated rows, validate them, and store the result | local Airflow DAG plus the configured storage backend |
 | Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
 | Inference pipeline | Serve health, predict, rank, and spot-list responses | FastAPI app container |
-| Online features | Surface curated fields through an online lookup route | Feast-backed path plus demo page |
-| Monitoring | Scrape runtime metrics, collect pushed gauges, and visualize starter alerts | Prometheus, StatsD exporter, and Grafana |
+| Online features | Surface curated fields through an online lookup route | Feast-backed service path plus demo page |
+| Monitoring | Scrape runtime metrics, collect pushed gauges, and visualize starter alerts | Prometheus, StatsD exporter, and Grafana operator stack |
+
+The orchestration layer now models the main data products as Airflow assets instead of only sequencing opaque tasks. In the validated local stack, the feature DAG publishes curated-feature, Feast-sync, and training-request assets, and the training DAG consumes the training request and emits MLflow training, evaluation, and registry assets.
 
 ## Deployment Targets
 
@@ -68,7 +82,7 @@ flowchart LR
 | Hosted inference target | FastAPI only, backed by shared GCP services | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | publish the inference API as a smaller hosted surface |
 | GitHub automation | image publishing and Terraform workflows | runtime services | repeatable delivery, not a runtime target |
 
-The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. The hosted full-stack target exposes only the app on port `8000` by default. Airflow and MLflow stay private unless you open their ports on purpose.
+The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. The hosted full-stack target exposes only the app on port `8000` by default. Airflow, MLflow, Prometheus, and Grafana stay private unless you open them on purpose for your own operator workflow.
 
 ## Current Local Architecture
 
@@ -88,6 +102,8 @@ flowchart TD
     FEAST --> APP
     APP --> MON[Prometheus + StatsD exporter + Grafana]
 </div>
+
+The Airflow control plane reflects those hand-offs directly. The feature pipeline owns the curated-row and Feast-sync publication steps, then emits a training-request asset. The training pipeline is scheduled from that asset rather than a direct DAG-to-DAG trigger, so the Assets view shows the real dependency graph between feature persistence, Feast serving preparation, model training, evaluation, and registration.
 
 ## Hosted Runtime Detail
 
@@ -125,7 +141,7 @@ The hosted targets reuse the same application boundaries, but they deploy differ
 | Check | What it shows |
 |-------|---------------|
 | feature DAG run through Airflow | the feature path executes inside the orchestration layer |
-| training DAG run through Airflow | the training path executes inside the orchestration layer |
+| asset-triggered training DAG run through Airflow | the training path starts from the published training-request asset and executes inside the orchestration layer |
 | API health and prediction routes | the app serves a real model-backed inference surface |
 | Feast serving path | the curated features are surfaced through the required online-serving layer without changing the base pipeline split |
 | container-side test suite | the local runtime remains reproducible after stack setup |
@@ -143,6 +159,7 @@ The hosted targets reuse the same application boundaries, but they deploy differ
 - The local default uses MinIO-backed object storage for curated features and MLflow artifacts, plus local Feast parquet and a Datastore-mode emulator for online serving.
 - The local stack mirrors the hosted object-access layer as closely as possible without pretending BigQuery and Datastore are themselves object storage.
 - In the cloud, raw landing fits object storage, while curated features fit native BigQuery tables.
+- Retained prediction-event history is a monitoring fact store, not a rider-facing page or a substitute for live dashboards.
 - Feast stays attached to the curated layer rather than becoming the primary ingestion or archive system.
 
 See [Use Case and Data](use-case.md) for the rider-focused problem framing and [Cloud Mapping](cloud-mapping.md) for the hosted path details.

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -40,6 +40,17 @@ FoehnCast has two hosted targets: a hosted full-stack target on one GCP host and
 - Hosted deployment keeps development-only assets, notebooks, docs build tooling, and local emulators out of the runtime surface.
 - The app remains a deployable container because inference is a service, not a DAG.
 
+## Surface Exposure In Cloud
+
+| Surface | Intended audience | Default exposure |
+|------|-------------------|------------------|
+| FastAPI app routes | riders, service clients, smoke tests | exposed by the active hosted app target |
+| `/metrics` and scrape targets | Prometheus and operators | service-only |
+| Airflow, MLflow, Prometheus, and Grafana | operators | private by default |
+| Public docs and review artifacts | reviewer, course audience, fork reader | public-safe when rendered from snapshots, markdown, or screenshots |
+
+This boundary matters because the hosted app is the product and service surface. Grafana remains an operator dashboard, and public docs should prefer rendered evidence over live embeds of private hosted tools.
+
 ## Current Hosted Topology
 
 <div class="mermaid">
@@ -64,7 +75,7 @@ flowchart LR
 | GitHub delivery | image publishing and remote Terraform runs | runtime services | implemented and bootstrapped for the shared environment |
 | BigQuery backend support | support for a BigQuery storage backend in the app | none | available in both local and hosted runtimes |
 
-The hosted paths deploy runtime services only. Development assets stay local or CI-only.
+The hosted paths deploy runtime services only. Development assets stay local or CI-only. The hosted full-stack target keeps Airflow, MLflow, Prometheus, and Grafana on the operator side unless you intentionally publish them yourself.
 
 The shared environment uses the hosted full-stack target because it keeps Airflow, MLflow, and the API together. The Cloud Run path stays available as a smaller API-only option.
 
@@ -143,7 +154,7 @@ In practice, GCS stores raw landing data and registry-style metadata for the clo
 | Artifacts | MinIO-backed MLflow artifact path | GCS bucket |
 | Auth | local `.env` plus developer credentials | runtime service accounts and GitHub OIDC |
 | Image source | local builds | GHCR runtime images or Artifact Registry app image |
-| Public exposure | local ports on the developer machine | the hosted full-stack target exposes only the app by default; Cloud Run exposes only the inference service |
+| Public exposure | local ports on the developer machine | the hosted full-stack target exposes only the app by default; Cloud Run exposes only the inference service; operator dashboards stay private unless you deliberately publish them |
 
 ## What Is Already In Place
 

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -29,13 +29,13 @@ docs/
 - `scripts/`: local bootstrap, cloud bootstrap, remote Terraform, and helper scripts.
 - `terraform/`: hosted infrastructure definition plus operator-facing notes.
 - `feature_repo/`: the Feast integration repo and configuration surface.
-- `prometheus_config/` and `grafana_work/`: the checked-in monitoring stack configuration for Prometheus and Grafana.
+- `prometheus_config/` and `grafana_work/`: the checked-in operator-monitoring configuration for Prometheus and Grafana, not a separate product UI.
 - `tests/`: regression coverage for the core pipeline logic and API behavior.
 - `docs/`: the public documentation site and system notes.
 
 One local workload data root lives under `data/`, while local runtime state stays separate. For example, curated feature rows and Feast offline parquet belong under `data/`, but local Feast registry, rendered runtime config, and inference prediction logs belong under `.state/` instead of mixing service state into the workload dataset tree.
 
-Airflow also writes operator-facing artifacts under `airflow/reports/`. That directory now includes the latest feature-pipeline run summary JSON and evaluation markdown outputs, and the local app mounts it so Prometheus and Grafana can expose the latest feature-pipeline monitoring panels.
+Airflow also writes operator-facing artifacts under `airflow/reports/`. That directory now includes the latest feature-pipeline run summary JSON and evaluation markdown outputs, and the local app mounts it so Prometheus and Grafana can expose the latest feature-pipeline monitoring panels. When those artifacts appear in public docs, prefer rendered markdown excerpts, static charts, or screenshots over live embeds of private operator tools.
 
 ## Why The Layout Matters
 
@@ -45,7 +45,7 @@ Central configuration lives in `config.yaml` and `src/foehncast/config.py`, so t
 
 Feature engineering starts in `feature_pipeline/engineer.py`, where raw weather inputs are turned into the engineered feature vector shared by training and inference.
 
-There is currently no separate product UI package in the repository. The optional interactive demo surface that does exist lives inside the inference pipeline, for example `src/foehncast/inference_pipeline/demo.py`, rather than in a separate top-level app tree.
+There is currently no separate product UI package in the repository. The optional interactive demo surface that does exist lives inside the inference pipeline, for example `src/foehncast/inference_pipeline/demo.py`, rather than in a separate top-level app tree. Grafana does not fill that role; it remains an operator dashboard surface.
 
 ## Configuration Ownership
 
@@ -54,7 +54,8 @@ There is currently no separate product UI package in the repository. The optiona
 - `terraform/terraform.tfvars`: infrastructure desired state such as regions, buckets, service names, machine shape, and deployment toggles.
 - `feature_repo/feature_store*.yaml`: checked-in Feast reference configs that stay separate from the base application config.
 - `.state/feast/feature_store.runtime.yaml`: the rendered runtime Feast binding generated from environment and used by the app and host-side Feast CLI commands.
-- `.state/monitoring/prediction-log.jsonl`: the local inference monitoring log used to compare current model outputs against earlier outputs from the same model version.
+- `.state/monitoring/prediction-log.jsonl`: the bounded local inference-monitoring working set used for request-side drift checks.
+- `.state/monitoring/prediction-events.jsonl`: the retained local prediction-event history contract used by monitoring readers and promotable to shared storage through environment wiring.
 - `airflow/reports/feature-pipeline-*-latest.json`: the persisted feature-pipeline summary files that the local monitoring path republishes through the app `/metrics` endpoint.
 
 The supported curated-storage backends are intentionally narrow: `s3` for the local MinIO-backed baseline and `bigquery` for the hosted analytical surface. The older file-backed curated-store compatibility path is no longer part of the runtime contract.


### PR DESCRIPTION
### What Changed
- Clarify the boundary between rider-facing demo surfaces, service APIs, operator dashboards, and public-safe rendered evidence.
- Update the local and hosted architecture docs so Grafana stays explicitly on the operator side.
- Align the public docs wording with the current Airflow asset flow, retained monitoring history, and deployable-safe dashboard defaults.

### Why
- Keep the public docs accurate without implying that private operator dashboards are the main product UI or a public embed target.

### Verification
- uv run mkdocs build --strict -f docs/mkdocs.yml

### Closes
- Closes #153