### PR TITLE
docs(site): regroup navigation

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -48,16 +48,19 @@ plugins:
 
 nav:
   - Home: index.md
-  - Getting Started: getting-started.md
-  - System:
+  - Overview:
+      - Getting Started: getting-started.md
+      - Use Case and Data: system/use-case.md
+      - Repository: system/repository.md
+  - Runtime and Deployment:
       - Architecture: system/architecture.md
       - Local Evaluator: system/local-evaluator.md
       - Hosted Full-Stack: system/hosted-full-stack.md
+      - Cloud Mapping: system/cloud-mapping.md
+  - Pipelines and Modeling:
       - Feature Pipeline: system/feature-pipeline.md
       - Training Pipeline: system/training-pipeline.md
       - Inference Pipeline: system/inference-pipeline.md
-      - Monitoring: system/monitoring.md
-      - Cloud Mapping: system/cloud-mapping.md
-      - Repository: system/repository.md
-      - Use Case and Data: system/use-case.md
       - Seasonality: system/seasonality.md
+  - Operations:
+      - Monitoring: system/monitoring.md

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -77,13 +77,25 @@ Hosted deployment keeps the runtime scope tight. The cloud targets deploy runtim
 
 ## Read Next
 
+### Overview
+
+- [Use Case and Data](system/use-case.md)
+- [Repository](system/repository.md)
+
+### Runtime and Deployment
+
 - [Architecture](system/architecture.md)
 - [Local Evaluator](system/local-evaluator.md)
 - [Hosted Full-Stack](system/hosted-full-stack.md)
+- [Cloud Mapping](system/cloud-mapping.md)
+
+### Pipelines and Modeling
+
 - [Feature Pipeline](system/feature-pipeline.md)
 - [Training Pipeline](system/training-pipeline.md)
 - [Inference Pipeline](system/inference-pipeline.md)
+- [Seasonality](system/seasonality.md)
+
+### Operations
+
 - [Monitoring](system/monitoring.md)
-- [Cloud Mapping](system/cloud-mapping.md)
-- [Repository](system/repository.md)
-- [Use Case and Data](system/use-case.md)

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -1,6 +1,6 @@
 # FoehnCast Docs
 
-FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live weather forecasts, engineered wind features, drive-time information, and a trained quality model. Use the repository README for the short summary. Use this site for setup help, system notes, and operator guidance.
+FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live weather forecasts, engineered wind features, drive-time information, and a trained quality model. Use the repository README for the short summary. Use this site for setup help, product scope, runtime notes, and operator guidance.
 
 This site keeps rider-facing demo surfaces, service APIs, operator dashboards, and public-safe rendered evidence separate on purpose. Grafana belongs to the operator layer here. It is not the primary product UI and the public docs do not depend on live private dashboard embeds.
 
@@ -65,9 +65,26 @@ flowchart LR
 
 ## Documentation Map
 
-- [Getting Started](getting-started.md): choose the right operator path and run the first commands.
-- [Architecture](system/architecture.md): the stable Feature-Training-Inference split and runtime surfaces.
-- [Feature Pipeline](system/feature-pipeline.md): how data moves from forecast ingestion to curated features.
-- [Cloud Mapping](system/cloud-mapping.md): how local boundaries map onto hosted storage and runtime choices.
-- [Repository](system/repository.md): where the code, orchestration, tests, docs, and demo live.
+### Overview
+
+- [Getting Started](getting-started.md): choose the right setup path and run the first commands.
 - [Use Case and Data](system/use-case.md): the rider profile, spot set, and data sources behind the ranking.
+- [Repository](system/repository.md): where the code, orchestration, tests, docs, and demo live.
+
+### Runtime and Deployment
+
+- [Architecture](system/architecture.md): the stable Feature-Training-Inference split and runtime surfaces.
+- [Local Evaluator](system/local-evaluator.md): the default local runtime contract for contributors.
+- [Hosted Full-Stack](system/hosted-full-stack.md): the active shared hosted runtime target and sync contract.
+- [Cloud Mapping](system/cloud-mapping.md): how local boundaries map onto hosted storage and runtime choices.
+
+### Pipelines and Modeling
+
+- [Feature Pipeline](system/feature-pipeline.md): how data moves from forecast ingestion to curated features.
+- [Training Pipeline](system/training-pipeline.md): how labeled data becomes a registered serving model.
+- [Inference Pipeline](system/inference-pipeline.md): how prediction, ranking, and online feature lookup are served.
+- [Seasonality](system/seasonality.md): how cyclical time features capture recurring daily and yearly structure.
+
+### Operations
+
+- [Monitoring](system/monitoring.md): how Prometheus, Grafana, alerts, and runtime evidence stay on the operator side.

--- a/docs/site/stylesheets/extra.css
+++ b/docs/site/stylesheets/extra.css
@@ -66,3 +66,7 @@
     height: auto;
     max-width: 100%;
 }
+
+.md-sidebar--primary .md-nav--primary > .md-nav__list > .md-nav__item + .md-nav__item {
+    margin-top: 0.45rem;
+}


### PR DESCRIPTION
## What changed
- regroup the public docs navigation into reader-facing sections for overview, runtime and deployment, pipelines and modeling, and operations
- add modest spacing between primary navigation blocks in the sidebar
- align the landing-page documentation map and the Getting Started `Read Next` section with the new site structure

## Why
- the docs site had become harder to scan because nearly every page sat under one `System` block even when the pages covered product scope, repository reference, or operator concerns
- this keeps the information architecture clearer without changing file paths or widening the slice into a content rewrite

## Verification
- `uv run python -c "from pathlib import Path; import yaml; data=yaml.safe_load(Path('docs/mkdocs.yml').read_text()); print([list(item.keys())[0] if isinstance(item, dict) else item for item in data['nav']])"`
- `uv run mkdocs build -f docs/mkdocs.yml --site-dir /tmp/foehncast-docs-180`
- `pre-commit run --files docs/mkdocs.yml docs/site/stylesheets/extra.css docs/site/index.md docs/site/getting-started.md`

Closes #180