### PR TITLE
docs: simplify public runtime docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,16 +30,30 @@ flowchart LR
 | Automation | Working | GitHub Actions publishes images, validates infrastructure, and drives remote Terraform workflows |
 | Monitoring | Working | Docker Compose runs Prometheus, a StatsD exporter, and Grafana; the app exposes `/metrics`; feature panels are derived from persisted Airflow report summaries; and Grafana loads starter dashboards and alert rules from checked-in config |
 
-## Default Setup
+## Setup Paths
 
-FoehnCast has one supported contributor setup path: run everything locally with Docker.
+FoehnCast has one supported contributor setup path: run everything locally with Docker. The shared cloud path is a separate maintainer workflow.
 
 ```mermaid
 flowchart TB
-    Local[Local setup] --> Compose[Airflow + MLflow + FastAPI]
-  Main[Push to main] --> Cloud[GitHub-managed shared cloud automation]
-  Cloud --> Host[Hosted full-stack target today]
-  Cloud -. optional .-> Run[Inference-only Cloud Run target]
+  subgraph Contributor[Contributor path]
+    Clone[Clone repo]
+    Local[./scripts/bootstrap-local.sh]
+    Compose[Local evaluator stack]
+  end
+
+  subgraph Maintainer[Maintainer path]
+    Shell[Google Cloud Shell]
+    Bootstrap[./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions]
+    Cloud[GitHub Actions + remote Terraform]
+    Host[Hosted full-stack target today]
+    Run[Inference-only Cloud Run target]
+  end
+
+  Clone --> Local --> Compose
+  Shell --> Bootstrap --> Cloud
+  Cloud --> Host
+  Cloud -. optional .-> Run
 ```
 
 ## Quick Start
@@ -72,6 +86,8 @@ After bootstrap completes, the main local endpoints are:
 
 The bootstrap summary also prints the resolved objectstore and Feast online-store emulator endpoints.
 
+If you maintain the shared cloud environment, use the separate workflow in [docs/site/system/delivery-and-operator-workflow.md](docs/site/system/delivery-and-operator-workflow.md). Contributors do not need that path for normal work.
+
 Feature-pipeline Grafana panels are backed by the latest summary JSON written under `airflow/reports/`. The app mounts that directory and republishes the summary as Prometheus metrics through `/metrics`, so local dashboard plots and Prometheus queries follow the same contract. The bootstrap also validates the Airflow health payload itself, not just the HTTP status code returned by the webserver.
 The pipeline summary writers also keep timestamped history copies under `airflow/reports/history/`, so operator review does not depend on a single mutable latest-summary file.
 
@@ -99,12 +115,13 @@ For the rider-facing demo, run `uv run streamlit run ui/app.py` from the repo ro
 The shared hosted environment is not part of normal contributor setup.
 
 - Contributors only need Docker and the local bootstrap path.
-- The shared cloud environment is maintained through GitHub Actions after a one-time maintainer bootstrap.
+- Maintainers start in Google Cloud Shell and run `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions` once.
+- After bootstrap, GitHub Actions owns the normal remote Terraform plan, apply, destroy, and cleanup flow for the shared environment.
 - Contributors do not need local Terraform, `gcloud`, or `gh` for normal work.
 
 The current shared environment uses the hosted full-stack target so Airflow, MLflow, and the API stay online together. The Cloud Run path is still available as an inference-only option, but it is not the active shared deployment target today.
 
-Maintainer-only cloud bootstrap and operator details live in `terraform/README.md`.
+Start with [docs/site/system/delivery-and-operator-workflow.md](docs/site/system/delivery-and-operator-workflow.md) for the maintainer workflow split and use `terraform/README.md` for operator detail.
 
 Hosted deployment keeps a narrow scope. The cloud targets deploy runtime services only. `development_env`, notebooks, docs build tooling, the local objectstore, and the local Datastore emulator stay local or CI-only.
 
@@ -125,6 +142,7 @@ Hosted deployment keeps a narrow scope. The cloud targets deploy runtime service
 - Docs home: <https://javihslu.github.io/foehncast/>
 - Getting started: <https://javihslu.github.io/foehncast/getting-started/>
 - Architecture: <https://javihslu.github.io/foehncast/system/architecture/>
+- Delivery and operator workflow: <https://javihslu.github.io/foehncast/system/delivery-and-operator-workflow/>
 - Cloud mapping: <https://javihslu.github.io/foehncast/system/cloud-mapping/>
 - Feature pipeline: <https://javihslu.github.io/foehncast/system/feature-pipeline/>
 - Terraform operator detail: `terraform/README.md`

--- a/containers/README.md
+++ b/containers/README.md
@@ -1,6 +1,6 @@
 # Container Components
 
-This directory holds the service definitions used by the validated local stack and reused by the online compose-host path.
+This directory holds the service definitions used by the validated local stack and reused by the online compose-host path. The default contributor entrypoint is still `./scripts/bootstrap-local.sh`. This README explains the container surfaces behind that local path and the hosted compose-host target. It is not a separate onboarding guide.
 
 ## Container Stack In One View
 
@@ -90,6 +90,8 @@ For the shortest evaluator path, run `./scripts/bootstrap-local.sh` from the rep
 
 This path is intentionally GCP-free. You do not need `gcloud`, Terraform, GitHub Actions variables, or Cloud Shell to run it.
 
+If you maintain the shared cloud environment, start with [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/system/delivery-and-operator-workflow.md) for the operator flow, then use [../terraform/README.md](../terraform/README.md) for the platform detail.
+
 The default local path uses the bundled MinIO service for curated feature storage and MLflow artifacts, starts Airflow and MLflow without a login, prepares Feast against the bundled Datastore-mode emulator, and resets Docker volumes plus disposable local runtime artifacts for a clean run each time. The helper keeps the container-side endpoints on `objectstore:9000` and `feast-online-store:8080`, and can shift the host-exposed ports when the preferred defaults are already occupied.
 The optional `development_env` container now stays off unless you explicitly target it through the dedicated Makefile notebook and dev-shell commands.
 The app image itself is Feast-capable, and the local bootstrap prepares Feast state, verifies the online-feature route, and confirms that Grafana loaded the checked-in dashboard and alerting resources before declaring the stack ready.
@@ -109,7 +111,7 @@ Run these checks before deployment work:
 
 ## Hosted Reuse
 
-The online compose-host path reuses the same service layout, but changes the runtime context:
+The online compose-host path is maintainer-owned and reuses the same service layout, but changes the runtime context:
 
 - the host writes `.env` from Terraform-managed values
 - `development_env`, MinIO, and the Feast emulator do not deploy to the hosted paths
@@ -117,6 +119,8 @@ The online compose-host path reuses the same service layout, but changes the run
 - Airflow and MLflow remain private unless their ports are deliberately opened
 - MLflow artifacts point at the shared GCS bucket instead of the local artifact volume
 - runtime images can be pulled from GHCR or built locally on the host if needed
+
+That hosted path follows the one-time `bootstrap-gcp` plus GitHub Actions workflow described in [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/system/delivery-and-operator-workflow.md).
 
 ## Build Targets
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -59,6 +59,7 @@ nav:
       - Local Evaluator: system/local-evaluator.md
       - Hosted Full-Stack: system/hosted-full-stack.md
       - Cloud Mapping: system/cloud-mapping.md
+      - Delivery and Operator Workflow: system/delivery-and-operator-workflow.md
   - Pipelines and Modeling:
       - Feature Pipeline: system/feature-pipeline.md
       - Training Pipeline: system/training-pipeline.md

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -1,6 +1,6 @@
 # Getting Started
 
-This page keeps setup intentionally simple. The supported contributor path is the local evaluator flow with Docker.
+This page keeps setup intentionally simple. The supported contributor path is the local evaluator flow with Docker. The shared cloud path is maintainer-only and documented separately.
 
 ## Local Evaluator
 
@@ -14,6 +14,8 @@ You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compil
 
 The local evaluator path uses the bundled MinIO surface as the default object-access layer for curated feature persistence and MLflow artifacts, while Feast uses the bundled Datastore-mode emulator as the required online-serving layer on top of the curated contract. The same local stack now includes Prometheus, a StatsD exporter, and Grafana from checked-in monitoring config, Airflow uses a bundled Postgres metadata database instead of a host-mounted SQLite file, the bootstrap helper waits for the feature DAG to publish a training-request asset and for the resulting asset-triggered training run to finish on a real registry version, and it verifies that Grafana loaded its starter resources before reporting success. If the preferred local host ports are already occupied, the bootstrap helper moves the bindings to the next free ports and prints the chosen endpoints.
 The optional `development_env` notebook container stays off by default and only starts when you explicitly target the notebook or dev-shell Makefile commands.
+
+If you maintain the shared cloud environment, use [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md). Contributors do not need the cloud path for normal work.
 
 ## Surface Roles
 
@@ -59,9 +61,11 @@ The shared hosted environment is maintained separately from normal contributor s
 
 - Contributors only need Docker and the local evaluator bootstrap.
 - Contributors do not need local Terraform, `gcloud`, or `gh`.
-- Maintainers use a one-time Cloud Shell bootstrap and then let GitHub Actions own the shared cloud path.
+- Maintainers start in Google Cloud Shell and run `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions` once.
+- After bootstrap, GitHub Actions owns the normal shared cloud Terraform flow.
+- The current shared environment uses the hosted full-stack target, while the inference-only Cloud Run target remains an optional smaller hosted surface.
 
-See `terraform/README.md` only if you maintain the shared cloud environment.
+See [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md) for the maintainer path. Use `terraform/README.md` only if you maintain the shared cloud environment.
 
 Hosted deployment keeps the runtime scope tight. The cloud targets deploy runtime services only; `development_env`, notebooks, docs build tooling, the local objectstore, and the local Datastore emulator stay local or CI-only.
 
@@ -90,6 +94,7 @@ Hosted deployment keeps the runtime scope tight. The cloud targets deploy runtim
 - [Local Evaluator](system/local-evaluator.md)
 - [Hosted Full-Stack](system/hosted-full-stack.md)
 - [Cloud Mapping](system/cloud-mapping.md)
+- [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md)
 
 ### Pipelines and Modeling
 

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -2,6 +2,8 @@
 
 FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live weather forecasts, engineered wind features, drive-time information, and a trained quality model. Use the repository README for the short summary. Use this site for setup help, product scope, runtime notes, and operator guidance.
 
+The default contributor path stays local with Docker. The shared cloud path is maintainer-owned and documented separately.
+
 This site keeps rider-facing demo surfaces, service APIs, operator dashboards, and public-safe rendered evidence separate on purpose. Grafana belongs to the operator layer here. It is not the primary product UI and the public docs do not depend on live private dashboard embeds.
 
 ## Start Here
@@ -9,6 +11,7 @@ This site keeps rider-facing demo surfaces, service APIs, operator dashboards, a
 | Need | Read this |
 |------|-----------|
 | Run the project locally with the default evaluator workflow | [Getting Started](getting-started.md) |
+| Maintain the shared cloud environment or understand the setup split | [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md) |
 | Understand what stays in package config versus runtime wiring | [Configuration and Contracts](system/configuration-and-contracts.md) |
 | Understand which routes and tools are rider-facing, service-only, or operator-only | [Interfaces and Surfaces](system/interfaces-and-surfaces.md) |
 | Understand the Feature-Training-Inference split | [Architecture](system/architecture.md) |
@@ -21,8 +24,8 @@ This site keeps rider-facing demo surfaces, service APIs, operator dashboards, a
 | Mode | Who runs it | Purpose |
 |------|-------------|---------|
 | Local stack | Any reader or contributor | Development, evaluation, and reproducible validation |
-| Online stack | The operator of a fork or a personal cloud setup | Full hosted deployment of Airflow, MLflow, and the API |
-| GitHub automation | Repository maintainer or fork owner | Image publishing, Terraform workflows, and docs publishing |
+| Shared cloud environment | Repository maintainer or fork owner after one-time bootstrap | Full hosted deployment of Airflow, MLflow, and the API |
+| GitHub automation | Repository maintainer or fork owner after bootstrap | Image publishing, Terraform workflows, and docs publishing |
 
 Public images are convenience artifacts, not a shared hosting promise. If you want a running online environment, deploy it in infrastructure you control.
 
@@ -79,6 +82,7 @@ flowchart LR
 
 - [Architecture](system/architecture.md): the stable Feature-Training-Inference split and runtime surfaces.
 - [Local Evaluator](system/local-evaluator.md): the default local runtime contract for contributors.
+- [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md): the maintainer path for shared cloud bootstrap and day-2 delivery.
 - [Hosted Full-Stack](system/hosted-full-stack.md): the active shared hosted runtime target and sync contract.
 - [Cloud Mapping](system/cloud-mapping.md): how local boundaries map onto hosted storage and runtime choices.
 

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -5,6 +5,8 @@ FoehnCast keeps the same Feature-Training-Inference split in every runtime mode.
 !!! note "How to read this page"
 
     The validated baseline is the local Compose stack.
+    The active shared environment uses the hosted full-stack target.
+    The hosted inference target remains a smaller optional path.
     The hosted paths use the same feature, training, and inference modules, but move storage, auth, and runtime services onto GCP in different ways.
     The rider-facing demo and prediction outputs are not the same thing as operator dashboards, and Grafana is not treated as the main product UI.
 
@@ -73,18 +75,20 @@ The orchestration layer now models the main data products as Airflow assets inst
 flowchart LR
     CORE[Shared Feature-Training-Inference boundaries]
     CORE --> LOCAL[Local evaluator target]
-    CORE --> HOST[Hosted full-stack target]
-    CORE --> RUN[Hosted inference target]
+    CORE --> HOST[Hosted full-stack target today]
+    CORE -. optional .-> RUN[Hosted inference target]
 </div>
 
 | Target | Deploys | Leaves out | Primary use |
 |------|---------|------------|-------------|
 | Local evaluator target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, Grafana, MinIO, the Feast Datastore emulator, and optional `development_env` tooling | shared GCP baseline | default development and evaluation |
-| Hosted full-stack target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, and Grafana on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | keep the whole stack online |
-| Hosted inference target | FastAPI only, backed by shared GCP services | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | publish the inference API as a smaller hosted surface |
-| GitHub automation | image publishing and Terraform workflows | runtime services | repeatable delivery, not a runtime target |
+| Hosted full-stack target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, and Grafana on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | active shared environment |
+| Hosted inference target | FastAPI only, backed by shared GCP services | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | smaller API-only hosted surface |
+| GitHub automation | image publishing and Terraform workflows | runtime services | shared cloud day-2 delivery, not a runtime target |
 
 The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. The hosted full-stack target exposes only the app on port `8000` by default. Airflow, MLflow, Prometheus, and Grafana stay private unless you open them on purpose for your own operator workflow.
+
+The active shared environment uses the hosted full-stack target today. The hosted inference target stays available when only the API needs to be online.
 
 ## Current Local Architecture
 
@@ -111,7 +115,7 @@ The Airflow control plane reflects those hand-offs directly. The feature pipelin
 
 <div class="mermaid">
 flowchart LR
-    subgraph Host[Hosted full-stack target]
+    subgraph Host[Hosted full-stack target today]
         HAF[Airflow]
         HML[MLflow]
         HAPI[FastAPI]
@@ -126,7 +130,7 @@ flowchart LR
 
 <div class="mermaid">
 flowchart LR
-    subgraph Run[Hosted inference target]
+    subgraph Run[Hosted inference target optional]
         RAPI[FastAPI]
     end
     BQ2[(BigQuery curated features)] --> RAPI
@@ -136,7 +140,7 @@ flowchart LR
     OSRM2[OSRM] --> RAPI
 </div>
 
-The hosted targets reuse the same application boundaries, but they deploy different runtime surfaces. The cloud path does not ship the local development container, local objectstore, notebooks, docs build tooling, or the Datastore emulator.
+The hosted targets reuse the same application boundaries, but they deploy different runtime surfaces. The first diagram matches the active shared environment. The second remains the smaller optional API-only path. The cloud path does not ship the local development container, local objectstore, notebooks, docs build tooling, or the Datastore emulator.
 
 ## Representative Validation
 
@@ -164,4 +168,4 @@ The hosted targets reuse the same application boundaries, but they deploy differ
 - Retained prediction-event history is a monitoring fact store, not a rider-facing page or a substitute for live dashboards.
 - Feast stays attached to the curated layer rather than becoming the primary ingestion or archive system.
 
-See [Use Case and Data](use-case.md) for the rider-focused problem framing and [Cloud Mapping](cloud-mapping.md) for the hosted path details.
+See [Use Case and Data](use-case.md) for the rider-focused problem framing, [Cloud Mapping](cloud-mapping.md) for the hosted path details, and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the contributor and maintainer rollout split.

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -1,11 +1,10 @@
 # Cloud Mapping
 
-FoehnCast has two hosted targets: a hosted full-stack target on one GCP host and an inference-only Cloud Run target. This page explains how the validated local stack maps onto GCP without changing the core Feature-Training-Inference boundaries.
+FoehnCast has two hosted targets, but the active shared environment uses the hosted full-stack target on one GCP host. The inference-only Cloud Run target remains available as a smaller alternative. This page explains how the validated local stack maps onto GCP without changing the core Feature-Training-Inference boundaries.
 
 !!! note "What this page does and does not claim"
 
     The shared GCP baseline and the hosted entry points already exist.
-    Some longer-term managed services are still future work.
     The current shared environment uses the hosted full-stack target. The inference-only Cloud Run path exists, but it is not the active shared deployment path today.
 
 ## Cloud Paths In One View
@@ -18,15 +17,15 @@ FoehnCast has two hosted targets: a hosted full-stack target on one GCP host and
 </li>
 <li>
 <p><strong>Hosted full-stack target</strong></p>
-<p>A single Compute Engine host can run Airflow, MLflow, and the API from the same repository.</p>
+<p>A single Compute Engine host can run Airflow, MLflow, and the API from the same repository. This is the active shared deployment path today.</p>
 </li>
 <li>
 <p><strong>Hosted inference target</strong></p>
-<p>The FastAPI inference service can also run as an inference-only Cloud Run target.</p>
+<p>The FastAPI inference service can also run as an inference-only Cloud Run target when a smaller API-only surface is enough.</p>
 </li>
 <li>
-<p><strong>Managed direction</strong></p>
-<p>Future work can replace parts of the host-based path with more managed services.</p>
+<p><strong>Operator delivery</strong></p>
+<p>Maintainers bootstrap once, then GitHub Actions advances the shared cloud path.</p>
 </li>
 </ul>
 </div>
@@ -59,7 +58,7 @@ flowchart LR
     GCP --> HOST[Hosted full-stack target]
     GCP -. optional .-> RUN[Hosted inference target]
     TF --> GH[GitHub OIDC delivery]
-    HOST --> STACK[Airflow + MLflow + API]
+    HOST --> STACK[Airflow + MLflow + API + monitoring]
     RUN --> API[Inference API only]
     GH --> HOST
     GH -. app image publish .-> RUN
@@ -79,17 +78,28 @@ The hosted paths deploy runtime services only. Development assets stay local or 
 
 The shared environment uses the hosted full-stack target because it keeps Airflow, MLflow, and the API together. The Cloud Run path stays available as a smaller API-only option.
 
+## Active Shared Deployment Path
+
+The shared environment currently follows one hosted lane:
+
+- maintainers bootstrap once from Google Cloud Shell and seed the remote Terraform plus repository-variable contract
+- GitHub Actions remote Terraform applies handle day-2 infrastructure changes after bootstrap
+- one Compute Engine host keeps Airflow, MLflow, the API, and the monitoring stack online together
+- the inference-only Cloud Run target remains implemented, but it is not the main shared deployment target today
+
+This is why the shared environment docs keep centering the compose-host path even though the Cloud Run path is real and supported.
+
 ## Honest Mapping From Local To Cloud
 
-| Local component | Current hosted path | Longer-term managed direction |
-|----------------|---------------------|-------------------------------|
-| `app` container | hosted full-stack target or hosted inference target | keep inference as a deployable service |
-| Airflow containers | hosted full-stack target today | managed Airflow / Cloud Composer later |
-| MLflow local service | hosted full-stack target today with GCS-backed artifacts | possibly a separate hosted MLflow service later |
-| Local feature storage | BigQuery backend already available | BigQuery remains the cloud data target |
-| Local MLflow artifact volume | GCS artifact destination on the hosted compose path | GCS-backed artifacts stay the direction |
-| `development_env` container | local and CI only | not intended as a cloud runtime |
-| Feast serving path | sits on top of the same curated data | can point the feature view at BigQuery |
+| Local component | Current hosted path |
+|----------------|---------------------|
+| `app` container | hosted full-stack target today, or the hosted inference target when a smaller API-only surface is enough |
+| Airflow containers | hosted full-stack target today |
+| MLflow local service | hosted full-stack target today with GCS-backed artifacts |
+| Local feature storage | BigQuery backend already available |
+| Local MLflow artifact volume | GCS artifact destination on the hosted compose path |
+| `development_env` container | local and CI only |
+| Feast serving path | sits on top of the same curated data |
 
 ## Cloud Pipeline Shape
 
@@ -100,11 +110,15 @@ flowchart TD
     FEAT --> BQ[(BigQuery curated features)]
     BQ --> TRAIN[Training job]
     TRAIN --> MLF[(MLflow)]
-    MLF --> RUN[Hosted inference target]
+    MLF --> HOST[Hosted full-stack target today]
+    MLF -. optional smaller target .-> RUN[Hosted inference target]
+    OME --> HOST
     OME --> RUN
-    OSRM[OSRM] --> RUN
+    OSRM[OSRM] --> HOST
+    OSRM --> RUN
     BQ --> FEAST[Feast view]
-    FEAST --> RUN
+    FEAST --> HOST
+    FEAST -. optional .-> RUN
 </div>
 
 | Layer | Cloud direction |
@@ -112,7 +126,7 @@ flowchart TD
 | Raw landing | keep immutable API payloads in GCS when a landing layer is needed |
 | Feature pipeline | transform landed or live inputs and write curated rows to BigQuery |
 | Training pipeline | read curated rows, train, evaluate, and register through MLflow |
-| Inference pipeline | serve the API on the hosted full-stack target or through the inference-only Cloud Run target |
+| Inference pipeline | serve the API on the active hosted full-stack target, or optionally through the inference-only Cloud Run target for a smaller surface |
 | Feast serving path | point the same logical feature view at BigQuery instead of local parquet |
 
 ## Storage Layering In Cloud
@@ -154,7 +168,7 @@ In practice, GCS stores raw landing data and registry-style metadata for the clo
 | Artifacts | MinIO-backed MLflow artifact path | GCS bucket |
 | Auth | local `.env` plus developer credentials | runtime service accounts and GitHub OIDC |
 | Image source | local builds | GHCR runtime images or Artifact Registry app image |
-| Public exposure | local ports on the developer machine | the hosted full-stack target exposes only the app by default; Cloud Run exposes only the inference service; operator dashboards stay private unless you deliberately publish them |
+| Public exposure | local ports on the developer machine | the active shared environment uses the hosted full-stack target and exposes only the app by default; Cloud Run exposes only the inference service when used; operator dashboards stay private unless you deliberately publish them |
 
 ## What Is Already In Place
 
@@ -163,15 +177,15 @@ In practice, GCS stores raw landing data and registry-style metadata for the clo
 - The application already supports a `bigquery` storage backend through the shared feature-store abstraction.
 - Local container runs can already mount ADC for BigQuery-based checks.
 
-## Current Gaps
+## Current Tradeoffs
 
-- The current online path still keeps MLflow on the compose host rather than a separate managed service.
-- Airflow is still running on the host, not in a managed Composer-style service. The hosted compose path does keep the repo in sync, write the last successful refresh to the host, and show that timestamp in Prometheus and Grafana.
-- Monitoring is still lighter than the long-term target.
-- The two hosted paths solve different needs today: one keeps the full stack online, the other isolates inference as a service.
+- MLflow stays on the compose host in the active shared environment.
+- Airflow also stays on the compose host, while the sync timer, retained sync state, and monitoring stack make that host observable.
+- The two hosted paths solve different needs: one keeps the full stack online, the other narrows hosting to the API.
+- The monitoring stack stays intentionally small and reviewable through checked-in dashboards, alert rules, and scrape config.
 
 ## Why This Fits The Project Brief
 
 The goal is cloud-ready pipelines and cloud orchestration. This mapping keeps the validated backend design, but replaces the local support stack with cloud services that can run after deployment.
 
-See [Architecture](architecture.md) for the current runtime view. The repository root also includes a Terraform README with the deployment details.
+See [Architecture](architecture.md) for the current runtime view and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the maintainer path that bootstraps and advances these hosted targets. The repository root also includes a Terraform README with the deployment details.

--- a/docs/site/system/configuration-and-contracts.md
+++ b/docs/site/system/configuration-and-contracts.md
@@ -91,7 +91,7 @@ The checked-in `.env.example` shows the kind of values that belong in runtime wi
 | Monitoring history path | `FOEHNCAST_PREDICTION_EVENT_LOG_PATH` |
 | Feast runtime binding | `FOEHNCAST_FEAST_SOURCE`, `FOEHNCAST_FEAST_REPO_PATH`, `FOEHNCAST_FEAST_CONFIG_PATH`, `FOEHNCAST_FEAST_BIGQUERY_*`, `FOEHNCAST_FEAST_DATASTORE_*` |
 
-These values describe one concrete runtime instance. They should stay overridable because the local evaluator, hosted full-stack target, and hosted inference target do not all bind to the same services.
+These values describe one concrete runtime instance. They should stay overridable because the local evaluator, hosted full-stack target, and hosted inference target do not all bind to the same services. The maintainer rollout split for `terraform.tfvars` versus GitHub delivery variables is described in [Delivery and Operator Workflow](delivery-and-operator-workflow.md).
 
 ## Storage And Warehouse Contract
 
@@ -145,4 +145,4 @@ Those values belong in runtime env, Terraform inputs, or GitHub delivery variabl
 - Feast stays downstream from the curated feature contract instead of becoming a shadow settings system
 - operator state stays inspectable under `.state/` and `airflow/reports/` without pretending to be workload source data
 
-See [Repository](repository.md), [Feature Pipeline](feature-pipeline.md), [Inference Pipeline](inference-pipeline.md), [Local Evaluator](local-evaluator.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding runtime and deployment boundaries.
+See [Repository](repository.md), [Feature Pipeline](feature-pipeline.md), [Inference Pipeline](inference-pipeline.md), [Local Evaluator](local-evaluator.md), [Cloud Mapping](cloud-mapping.md), and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the surrounding runtime and deployment boundaries.

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -1,0 +1,137 @@
+# Delivery and Operator Workflow
+
+FoehnCast keeps contributor onboarding and shared-cloud delivery separate on purpose. Contributors use `./scripts/bootstrap-local.sh` to run the validated local evaluator. Maintainers use `./scripts/bootstrap-gcp.sh`, GitHub Actions, and Terraform to bootstrap and advance the shared hosted environment. This page records the current workflow contract validated by the bootstrap scripts, the Terraform reference, and the cloud-operator tests.
+
+!!! note "Scope"
+
+    This page describes the current validated delivery and operator workflow.
+    It is not a roadmap.
+    Future deployment changes should be documented after they are chosen and implemented.
+
+## Workflow In One View
+
+<div class="mermaid">
+flowchart LR
+    subgraph Local[Default contributor lane]
+        CLONE[Clone repo]
+        LOCAL[./scripts/bootstrap-local.sh]
+        LSTACK[Local evaluator stack]
+        LVERIFY[Feature and training hand-off plus Feast and monitoring checks]
+    end
+
+    subgraph Bootstrap[One-time maintainer bootstrap]
+        SHELL[Google Cloud Shell]
+        BGCP[./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions]
+        BACKEND[Remote Terraform backend]
+        VARS[GitHub repository variables]
+    end
+
+    subgraph Remote[Normal shared-cloud delivery]
+        PUSH[Push to main or manual workflow dispatch]
+        TFWF[.github/workflows/terraform.yml]
+        HOST[Hosted full-stack target]
+        RUN[Optional Cloud Run target]
+    end
+
+    CLONE --> LOCAL --> LSTACK --> LVERIFY
+    SHELL --> BGCP
+    BGCP --> BACKEND
+    BGCP --> VARS
+    PUSH --> TFWF
+    BACKEND --> TFWF
+    VARS --> TFWF
+    TFWF --> HOST
+    TFWF -. when enabled .-> RUN
+</div>
+
+The split matters because the local path is the supported public onboarding path, while the cloud path assumes GCP ownership, GitHub repository administration, and access to private operator surfaces.
+
+## Default Contributor Path
+
+The default contributor path stays local and small:
+
+1. Clone the repository.
+2. Install Docker.
+3. Run `./scripts/bootstrap-local.sh`.
+
+This path does not require local `gcloud`, Terraform, or GitHub Actions repository variables.
+
+The local bootstrap owns the full evaluator hand-off instead of stopping at container startup:
+
+- it creates `.env` from `.env.example` when needed
+- it resets Docker volumes, Airflow metadata, and disposable local runtime artifacts so each run starts clean
+- it starts the validated runtime subset without enabling the optional `development_env` container
+- it waits for Airflow component health checks and the Airflow API health payload
+- it verifies Grafana dashboard, alert-rule, contact-point, and policy provisioning before any pipeline run starts
+- it runs the `feature_pipeline` DAG for the selected date and waits for the asset-triggered `training_pipeline` run to succeed
+- it prepares local Feast state, verifies `/features/online`, and checks hosted-sync metrics on `/metrics`
+
+If the preferred local ports are already occupied, the bootstrap resolves alternate bindings and prints the final endpoints. See [Local Evaluator](local-evaluator.md) for the full local runtime contract.
+
+## One-Time Shared Cloud Bootstrap
+
+The cloud bootstrap is a maintainer workflow, not a second onboarding path. The preferred first-time environment is Google Cloud Shell. That keeps admin tools off the default evaluator machine and matches the supported no-local-install path.
+
+For the initial shared-cloud setup, run:
+
+`./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions`
+
+The script is interactive by design. It asks the operator to:
+
+- sign in with `gcloud`
+- choose an existing GCP project or create one
+- choose a billing account
+- confirm or edit the region, state bucket, Artifact Registry repository, BigQuery dataset, and BigQuery table
+- choose which hosted targets to enable
+- sync the GitHub repository variables that the shared cloud path uses later
+
+In `--bootstrap-only` mode, the script prepares the remote Terraform control plane and leaves the broader hosted apply to the remote workflow. It also writes `.env` and `terraform/terraform.tfvars` in the working tree so the local repository reflects the selected project and platform identifiers.
+
+When the script runs a normal apply instead of bootstrap-only mode, it also verifies the hosted runtime surfaces that Terraform exposed. The Cloud Run path checks `/health` and `/spots`. The hosted full-stack path checks `/health` and confirms the hosted sync metrics on `/metrics` when the compose host is enabled.
+
+## Day-2 Delivery Contract
+
+After the one-time bootstrap establishes OIDC, the remote backend, and the repository-variable contract, GitHub Actions becomes the primary operator surface for Terraform-managed changes.
+
+| Surface | Current role | Current contract |
+|------|---------------|------------------|
+| `.github/workflows/terraform.yml` | primary Terraform operator path | pushes to `main` automatically resolve to `apply` after bootstrap; manual dispatch stays available for `plan`, `destroy`, `cleanup`, and explicit overrides |
+| `scripts/configure-github-actions.sh` | repo-variable sync | Terraform outputs are copied into GitHub repository variables so the remote workflow reads one shared contract |
+| `terraform/terraform.tfvars` | bootstrap input | used during the interactive bootstrap path, not as the day-2 source of truth for remote applies |
+| runtime image workflows | app delivery follow-up | when Terraform has already provisioned `GCP_CLOUD_RUN_SERVICE`, publish automation updates the existing Cloud Run service with new images |
+| `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up | run this after a remote apply succeeds and curated BigQuery rows exist |
+
+This contract is deliberate. The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as container port, CPU, and memory stay repo-variable-backed instead of becoming more manual workflow inputs.
+
+## What The Cloud-Operator Tests Enforce
+
+The cloud-operator tests keep the delivery path honest in a few specific ways:
+
+- Terraform output names and GitHub repository variable names must stay in one shared mapping
+- the remote workflow must read the repository-backed contract instead of requiring operators to re-enter the same platform values on every run
+- pushes to `main` only become automatic remote applies after bootstrap has populated the required repository variables; before that, push runs explain the skip and manual runs fail fast
+- repository-variable resync after apply is best effort, so a GitHub token limitation does not invalidate a successful Terraform apply
+- destroy and cleanup remain explicit maintainer actions with project-id confirmation checks
+
+This is why the public docs can describe the shared-cloud path as reviewable and repeatable without pretending it is a casual contributor setup.
+
+## Delivery Boundaries That Stay Deliberate
+
+Several boundaries stay explicit across the scripts, Terraform reference, and tests:
+
+- the local Docker evaluator remains the only default contributor path
+- the shared cloud environment stays operator-owned, even though the repository and images are public
+- `terraform/terraform.tfvars` belongs to bootstrap and local preview work, while day-2 remote runs read GitHub repository variables
+- Grafana, Airflow, MLflow, and Prometheus remain operator surfaces rather than rider-facing product surfaces
+- public docs should explain those surfaces with rendered evidence and checked-in configuration, not live control-plane embeds
+
+The same split also keeps cloud retirement reviewable. Destroy and cleanup stay separate workflow commands, and cleanup only runs the specific follow-up actions that the operator selected.
+
+## Why This Workflow Works
+
+- it gives contributors one small supported setup path instead of parallel onboarding stories
+- it keeps the one-time cloud bootstrap explicit and interactive, which is safer for project, billing, and hosted-target choices
+- it moves normal day-2 infrastructure changes into GitHub Actions so operators do not need local Terraform for routine work
+- it keeps shared-cloud configuration reviewable because Terraform outputs, repository variables, and workflow behavior are tied together by regression tests
+
+See [Interfaces and Surfaces](interfaces-and-surfaces.md), [Hosted Full-Stack](hosted-full-stack.md), [Cloud Mapping](cloud-mapping.md), and [Monitoring](monitoring.md) for the surrounding runtime and exposure boundaries.

--- a/docs/site/system/feature-pipeline.md
+++ b/docs/site/system/feature-pipeline.md
@@ -1,6 +1,6 @@
 # Feature Pipeline
 
-FoehnCast keeps the feature pipeline as a clear set of boundaries. Forecast data is ingested, turned into curated features, checked against explicit bounds, stored through a backend abstraction, and then reshaped for Feast serving use without changing the meaning of the feature set.
+FoehnCast keeps the feature pipeline as a clear set of boundaries. The same curated feature contract drives the local evaluator and the hosted paths: forecast data is ingested, turned into curated features, checked against explicit bounds, stored through a backend abstraction, and then reshaped for Feast serving use without changing the meaning of the feature set.
 
 This page records the current design that has been validated in the local stack and in the review notebook. It focuses on what each stage owns today and what stays outside its scope.
 
@@ -33,6 +33,14 @@ The key point is that each stage has one clear job:
 - Feast preparation consumes curated rows instead of reimplementing the feature pipeline
 - Airflow publishes the downstream asset hand-offs after persistence and Feast preparation succeed
 
+## Runtime Role
+
+| Runtime mode | What the feature path does today |
+|------|-----------------------------|
+| Local evaluator | Airflow writes curated rows to the MinIO-backed baseline, exports local Feast parquet, and materializes the Datastore-mode emulator |
+| Active shared environment | the same DAG and curated contract write to BigQuery and keep Feast downstream through BigQuery, GCS, and Datastore |
+| Hosted inference target | consumes the curated layer through the app and Feast; it does not run the feature DAG itself |
+
 ## Stage Responsibilities
 
 | Stage | Main responsibility | Must not become |
@@ -58,7 +66,7 @@ The validated ingest assumptions are:
 
 For this project, raw weather features stay in source weather units, which currently means km/h for wind speed and gusts. That is separate from domain-facing rideability thresholds, which remain configured in knots and are converted at scoring time instead of changing the stored feature contract.
 
-If the project grows a more formal landing layer, ingest should still preserve the upstream payload faithfully instead of mixing raw capture with curated enrichment.
+Ingest keeps the upstream payload boundary explicit instead of mixing raw capture with curated enrichment.
 
 ## Curated Feature Boundary
 
@@ -71,9 +79,7 @@ The engineering layer creates the project's curated feature frame. The current f
 - raw columns remain available alongside engineered columns so downstream validation and storage operate on one complete curated frame
 - the datetime index and time basis are preserved so later storage and Feast preparation can add persistence and serving context without redefining the feature set
 
-The current training path is tree-based, so the design priority is feature representation quality rather than blanket feature scaling. Circular wind-direction encoding and the shift from ratio-heavy gustiness toward `gust_excess_10m` are part of that same representation choice, not a generic normalization layer.
-
-The engineering stage should also stay narrow. It creates the curated feature frame, but it should not add serving metadata or turn into a Feast-specific layer. That downstream hand-off remains intentional: engineer first, then validate, store, and only later project into Feast-friendly shapes.
+The current training path is tree-based, so feature representation quality matters more than blanket scaling. Circular wind-direction encoding and the shift toward `gust_excess_10m` follow that same choice. The engineering stage stays narrow: create curated rows first, then let validation, storage, and Feast-specific projection happen downstream.
 
 ## Validation Boundary
 

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -1,6 +1,6 @@
 # Hosted Full-Stack
 
-FoehnCast uses a hosted full-stack target for the current shared environment. This target keeps Airflow, MLflow, the FastAPI app, and the operator monitoring stack online from one Compute Engine host while reusing the shared GCP baseline for storage, identity, and image-delivery dependencies.
+FoehnCast uses the hosted full-stack target as the active shared deployment path. This target keeps Airflow, MLflow, the FastAPI app, and the operator monitoring stack online from one Compute Engine host while reusing the shared GCP baseline for storage, identity, and image-delivery dependencies.
 
 This page records the current hosted full-stack contract that is described by the cloud bootstrap, Terraform reference, and cloud-operator tests. It focuses on the active shared runtime target, not on future migrations.
 
@@ -25,7 +25,7 @@ flowchart LR
     HOST --> APP[FastAPI app]
     HOST --> AIR[Airflow]
     HOST --> MLF[MLflow]
-    HOST --> MON[Prometheus and Grafana]
+    HOST --> MON[Prometheus + StatsD exporter + Grafana]
     HOST --> SYNC[Repo sync timer]
     SYNC --> MET[/metrics sync status]
     MET --> MON
@@ -35,7 +35,7 @@ The important boundary is that the hosted full-stack target stays a runtime targ
 
 - the same repository owns the running Airflow, MLflow, app, and monitoring surfaces
 - the host depends on shared GCP storage and identity surfaces instead of local emulators
-- GitHub delivery updates the target after the initial maintainer bootstrap
+- GitHub Actions remote Terraform plus the host sync timer update the target after the one-time maintainer bootstrap
 - only the app is public by default, while operator tools stay private unless deliberately exposed
 
 ## Surface Responsibilities
@@ -45,10 +45,21 @@ The important boundary is that the hosted full-stack target stays a runtime targ
 | Shared GCP baseline | provide Artifact Registry, GCS, BigQuery, Datastore, and identity foundations | the application runtime itself |
 | Online compose host | keep the full runtime stack online from one VM | a contributor setup path or notebook host |
 | FastAPI app | serve the product and service routes | a hidden deployment control plane |
-| Airflow, MLflow, Prometheus, and Grafana | operator orchestration, tracking, monitoring, and review | the rider-facing interface |
+| Airflow, MLflow, Prometheus, StatsD exporter, and Grafana | operator orchestration, tracking, monitoring, and review | the rider-facing interface |
 | GitHub OIDC delivery | run remote Terraform and image-driven deploy updates | a substitute for the runtime host |
 
 This keeps the current shared environment honest. The runtime lives on the host, while Terraform and GitHub delivery keep the dependencies and rollout path reviewable.
+
+## Shared Environment Today
+
+The shared environment uses this target today:
+
+- one Compute Engine host runs Airflow, MLflow, the FastAPI app, Prometheus, the StatsD exporter, and Grafana together
+- maintainers bootstrap the shared GCP baseline and remote Terraform control plane once from Google Cloud Shell
+- GitHub Actions remote Terraform applies advance the shared environment after bootstrap
+- the inference-only Cloud Run target remains available, but it is not the main shared deployment target today
+
+That keeps the current deployment story concrete: the shared environment is the compose-host path, while Cloud Run stays the smaller optional API-only path.
 
 ## Runtime Contract
 
@@ -62,16 +73,17 @@ The hosted full-stack target currently relies on these shared runtime dependenci
 
 That service account is expected to cover BigQuery jobs, BigQuery Storage API read sessions, bucket object access for MLflow and Feast, and Datastore access. The goal is to let the hosted containers read the shared cloud surfaces directly without inventing a separate credential path.
 
-## Bootstrap And Delivery Boundary
+## Bootstrap And Day-2 Delivery
 
 The hosted full-stack target is not part of the default contributor path. Its lifecycle is split into two layers:
 
-- a maintainer bootstrap through `./scripts/bootstrap-gcp.sh` to create or reuse the shared GCP baseline and the optional online compose host target
+- a one-time maintainer bootstrap through `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions` from Google Cloud Shell
 - GitHub-managed day-2 delivery for remote Terraform runs and image-based updates after the shared environment is bootstrapped
 
 The current bootstrap and host contract is:
 
 - Terraform can provision the Compute Engine host, static IP, network, and cloud data surfaces
+- day-2 remote applies read synced GitHub repository variables instead of treating `terraform.tfvars` as the ongoing source of truth
 - the host clones the repository, writes a runtime `.env`, and tries to pull the published images
 - if those images are not available yet, the host can build them locally as a fallback
 - bootstrap prints the host, app, Airflow, and MLflow URLs when those outputs exist
@@ -123,9 +135,9 @@ The hosted target also does not replace the separate Cloud Run path. The inferen
 
 ## Why This Target Works
 
-- it keeps the full operator stack online without forcing Airflow into Cloud Run
+- it keeps the full operator stack online in the active shared environment without forcing Airflow into Cloud Run
 - it reuses the same repository and application boundaries as the local evaluator target
 - it keeps the hosted runtime tied to reviewable Terraform outputs, GitHub delivery, and sync metrics
 - it keeps public exposure narrow enough that the app remains the only default internet-facing surface
 
-See [Architecture](architecture.md), [Local Evaluator](local-evaluator.md), [Inference Pipeline](inference-pipeline.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding runtime and deployment boundaries.
+See [Architecture](architecture.md), [Local Evaluator](local-evaluator.md), [Inference Pipeline](inference-pipeline.md), [Cloud Mapping](cloud-mapping.md), and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the surrounding runtime and deployment boundaries.

--- a/docs/site/system/inference-pipeline.md
+++ b/docs/site/system/inference-pipeline.md
@@ -1,6 +1,6 @@
 # Inference Pipeline
 
-FoehnCast keeps inference inside the application layer. The serving path resolves the live MLflow alias, fetches fresh forecasts for configured spots, rebuilds the shared engineered feature vector, returns per-spot quality predictions, and optionally exposes the Feast-backed online lookup without pulling training or operator concerns into the request path.
+FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs in the local evaluator, in the active hosted full-stack environment, and in the optional inference-only Cloud Run target. The serving path resolves the live MLflow alias, fetches fresh forecasts for configured spots, rebuilds the shared engineered feature vector, returns per-spot quality predictions, and optionally exposes the Feast-backed online lookup without pulling training or operator concerns into the request path.
 
 This page records the current serving contract that is validated in the local stack and in endpoint, dashboard, and cloud-runtime tests. It focuses on what the running app owns today and what stays optional or operator-controlled.
 
@@ -126,15 +126,22 @@ The current hand-off is:
 
 This keeps the inference service responsible for request-side facts while leaving dashboards, alert rules, and long-range operator review to the monitoring stack.
 
-## Hosted Serving Boundary
+## Serving Targets Today
+
+<div class="mermaid">
+flowchart LR
+    APP[Same FastAPI app] --> LOCAL[Local evaluator target]
+    APP --> HOST[Hosted full-stack target today]
+    APP -. optional smaller path .-> RUN[Hosted inference target]
+</div>
 
 The same FastAPI app runs across the supported serving targets.
 
 The current hosted contract is:
 
 - the local evaluator target serves the full app inside the Compose stack
-- the hosted full-stack target keeps the app online next to the other runtime services on one GCP host
-- the hosted inference target publishes the same FastAPI inference surface on Cloud Run without shipping Airflow, notebooks, docs tooling, or local emulators
+- the active shared environment uses the hosted full-stack target and keeps the app online next to the other runtime services on one GCP host
+- the hosted inference target publishes the same FastAPI inference surface on Cloud Run without shipping Airflow, notebooks, docs tooling, or local emulators when a smaller API-only surface is enough
 - cloud bootstrap and operator checks verify the live `/health` and `/spots` routes when the hosted inference path is enabled
 
 That boundary matters because the app is the product and service surface. Grafana remains an operator surface, not the rider product UI.
@@ -144,6 +151,7 @@ That boundary matters because the app is the product and service surface. Grafan
 - it keeps live requests narrow enough to verify through simple route and dashboard tests
 - it reuses the shared feature contract instead of inventing a serving-only schema
 - it ties responses back to a concrete registry version without giving the app promotion authority
+- it lets one FastAPI contract run locally, in the active shared environment, and in the optional Cloud Run path
 - it keeps the Feast lookup path useful for integration checks while leaving prediction and ranking available from the core app alone
 
 See [Architecture](architecture.md), [Training Pipeline](training-pipeline.md), [Monitoring](monitoring.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding system boundaries.

--- a/docs/site/system/interfaces-and-surfaces.md
+++ b/docs/site/system/interfaces-and-surfaces.md
@@ -136,4 +136,4 @@ The shared hosted environment keeps the same rule as the docs: the app is the pr
 - it leaves orchestration, tracking, monitoring, and alerting on the operator side
 - it gives the public docs stable evidence sources that do not depend on exposing private hosted dashboards
 
-See [Architecture](architecture.md), [Inference Pipeline](inference-pipeline.md), [Monitoring](monitoring.md), [Local Evaluator](local-evaluator.md), and [Hosted Full-Stack](hosted-full-stack.md) for the surrounding runtime contracts.
+See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Inference Pipeline](inference-pipeline.md), [Monitoring](monitoring.md), [Local Evaluator](local-evaluator.md), and [Hosted Full-Stack](hosted-full-stack.md) for the surrounding runtime contracts.

--- a/docs/site/system/local-evaluator.md
+++ b/docs/site/system/local-evaluator.md
@@ -122,4 +122,4 @@ The local evaluator applies local-only access overrides so a fresh Docker run ca
 - it keeps the online feature contract real by preparing Feast state and calling the live route
 - it keeps optional notebook tooling outside the default path so the supported baseline stays smaller and easier to reproduce
 
-See [Architecture](architecture.md), [Inference Pipeline](inference-pipeline.md), [Monitoring](monitoring.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding runtime and deployment boundaries.
+See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Inference Pipeline](inference-pipeline.md), [Monitoring](monitoring.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding runtime and deployment boundaries.

--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -28,6 +28,16 @@ flowchart LR
 
 The important split is that monitoring consumes persisted or runtime monitoring state after the pipeline and serving paths run. It does not own feature engineering, model scoring, or orchestration itself.
 
+## Monitoring By Runtime Mode
+
+| Runtime mode | What is monitored | What stays private |
+|------|-------------------|--------------------|
+| Local evaluator | app `/metrics`, StatsD drift export, local pipeline summaries, and local Grafana dashboards | local Airflow, MLflow, Prometheus, and Grafana remain operator tools |
+| Active shared environment | app `/metrics`, hosted sync state, and the hosted monitoring stack on the compose host | Airflow, MLflow, Prometheus, and Grafana stay private by default |
+| Public docs | rendered metrics snippets, screenshots, checked-in configs, and summary artifacts | no live control planes |
+
+This keeps the public explanation clear: operators use the monitoring stack directly, while the docs site uses rendered evidence.
+
 ## Surface Roles
 
 | Surface | What it exposes | Why it matters |
@@ -105,6 +115,8 @@ Grafana is provisioned from repository-owned dashboards and alert rules. The val
 
 That makes the dashboard a view over checked-in metrics contracts rather than a manually assembled local-only artifact.
 
+The same dashboard contract works in the local evaluator and in the active shared environment. What changes is the runtime around it, not the meaning of the monitored signals.
+
 ## Alert Rules
 
 The checked-in alert rules cover the main operator failure modes.
@@ -141,4 +153,4 @@ This keeps the public docs understandable in review while leaving live Grafana, 
 - it keeps alerting reviewable because dashboards, rules, and scrape config live in git
 - it lets one `/metrics` surface describe the app-owned monitoring contract while StatsD handles Evidently drift export
 
-See [Architecture](architecture.md), [Feature Pipeline](feature-pipeline.md), and [Getting Started](../getting-started.md) for the surrounding system and local operator path.
+See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Feature Pipeline](feature-pipeline.md), and [Getting Started](../getting-started.md) for the surrounding system and local operator path.

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -22,6 +22,19 @@ tests/
 docs/
 ```
 
+## Repository Roles
+
+<div class="mermaid">
+flowchart LR
+  CODE[src/foehncast] --> APP[Feature + Training + Inference + Monitoring code]
+  DAGS[dags] --> ORCH[Airflow orchestration]
+  OPS[scripts + terraform] --> DELIV[Bootstrap and hosted delivery]
+  FEAST[feature_repo] --> STORE[Feast integration contract]
+  MON[prometheus_config + grafana_work] --> OBS[Checked-in operator monitoring]
+  TESTS[tests] --> VERIFY[Regression validation]
+  DOCS[docs] --> SITE[Public documentation]
+</div>
+
 ## Where To Start
 
 - `src/foehncast/`: the application modules for configuration, feature engineering, training, inference, monitoring, and spot metadata.
@@ -45,7 +58,7 @@ Central configuration lives in `config.yaml` and `src/foehncast/config.py`, so t
 
 Feature engineering starts in `feature_pipeline/engineer.py`, where raw weather inputs are turned into the engineered feature vector shared by training and inference.
 
-There is currently no separate product UI package in the repository. The optional interactive demo surface that does exist lives inside the inference pipeline, for example `src/foehncast/inference_pipeline/demo.py`, rather than in a separate top-level app tree. Grafana does not fill that role; it remains an operator dashboard surface.
+There is no separate product UI package in the repository. The interactive demo surface lives inside the inference pipeline, for example `src/foehncast/inference_pipeline/demo.py`, rather than in a separate top-level app tree. Grafana does not fill that role; it remains an operator dashboard surface.
 
 ## Configuration Ownership
 

--- a/docs/site/system/seasonality.md
+++ b/docs/site/system/seasonality.md
@@ -1,34 +1,35 @@
 # Seasonality
 
-Seasonality is already handled in FoehnCast through cyclical time features derived from the forecast timestamp. The project does not split the model by season; it encodes repeating daily and yearly patterns directly in the feature table.
+FoehnCast handles seasonality through cyclical time features derived from the forecast timestamp. The project does not split the model by season. It keeps repeating daily and yearly patterns in the shared feature layer so the same contract works in local and hosted runtimes.
 
 ## Why It Matters
 
-Swiss kite spots do not behave the same way all year.
-Summer thermals, winter pressure systems, daylight, and temperature patterns all affect when a spot becomes rideable. If the model only sees raw weather values, it may miss some of that structure.
+Swiss kite spots do not behave the same way all year. Summer thermals, winter pressure systems, daylight, and temperature patterns all affect when a spot becomes rideable. If the model only sees raw weather values, it misses part of that repeating structure.
 
-## Current Implementation
+## Current Contract
 
-The feature pipeline currently engineers four timestamp-derived fields:
+The feature pipeline engineers four timestamp-derived fields:
 
 - `hour_of_day_sin`
 - `hour_of_day_cos`
 - `day_of_year_sin`
 - `day_of_year_cos`
 
-These features let the model learn that 14:00 is close to 15:00, and that late June is close to early July, without introducing a discontinuity at midnight or year-end.
+These features let the model learn that `14:00` is close to `15:00`, and that late June is close to early July, without introducing a discontinuity at midnight or year-end.
 
 ## Where It Fits In FTI
 
-- The feature pipeline creates the cyclical time fields from each forecast timestamp.
-- The training pipeline consumes those fields as part of the model feature vector.
-- The inference pipeline builds the same fields from live forecast timestamps.
+| Stage | Seasonality role |
+|------|------------------|
+| Feature pipeline | creates the cyclical time fields from each forecast timestamp |
+| Training pipeline | consumes those fields as part of the model feature vector |
+| Inference pipeline | rebuilds the same fields from live forecast timestamps |
 
 This keeps training and inference aligned around the same time encoding.
 
 ## Why The Current Scope Stays Simple
 
-The current implementation favors the smallest feature set that can still capture recurring patterns.
+The current implementation favors the smallest feature set that still captures recurring patterns.
 
 - No separate seasonal model families.
 - No wide month-dummy design.
@@ -36,9 +37,9 @@ The current implementation favors the smallest feature set that can still captur
 
 That keeps the design simple while still giving the model useful time context.
 
-## How It Can Be Evaluated
+## How It Is Reviewed
 
-Seasonality changes can be evaluated through the same training and MLflow workflow used for the rest of the model.
+Seasonality changes are reviewed through the same training and MLflow workflow used for the rest of the model.
 
 - compare training runs with and without additional seasonal features
 - inspect error metrics and ranking quality across different parts of the year
@@ -46,4 +47,4 @@ Seasonality changes can be evaluated through the same training and MLflow workfl
 
 ## Summary
 
-FoehnCast already accounts for seasonality in a lightweight way. The current design is to keep cyclical time features in the shared feature layer and only add more seasonal complexity if model evidence makes that worthwhile.
+FoehnCast already accounts for seasonality in a lightweight way. The current design keeps cyclical time features in the shared feature layer and treats extra seasonal complexity as something that must earn its place through model evidence.

--- a/docs/site/system/training-pipeline.md
+++ b/docs/site/system/training-pipeline.md
@@ -1,6 +1,6 @@
 # Training Pipeline
 
-FoehnCast keeps training downstream from the curated feature store. The training path reads stored curated rows, rebuilds schema-derived features when needed, generates synthetic rideability labels, trains the configured regressor, writes evaluation evidence, and registers a versioned model in MLflow without pushing training concerns back into the feature pipeline.
+FoehnCast keeps training downstream from the curated feature store. The same training contract runs in the local evaluator and in the active shared environment: the training path reads stored curated rows, rebuilds schema-derived features when needed, generates synthetic rideability labels, trains the configured regressor, writes evaluation evidence, and registers a versioned model in MLflow without pushing training concerns back into the feature pipeline.
 
 This page records the current training design that is validated in the local stack and in regression tests. It focuses on what each stage owns today and what remains an explicit operator control rather than an automatic side effect.
 
@@ -31,6 +31,14 @@ The key point is that the training path stays explicit:
 - evaluation owns reviewable reporting
 - registration owns versioning and alias assignment in MLflow
 - promotion and rollback stay separate operator controls even though they reuse the same registry aliases
+
+## Runtime Role
+
+| Runtime mode | Training role today |
+|------|---------------------|
+| Local evaluator | local Airflow and MLflow run labeling, training, evaluation, and registration |
+| Active shared environment | the hosted full-stack target runs the same Airflow and MLflow contract online |
+| Hosted inference target | serves a registered alias; it does not run training |
 
 ## Stage Responsibilities
 
@@ -65,7 +73,7 @@ This means labeling is part of the training contract, not part of the inference 
 
 ## Training Boundary
 
-Training reads stored feature rows by spot and dataset, then rebuilds schema-derived time, direction, and gust features before labeling. That compatibility step matters because the training path is expected to keep working even when stored datasets predate a later feature-schema expansion.
+Training reads stored feature rows by spot and dataset, then rebuilds schema-derived time, direction, and gust features before labeling. That compatibility step keeps older stored slices usable when the curated schema gains new derived fields.
 
 The current training contract is:
 
@@ -101,7 +109,7 @@ The current registry contract is:
 - the live-serving alias is `champion`
 - training summaries persist run-level metrics, row counts, report paths, stage durations, and the registered version so the monitoring surface can expose the latest training state
 
-Manual training runs default to the `Candidate` stage. Asset-triggered runs from the feature pipeline can request `Production`, which lets the asset flow produce a candidate-ready or live-ready registration path without changing the training code itself.
+Manual training runs default to the `Candidate` stage. Asset-triggered runs from the feature pipeline can request `Production`, which lets the asset flow produce a live-ready registration path without changing the training code itself.
 
 ## Airflow Hand-Off
 
@@ -135,4 +143,4 @@ That separation is deliberate. Training can succeed without immediately changing
 - it keeps candidate and champion semantics explicit in the registry rather than buried in deployment scripts
 - it makes automatic retraining visible in Airflow through asset hand-offs instead of opaque trigger chains
 
-See [Architecture](architecture.md), [Feature Pipeline](feature-pipeline.md), and [Monitoring](monitoring.md) for the surrounding system boundaries.
+See [Architecture](architecture.md), [Feature Pipeline](feature-pipeline.md), [Monitoring](monitoring.md), and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the surrounding system boundaries.

--- a/docs/site/system/use-case.md
+++ b/docs/site/system/use-case.md
@@ -80,15 +80,15 @@ These are not example rows. They are the actual fixed spot set used in the curre
 |--------|---------------------|----------------|
 | Open-Meteo | primary forecast and archive weather source | implemented |
 | OSRM | drive-time personalization for ranking | implemented |
-| MeteoSwiss | possible observation reference for later validation | planned |
+| MeteoSwiss | not part of the current runtime contract | not active |
 
-Open-Meteo supplies the forecast data, OSRM already contributes travel-time ranking inputs, and MeteoSwiss remains a possible future reference source rather than an active dependency in the current stack.
+Open-Meteo supplies the forecast data and OSRM contributes travel-time ranking inputs. MeteoSwiss is not part of the current stack.
 
 ## Why The Scope Is Fixed
 
 - It keeps the labeling and ranking problem aligned with one real rider scenario.
 - It makes route-time personalization meaningful instead of theoretical.
 - It avoids turning the course project into a generic weather portal with weak decision support.
-- It keeps later changes focused on implementation maturity rather than on changing the product question.
+- It keeps implementation work focused on one concrete product question.
 
 See [Architecture](architecture.md) for the current system structure and [Feature Pipeline](feature-pipeline.md) for how the data moves through the stack.

--- a/feature_repo/README.md
+++ b/feature_repo/README.md
@@ -1,6 +1,16 @@
 # Feast Repo
 
-This Feast repo sits on top of the curated features that FoehnCast already writes. It does not replace the main feature pipeline or the local bootstrap path; it is the serving layer bound to that curated contract.
+This Feast repo sits downstream from the curated features that FoehnCast already writes. It does not replace the main feature pipeline or the default contributor path. It is the serving layer bound to that curated contract.
+
+## Path Split
+
+| Path | Who uses it | Main entrypoint | What happens |
+|------|-------------|-----------------|--------------|
+| Local evaluator | contributor or reviewer | `./scripts/bootstrap-local.sh` | prepares Feast automatically and verifies `/features/online` |
+| Manual local Feast prep | contributor troubleshooting the serving layer | `./scripts/prepare-feast-local.sh` | renders the local runtime config, applies the repo, and materializes the emulator-backed online store |
+| Shared cloud path | maintainer | `./scripts/prepare-feast-cloud.sh` after remote apply | applies the same Feast contract to curated BigQuery rows and the hosted Datastore online store |
+
+Use [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/system/delivery-and-operator-workflow.md) for the maintainer workflow split. This README stays focused on the Feast serving layer itself.
 
 ## When To Use It
 
@@ -25,21 +35,21 @@ The runtime contract now renders the active Feast config from environment into `
 
 ## Local Path
 
+The normal local path is still `./scripts/bootstrap-local.sh`. Use the manual Feast steps only when you want to inspect or rerun the serving layer yourself.
+
 1. Sync the Feast dependency group for host-side CLI commands if needed:
    `uv sync --group feast`
-2. Export the current stored features, render the active Feast runtime config, apply the repo, and materialize the local online store:
+2. Render the active Feast runtime config, apply the repo, and materialize the local online store:
    `./scripts/prepare-feast-local.sh`
-3. Read features back through the application-side helper:
-   `uv run --group feast python -c "from foehncast.inference_pipeline.online_features import get_online_spot_features; print(get_online_spot_features(['silvaplana'], ['wind_speed_10m', 'gust_excess_10m']))"`
-4. Or use the API endpoint if the app is already running:
-   `curl -fsS -X POST http://127.0.0.1:8000/features/online -H 'content-type: application/json' -d '{"spot_ids":["silvaplana"],"feature_names":["wind_speed_10m","gust_excess_10m"]}'`
-5. Or open the built-in demo page in the running app:
-   `http://127.0.0.1:8000/features/online/demo`
+3. Verify through one of these surfaces:
 
-The local repo keeps using the default local stack. It does not replace the existing feature pipeline or the local bootstrap path.
-The online read should return a dictionary with `rows`, `returned_features`, and the requested spot values when materialization has already run.
-The app runtime image includes Feast support and the bundled repo path; the generated config under `.state/feast/feature_store.runtime.yaml` binds the local resources to that shared contract.
-The default `./scripts/bootstrap-local.sh` path runs this preparation step and verifies `/features/online` automatically.
+| Surface | Example |
+|---------|---------|
+| Python helper | `uv run --group feast python -c "from foehncast.inference_pipeline.online_features import get_online_spot_features; print(get_online_spot_features(['silvaplana'], ['wind_speed_10m', 'gust_excess_10m']))"` |
+| API route | `curl -fsS -X POST http://127.0.0.1:8000/features/online -H 'content-type: application/json' -d '{"spot_ids":["silvaplana"],"feature_names":["wind_speed_10m","gust_excess_10m"]}'` |
+| Demo page | `http://127.0.0.1:8000/features/online/demo` |
+
+The local repo keeps using the default local stack. The app runtime image includes Feast support and the bundled repo path, the generated config under `.state/feast/feature_store.runtime.yaml` binds the local resources to that shared contract, and `./scripts/bootstrap-local.sh` already runs this preparation step for the supported contributor path.
 
 The default local stack uses the bundled MinIO surface for curated feature storage and MLflow artifacts. Feast still reads an exported parquet offline source built from those curated rows, while the registry and runtime config stay under `.state/feast/` and the online store runs through the bundled Datastore-mode emulator.
 
@@ -58,16 +68,16 @@ That keeps the derived offline source separate from local registry and runtime c
 
 ## Cloud Path
 
-1. Set `FOEHNCAST_FEAST_SOURCE=bigquery`.
-2. Set `GCP_PROJECT_ID` and `GCP_BUCKET_NAME`, or the Feast-specific overrides `FOEHNCAST_FEAST_PROJECT_ID`, `FOEHNCAST_FEAST_REGISTRY`, and `FOEHNCAST_FEAST_GCS_STAGING_LOCATION`.
-3. Set `FOEHNCAST_FEAST_BIGQUERY_TABLE` to a BigQuery table or view that exposes curated rows with `spot_id`, `forecast_time`, and the same curated feature columns defined in `features.py`.
-4. Optionally set `FOEHNCAST_FEAST_BIGQUERY_DATASET` and `FOEHNCAST_FEAST_BIGQUERY_LOCATION` if the defaults do not fit the target environment.
-5. Set `FOEHNCAST_FEAST_DATASTORE_DATABASE` when the hosted environment uses a named Datastore-mode database for Feast online serving.
-6. Run `./scripts/prepare-feast-cloud.sh` after curated BigQuery rows are available. It renders the active Feast runtime config, applies the repo, and materializes the Datastore online store.
+This is the maintainer path. Start with [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/system/delivery-and-operator-workflow.md), then use this repo after curated BigQuery rows are available.
 
-The cloud bootstrap and Terraform-managed hosted runtimes populate this same Feast env contract automatically. You do not need to keep a separate handwritten cloud YAML in sync for normal operator flows.
+The current cloud contract is:
 
-The simplest cloud hand-off from the current storage layer is a BigQuery view that filters the curated feature table to the split or dataset you want Feast to read.
+- `FOEHNCAST_FEAST_SOURCE=bigquery`
+- `FOEHNCAST_FEAST_BIGQUERY_TABLE` points at a BigQuery table or view with `spot_id`, `forecast_time`, and the curated feature columns defined in `features.py`
+- the bootstrap and Terraform-managed hosted runtimes normally populate the project, registry, staging, and Datastore settings for the shared environment
+- `./scripts/prepare-feast-cloud.sh` renders the active runtime config, applies the repo, and materializes the hosted online store
+
+If another environment needs different defaults, override the Feast-specific BigQuery, registry, staging, or Datastore settings through the corresponding environment variables.
 
 Keep the storage roles separate:
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -4,6 +4,8 @@ This directory defines one shared GCP baseline and two hosted runtime targets.
 
 This is maintainer/operator reference material. Default contributor setup stays local with Docker and does not require Terraform, `gcloud`, or `gh`.
 
+Start with [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/system/delivery-and-operator-workflow.md) for the high-level contributor-versus-maintainer split. Use this file when you need the maintainer-specific platform inputs, bootstrap steps, and remote Terraform behavior.
+
 ## Terraform In One View
 
 | Surface | Purpose | Deploys |
@@ -231,8 +233,9 @@ Automatic Terraform apply on `main` is no longer paused behind a GitHub environm
 ## Recommended Reading Order
 
 1. Read the root `README.md` for the runtime overview.
-2. Use this file when you need the Terraform-specific deployment inputs and teardown steps.
-3. Use `docs/site/system/cloud-mapping.md` when you want the higher-level architecture explanation.
+2. Read `../docs/site/system/delivery-and-operator-workflow.md` for the shared cloud operator flow.
+3. Use this file when you need the Terraform-specific deployment inputs and teardown steps.
+4. Use `../docs/site/system/cloud-mapping.md` when you want the higher-level architecture explanation.
 
 ## Cloud Operator Bootstrap
 


### PR DESCRIPTION
Clean up the public docs so they present one clear runtime story: local Docker for contributors, separate cloud delivery for maintainers.

Add the workflow page, align the surrounding docs, and make the hosted full-stack path the explicit shared environment today, with Cloud Run kept as the smaller optional inference path.

Closes #186