### PR TITLE
fix(terraform): reconcile hosted drift on main

### DIFF
--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -44,6 +44,19 @@ in_cloud_shell() {
   [[ -n "${CLOUD_SHELL:-}" || -n "${DEVSHELL_PROJECT_ID:-}" ]]
 }
 
+resolve_invocation_path() {
+  local path_value="$1"
+
+  case "$path_value" in
+    /*)
+      printf '%s\n' "$path_value"
+      ;;
+    *)
+      printf '%s/%s\n' "$PWD" "$path_value"
+      ;;
+  esac
+}
+
 cleanup_bootstrap_terraform_dir() {
   if [[ -n "$TEMP_TERRAFORM_DIR" && -d "$TEMP_TERRAFORM_DIR" ]]; then
     rm -rf "$TEMP_TERRAFORM_DIR"
@@ -51,7 +64,7 @@ cleanup_bootstrap_terraform_dir() {
 }
 
 prepare_bootstrap_terraform_dir() {
-  if [[ "$BOOTSTRAP_ONLY" != "true" || -n "$TEMP_TERRAFORM_DIR" ]]; then
+  if [[ -n "$TEMP_TERRAFORM_DIR" ]]; then
     return
   fi
 
@@ -61,9 +74,7 @@ prepare_bootstrap_terraform_dir() {
   rm -f "$TEMP_TERRAFORM_DIR/terraform.tfstate" "$TEMP_TERRAFORM_DIR/terraform.tfstate.backup"
   TERRAFORM_DIR="$TEMP_TERRAFORM_DIR"
 
-  if [[ -f "${ROOT_DIR}/terraform/terraform.tfstate" || -d "${ROOT_DIR}/terraform/.terraform" ]]; then
-    echo "Using an isolated Terraform working directory for bootstrap-only so local state files do not interfere with remote backend initialization."
-  fi
+  echo "Using an isolated Terraform working directory so local state files do not interfere with remote backend initialization."
 }
 
 trap cleanup_bootstrap_terraform_dir EXIT
@@ -799,6 +810,9 @@ if [[ -n "$TARGET_REPO" ]]; then
   CONFIGURE_GITHUB=true
 fi
 
+ENV_FILE="$(resolve_invocation_path "$ENV_FILE")"
+TFVARS_FILE="$(resolve_invocation_path "$TFVARS_FILE")"
+
 print_bootstrap_context
 
 require_command gcloud
@@ -829,14 +843,15 @@ echo "Checking access to GCP project ${GCP_PROJECT_ID}..."
 gcloud projects describe "$GCP_PROJECT_ID" >/dev/null
 
 echo "Initializing Terraform..."
-terraform_init_args=(init -reconfigure)
+terraform_init_args=(
+  init
+  -reconfigure
+  -backend-config="bucket=$(terraform_remote_state_bucket)"
+  -backend-config="prefix=$(terraform_remote_state_prefix)"
+)
 
 if [[ "$BOOTSTRAP_ONLY" == "true" && "$PLAN_ONLY" != "true" ]]; then
   ensure_remote_state_bucket
-  terraform_init_args+=(
-    -backend-config="bucket=$(terraform_remote_state_bucket)"
-    -backend-config="prefix=$(terraform_remote_state_prefix)"
-  )
 fi
 
 run_terraform -chdir="$TERRAFORM_DIR" "${terraform_init_args[@]}"

--- a/src/foehncast/feast_runtime.py
+++ b/src/foehncast/feast_runtime.py
@@ -175,6 +175,20 @@ def render_runtime_config(output_path: str | Path | None = None) -> Path:
         Path(output_path) if output_path else feast_runtime_config_path(repo_path)
     )
     destination.parent.mkdir(parents=True, exist_ok=True)
+    desired_config = resolve_runtime_config()
+
+    if destination.exists():
+        try:
+            with destination.open("r", encoding="utf-8") as handle:
+                current_config = yaml.safe_load(handle)
+        except (OSError, yaml.YAMLError):
+            current_config = None
+
+        # The app and Airflow containers may share this file through a bind
+        # mount while running under different UIDs. If the rendered config is
+        # already correct, reuse it instead of forcing another rewrite.
+        if current_config == desired_config:
+            return destination
 
     # In the local stack multiple containers may render the same runtime file.
     # If another container created it with a restrictive mode, remove it first
@@ -183,7 +197,7 @@ def render_runtime_config(output_path: str | Path | None = None) -> Path:
         destination.unlink()
 
     with destination.open("w", encoding="utf-8") as handle:
-        yaml.safe_dump(resolve_runtime_config(), handle, sort_keys=False)
+        yaml.safe_dump(desired_config, handle, sort_keys=False)
 
     # A different container UID may still be able to rewrite the file through
     # the shared bind mount while not being allowed to change its mode.

--- a/src/foehncast/feature_pipeline/store.py
+++ b/src/foehncast/feature_pipeline/store.py
@@ -247,6 +247,16 @@ def _bigquery_time_partitioning(bigquery: Any, contract: dict[str, Any]) -> Any:
     )
 
 
+def _bigquery_schema_update_options(bigquery: Any) -> list[Any]:
+    schema_update_option = getattr(bigquery, "SchemaUpdateOption", None)
+    allow_field_addition = getattr(
+        schema_update_option,
+        "ALLOW_FIELD_ADDITION",
+        "ALLOW_FIELD_ADDITION",
+    )
+    return [allow_field_addition]
+
+
 def _validate_bigquery_contract_frame(
     frame: pd.DataFrame,
     contract: dict[str, Any],
@@ -332,12 +342,22 @@ def _write_features_bigquery(
     write_frame = _bigquery_write_frame(df, spot_id=spot_id, dataset=dataset)
     contract = _bigquery_curated_feature_contract(storage_config)
     _validate_bigquery_contract_frame(write_frame, contract)
-    _delete_features_bigquery(storage_config, spot_id=spot_id, dataset=dataset)
-    job_config = bigquery.LoadJobConfig(
-        write_disposition="WRITE_APPEND",
-        time_partitioning=_bigquery_time_partitioning(bigquery, contract),
-        clustering_fields=contract["cluster_fields"],
-    )
+    table_missing = _bigquery_not_found(storage_config)
+    if not table_missing:
+        _delete_features_bigquery(storage_config, spot_id=spot_id, dataset=dataset)
+
+    job_config_kwargs: dict[str, Any] = {
+        "write_disposition": "WRITE_APPEND",
+        "schema_update_options": _bigquery_schema_update_options(bigquery),
+    }
+    if table_missing:
+        job_config_kwargs["time_partitioning"] = _bigquery_time_partitioning(
+            bigquery,
+            contract,
+        )
+        job_config_kwargs["clustering_fields"] = contract["cluster_fields"]
+
+    job_config = bigquery.LoadJobConfig(**job_config_kwargs)
     client.load_table_from_dataframe(
         write_frame,
         _bigquery_table_id(storage_config),

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -74,24 +74,6 @@ locals {
       description = "Hourly forecast timestamp."
     },
     {
-      name        = "spot_id"
-      type        = "STRING"
-      mode        = "REQUIRED"
-      description = "Stable spot identifier from config.yaml."
-    },
-    {
-      name        = "spot_name"
-      type        = "STRING"
-      mode        = "NULLABLE"
-      description = "Human-readable spot name."
-    },
-    {
-      name        = "dataset_name"
-      type        = "STRING"
-      mode        = "REQUIRED"
-      description = "Logical dataset partition such as train or forecast."
-    },
-    {
       name        = "wind_speed_10m"
       type        = "FLOAT"
       mode        = "NULLABLE"
@@ -170,6 +152,18 @@ locals {
       description = "Lifted index from Open-Meteo."
     },
     {
+      name        = "spot_id"
+      type        = "STRING"
+      mode        = "REQUIRED"
+      description = "Stable spot identifier from config.yaml."
+    },
+    {
+      name        = "spot_name"
+      type        = "STRING"
+      mode        = "NULLABLE"
+      description = "Human-readable spot name."
+    },
+    {
       name        = "hour_of_day_sin"
       type        = "FLOAT"
       mode        = "NULLABLE"
@@ -194,6 +188,18 @@ locals {
       description = "Cyclical encoding of the day of year."
     },
     {
+      name        = "wind_direction_10m_sin"
+      type        = "FLOAT"
+      mode        = "NULLABLE"
+      description = "Cyclical sine encoding of 10 m wind direction."
+    },
+    {
+      name        = "wind_direction_10m_cos"
+      type        = "FLOAT"
+      mode        = "NULLABLE"
+      description = "Cyclical cosine encoding of 10 m wind direction."
+    },
+    {
       name        = "wind_steadiness"
       type        = "FLOAT"
       mode        = "NULLABLE"
@@ -216,6 +222,12 @@ locals {
       type        = "FLOAT"
       mode        = "NULLABLE"
       description = "Cosine similarity of wind direction to shore orientation."
+    },
+    {
+      name        = "dataset_name"
+      type        = "STRING"
+      mode        = "REQUIRED"
+      description = "Logical dataset partition such as train or forecast."
     },
   ]
 
@@ -383,6 +395,12 @@ resource "google_storage_bucket_iam_member" "cloud_run_bucket_reader" {
   member = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
 }
 
+resource "google_storage_bucket_iam_member" "cloud_run_bucket_metadata_reader" {
+  bucket = google_storage_bucket.artifacts.name
+  role   = "roles/storage.legacyBucketReader"
+  member = "serviceAccount:${google_service_account.cloud_run_runtime.email}"
+}
+
 resource "google_project_iam_member" "cloud_run_bigquery_job_user" {
   project = var.project_id
   role    = "roles/bigquery.jobUser"
@@ -436,6 +454,14 @@ resource "google_storage_bucket_iam_member" "online_compose_bucket_admin" {
 
   bucket = google_storage_bucket.artifacts.name
   role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_service_account.online_compose_runtime[0].email}"
+}
+
+resource "google_storage_bucket_iam_member" "online_compose_bucket_metadata_reader" {
+  count = var.provision_online_compose_host ? 1 : 0
+
+  bucket = google_storage_bucket.artifacts.name
+  role   = "roles/storage.legacyBucketReader"
   member = "serviceAccount:${google_service_account.online_compose_runtime[0].email}"
 }
 
@@ -497,6 +523,7 @@ resource "google_cloud_run_v2_service" "app" {
     google_firestore_database.feast_online_store,
     google_artifact_registry_repository_iam_member.cloud_run_reader,
     google_storage_bucket_iam_member.cloud_run_bucket_reader,
+    google_storage_bucket_iam_member.cloud_run_bucket_metadata_reader,
     google_project_iam_member.cloud_run_bigquery_job_user,
     google_project_iam_member.cloud_run_bigquery_read_session_user,
     google_project_iam_member.cloud_run_datastore_user,
@@ -591,6 +618,7 @@ resource "google_compute_instance" "online_compose" {
     google_project_iam_member.online_compose_bigquery_read_session_user,
     google_project_iam_member.online_compose_datastore_user,
     google_storage_bucket_iam_member.online_compose_bucket_admin,
+    google_storage_bucket_iam_member.online_compose_bucket_metadata_reader,
     google_bigquery_dataset_iam_member.online_compose_bigquery_editor,
   ]
 }

--- a/terraform/templates/online-compose-host.sh.tftpl
+++ b/terraform/templates/online-compose-host.sh.tftpl
@@ -4,8 +4,19 @@ set -euo pipefail
 
 export DEBIAN_FRONTEND=noninteractive
 
+if command -v journalctl >/dev/null 2>&1; then
+  journalctl --rotate >/dev/null 2>&1 || true
+  journalctl --vacuum-size=100M >/dev/null 2>&1 || true
+fi
+
+if [[ -d /var/lib/docker/containers ]]; then
+  find /var/lib/docker/containers -name '*-json.log' -type f -size +50M -exec truncate -s 0 {} \; >/dev/null 2>&1 || true
+fi
+
+rm -rf /var/lib/apt/lists/* >/dev/null 2>&1 || true
+
 apt-get update
-apt-get install -y ca-certificates curl git gnupg lsb-release
+apt-get install -y ca-certificates curl git gnupg lsb-release python3
 
 install -m 0755 -d /etc/apt/keyrings
 if [[ ! -f /etc/apt/keyrings/docker.gpg ]]; then
@@ -19,7 +30,18 @@ echo \
 
 apt-get update
 apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+install -d -m 0755 /etc/docker
+cat > /etc/docker/daemon.json <<'EOF'
+{
+  "log-driver": "json-file",
+  "log-opts": {
+    "max-size": "10m",
+    "max-file": "3"
+  }
+}
+EOF
 systemctl enable docker --now
+systemctl restart docker
 
 install -d -m 0755 /opt/foehncast
 
@@ -35,11 +57,15 @@ git -C /opt/foehncast fetch --depth 1 origin "${git_ref}"
 git -C /opt/foehncast checkout --force FETCH_HEAD
 
 install -d -m 0775 /opt/foehncast/airflow /opt/foehncast/airflow/logs /opt/foehncast/airflow/reports
-install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync
+install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/airflow /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync
+install -d -m 0775 /opt/foehncast/data/feast
 install -d -m 0755 /opt/foehncast/grafana_work/data
 
 chown -R $${airflow_uid}:0 /opt/foehncast/airflow
 chown -R $${app_uid}:$${app_uid} /opt/foehncast/.state
+chown -R $${airflow_uid}:0 /opt/foehncast/.state/airflow
+chown -R $${airflow_uid}:0 /opt/foehncast/.state/feast
+chown -R $${airflow_uid}:0 /opt/foehncast/data/feast
 chown -R $${grafana_uid}:$${grafana_uid} /opt/foehncast/grafana_work/data
 
 if [[ ! -s /opt/foehncast/airflow/.admin-password ]]; then
@@ -73,16 +99,135 @@ set -euo pipefail
 
 sync_status_file="/opt/foehncast/.state/online-compose-sync/last-success.json"
 compose_deploy_mode="build"
+feature_logical_date="$${FEATURE_LOGICAL_DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"
+feature_run_id="$${FEATURE_RUN_ID:-hosted_sync__$(date -u +"%Y-%m-%dT%H-%M-%SZ")}"
+airflow_health_url="http://127.0.0.1:8080/api/v2/monitor/health"
+app_health_url="http://127.0.0.1:8000/health"
+online_features_url="http://127.0.0.1:8000/features/online"
+compose_args=(
+  -f /opt/foehncast/docker-compose.yml
+  -f /opt/foehncast/docker-compose.cloud.yml
+  --env-file /opt/foehncast/.env
+)
+
+vacuum_host_logs() {
+  if command -v journalctl >/dev/null 2>&1; then
+    journalctl --rotate >/dev/null 2>&1 || true
+    journalctl --vacuum-size=100M >/dev/null 2>&1 || true
+  fi
+
+  if [[ -d /var/lib/docker/containers ]]; then
+    find /var/lib/docker/containers -name '*-json.log' -type f -size +50M -exec truncate -s 0 {} \; >/dev/null 2>&1 || true
+  fi
+}
+
+verify_airflow_api_health() {
+  local max_attempts="$${1:-60}"
+  local sleep_seconds="$${2:-2}"
+  local payload=""
+  local attempt
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if payload="$(curl --retry 1 --retry-all-errors --retry-delay 0 -fsS "$${airflow_health_url}" 2>/dev/null)"; then
+      if printf '%s' "$${payload}" | python3 -c $'import json, sys\npayload = json.load(sys.stdin)\nrequired = ("metadatabase", "scheduler", "dag_processor", "triggerer")\nfailed = []\nfor name in required:\n    status = (payload.get(name) or {}).get("status")\n    if status != "healthy":\n        failed.append(f"{name}={status!r}")\nif failed:\n    print(", ".join(failed), file=sys.stderr)\n    raise SystemExit(1)\n'; then
+        return 0
+      fi
+    fi
+
+    sleep "$${sleep_seconds}"
+  done
+
+  echo "Timed out waiting for Airflow health endpoint to report all required components healthy." >&2
+  if [[ -n "$${payload}" ]]; then
+    printf '%s\n' "$${payload}" >&2
+  fi
+  return 1
+}
+
+wait_for_airflow_dag_run_state() {
+  local dag_id="$1"
+  local expected_state="$2"
+  local expected_run_type="$${3:-}"
+  local max_attempts="$${4:-120}"
+  local sleep_seconds="$${5:-2}"
+  local payload=""
+  local status
+  local attempt
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if payload="$(curl --retry 1 --retry-all-errors --retry-delay 0 -fsS "http://127.0.0.1:8080/api/v2/dags/$${dag_id}/dagRuns?limit=20&order_by=-start_date" 2>/dev/null)"; then
+      if printf '%s' "$${payload}" | EXPECTED_STATE="$${expected_state}" EXPECTED_RUN_TYPE="$${expected_run_type}" python3 -c $'import json, os, sys\npayload = json.load(sys.stdin)\nexpected_state = os.environ["EXPECTED_STATE"]\nexpected_run_type = os.environ.get("EXPECTED_RUN_TYPE", "").strip()\nruns = payload.get("dag_runs") or []\nif expected_run_type:\n    runs = [run for run in runs if run.get("run_type") == expected_run_type]\nif not runs:\n    raise SystemExit(1)\nrun = runs[0]\nstate = (run.get("state") or "").lower()\nif state == expected_state.lower():\n    print(run.get("dag_run_id") or "")\n    raise SystemExit(0)\nif state in {"failed", "error"}:\n    print(json.dumps(run), file=sys.stderr)\n    raise SystemExit(2)\nraise SystemExit(1)\n'; then
+        return 0
+      else
+        status=$?
+        if [[ "$${status}" -eq 2 ]]; then
+          echo "Airflow DAG '$${dag_id}' reached a terminal failure state." >&2
+          printf '%s\n' "$${payload}" >&2
+          return 1
+        fi
+      fi
+    fi
+
+    sleep "$${sleep_seconds}"
+  done
+
+  echo "Timed out waiting for Airflow DAG '$${dag_id}' to reach state '$${expected_state}'." >&2
+  if [[ -n "$${payload}" ]]; then
+    printf '%s\n' "$${payload}" >&2
+  fi
+  return 1
+}
+
+serving_surface_ready() {
+  if ! curl --retry 1 --retry-all-errors --retry-delay 0 -fsS "$${app_health_url}" >/dev/null 2>&1; then
+    return 1
+  fi
+
+  curl --retry 1 --retry-all-errors --retry-delay 0 -fsS -X POST -H "Content-Type: application/json" -d '{}' "$${online_features_url}" >/dev/null 2>&1
+}
+
+bootstrap_serving_surface() {
+  echo "Hosted runtime not ready; triggering feature and training convergence."
+  docker compose "$${compose_args[@]}" exec -T airflow-webserver \
+    airflow dags trigger feature_pipeline \
+    --logical-date "$${feature_logical_date}" \
+    --run-id "$${feature_run_id}" >/dev/null
+
+  echo "Waiting for hosted feature pipeline..."
+  wait_for_airflow_dag_run_state feature_pipeline success manual 120 2
+
+  echo "Waiting for asset-triggered training pipeline..."
+  wait_for_airflow_dag_run_state training_pipeline success asset_triggered 120 2
+}
+
+verify_serving_surface() {
+  echo "Waiting for hosted app health..."
+  curl --retry 60 --retry-all-errors --retry-delay 2 -fsS "$${app_health_url}" >/dev/null
+
+  echo "Checking hosted online features..."
+  curl --retry 30 --retry-all-errors --retry-delay 2 -fsS -X POST -H "Content-Type: application/json" -d '{}' "$${online_features_url}" >/dev/null
+}
 
 git -C /opt/foehncast fetch --depth 1 origin "${git_ref}"
 git -C /opt/foehncast checkout --force FETCH_HEAD
 
-if docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env pull model-registry app airflow-init airflow-webserver airflow-dag-processor airflow-scheduler airflow-triggerer; then
+vacuum_host_logs
+
+if docker compose "$${compose_args[@]}" pull model-registry app airflow-init airflow-webserver airflow-dag-processor airflow-scheduler airflow-triggerer; then
   compose_deploy_mode="pull"
-  docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env up -d --no-build
+  docker compose "$${compose_args[@]}" up -d --no-build
 else
-  docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env up -d --build
+  docker compose "$${compose_args[@]}" up -d --build
 fi
+
+echo "Waiting for Airflow API server health..."
+verify_airflow_api_health 90 2
+
+if ! serving_surface_ready; then
+  bootstrap_serving_surface
+fi
+
+verify_serving_surface
 
 sync_timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
 sync_commit="$(git -C /opt/foehncast rev-parse HEAD)"

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -1059,8 +1059,17 @@ def test_terraform_grants_hosted_runtime_identities_bigquery_storage_and_bucket_
         'resource "google_storage_bucket_iam_member" "online_compose_bucket_admin"'
         in terraform
     )
+    assert (
+        'resource "google_storage_bucket_iam_member" "cloud_run_bucket_metadata_reader"'
+        in terraform
+    )
+    assert (
+        'resource "google_storage_bucket_iam_member" "online_compose_bucket_metadata_reader"'
+        in terraform
+    )
     assert 'role    = "roles/bigquery.readSessionUser"' in terraform
     assert 'role   = "roles/storage.objectAdmin"' in terraform
+    assert 'role   = "roles/storage.legacyBucketReader"' in terraform
     assert (
         "google_project_iam_member.cloud_run_bigquery_read_session_user," in terraform
     )
@@ -1069,6 +1078,25 @@ def test_terraform_grants_hosted_runtime_identities_bigquery_storage_and_bucket_
         in terraform
     )
     assert "google_storage_bucket_iam_member.online_compose_bucket_admin," in terraform
+    assert (
+        "google_storage_bucket_iam_member.cloud_run_bucket_metadata_reader,"
+        in terraform
+    )
+    assert (
+        "google_storage_bucket_iam_member.online_compose_bucket_metadata_reader,"
+        in terraform
+    )
+
+
+def test_terraform_forecast_feature_schema_tracks_direction_encoding_columns() -> None:
+    terraform = _read_text("terraform/main.tf")
+
+    assert 'name        = "wind_direction_10m_sin"' in terraform
+    assert 'description = "Cyclical sine encoding of 10 m wind direction."' in terraform
+    assert 'name        = "wind_direction_10m_cos"' in terraform
+    assert (
+        'description = "Cyclical cosine encoding of 10 m wind direction."' in terraform
+    )
 
 
 def test_online_compose_startup_template_prepares_writable_runtime_dirs() -> None:
@@ -1082,12 +1110,16 @@ def test_online_compose_startup_template_prepares_writable_runtime_dirs() -> Non
         in template
     )
     assert (
-        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync"
+        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/airflow /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync"
         in template
     )
+    assert "install -d -m 0775 /opt/foehncast/data/feast" in template
     assert "install -d -m 0755 /opt/foehncast/grafana_work/data" in template
     assert "chown -R $${airflow_uid}:0 /opt/foehncast/airflow" in template
     assert "chown -R $${app_uid}:$${app_uid} /opt/foehncast/.state" in template
+    assert "chown -R $${airflow_uid}:0 /opt/foehncast/.state/airflow" in template
+    assert "chown -R $${airflow_uid}:0 /opt/foehncast/.state/feast" in template
+    assert "chown -R $${airflow_uid}:0 /opt/foehncast/data/feast" in template
     assert (
         "chown -R $${grafana_uid}:$${grafana_uid} /opt/foehncast/grafana_work/data"
         in template
@@ -1112,12 +1144,16 @@ def test_online_compose_startup_template_prepares_writable_runtime_directories()
         in template
     )
     assert (
-        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync"
+        "install -d -m 0755 /opt/foehncast/.state /opt/foehncast/.state/airflow /opt/foehncast/.state/feast /opt/foehncast/.state/online-compose-sync"
         in template
     )
+    assert "install -d -m 0775 /opt/foehncast/data/feast" in template
     assert "install -d -m 0755 /opt/foehncast/grafana_work/data" in template
     assert "chown -R $${airflow_uid}:0 /opt/foehncast/airflow" in template
     assert "chown -R $${app_uid}:$${app_uid} /opt/foehncast/.state" in template
+    assert "chown -R $${airflow_uid}:0 /opt/foehncast/.state/airflow" in template
+    assert "chown -R $${airflow_uid}:0 /opt/foehncast/.state/feast" in template
+    assert "chown -R $${airflow_uid}:0 /opt/foehncast/data/feast" in template
     assert (
         "chown -R $${grafana_uid}:$${grafana_uid} /opt/foehncast/grafana_work/data"
         in template
@@ -1143,10 +1179,84 @@ def test_online_compose_startup_template_installs_periodic_repo_sync_timer() -> 
     assert "OnBootSec=2m" in template
     assert "OnUnitActiveSec=5m" in template
     assert "Persistent=true" in template
+    assert "compose_args=(" in template
+    assert "-f /opt/foehncast/docker-compose.yml" in template
+    assert "-f /opt/foehncast/docker-compose.cloud.yml" in template
+    assert "--env-file /opt/foehncast/.env" in template
     assert (
-        "docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env pull"
+        'docker compose "$${compose_args[@]}" pull model-registry app airflow-init airflow-webserver airflow-dag-processor airflow-scheduler airflow-triggerer'
         in template
     )
+
+
+def test_online_compose_startup_template_configures_docker_log_rotation() -> None:
+    template = _read_text("terraform/templates/online-compose-host.sh.tftpl")
+
+    assert template.index("journalctl --vacuum-size=100M") < template.index(
+        "apt-get update"
+    )
+    assert "install -d -m 0755 /etc/docker" in template
+    assert "cat > /etc/docker/daemon.json <<'EOF'" in template
+    assert '"log-driver": "json-file"' in template
+    assert '"max-size": "10m"' in template
+    assert '"max-file": "3"' in template
+    assert "journalctl --vacuum-size=100M" in template
+    assert (
+        r"find /var/lib/docker/containers -name '*-json.log' -type f -size +50M -exec truncate -s 0 {} \;"
+        in template
+    )
+    assert "systemctl restart docker" in template
+
+
+def test_online_compose_sync_template_repairs_serving_surface_when_cold() -> None:
+    template = _read_text("terraform/templates/online-compose-host.sh.tftpl")
+
+    assert (
+        'feature_logical_date="$${FEATURE_LOGICAL_DATE:-$(date -u +"%Y-%m-%dT%H:%M:%SZ")}"'
+        in template
+    )
+    assert (
+        'feature_run_id="$${FEATURE_RUN_ID:-hosted_sync__$(date -u +"%Y-%m-%dT%H-%M-%SZ")}"'
+        in template
+    )
+    assert (
+        'airflow_health_url="http://127.0.0.1:8080/api/v2/monitor/health"' in template
+    )
+    assert 'app_health_url="http://127.0.0.1:8000/health"' in template
+    assert 'online_features_url="http://127.0.0.1:8000/features/online"' in template
+    assert "verify_airflow_api_health() {" in template
+    assert "wait_for_airflow_dag_run_state() {" in template
+    assert "serving_surface_ready() {" in template
+    assert "bootstrap_serving_surface() {" in template
+    assert "verify_serving_surface() {" in template
+    assert (
+        "airflow dags trigger feature_pipeline \\\n"
+        '    --logical-date "$${feature_logical_date}" \\\n'
+        '    --run-id "$${feature_run_id}" >/dev/null' in template
+    )
+    assert (
+        'curl --retry 1 --retry-all-errors --retry-delay 0 -fsS -X POST -H "Content-Type: application/json" -d \'{}\' "$${online_features_url}" >/dev/null 2>&1'
+        in template
+    )
+    assert (
+        'curl --retry 30 --retry-all-errors --retry-delay 2 -fsS -X POST -H "Content-Type: application/json" -d \'{}\' "$${online_features_url}" >/dev/null'
+        in template
+    )
+    assert (
+        "wait_for_airflow_dag_run_state feature_pipeline success manual 120 2"
+        in template
+    )
+    assert (
+        "wait_for_airflow_dag_run_state training_pipeline success asset_triggered 120 2"
+        in template
+    )
+    assert (
+        'echo "Hosted runtime not ready; triggering feature and training convergence."'
+        in template
+    )
+    assert 'echo "Waiting for hosted feature pipeline..."' in template
+    assert "if ! serving_surface_ready; then" in template
+    assert 'echo "Checking hosted online features..."' in template
 
 
 def test_online_compose_sync_template_records_last_success_status_file() -> None:
@@ -1189,6 +1299,14 @@ def test_terraform_runtime_iam_includes_bigquery_storage_api_and_bucket_access()
         'resource "google_storage_bucket_iam_member" "online_compose_bucket_admin"'
         in terraform
     )
+    assert (
+        'resource "google_storage_bucket_iam_member" "cloud_run_bucket_metadata_reader"'
+        in terraform
+    )
+    assert (
+        'resource "google_storage_bucket_iam_member" "online_compose_bucket_metadata_reader"'
+        in terraform
+    )
 
 
 def test_terraform_grants_github_deployer_firestore_admin() -> None:
@@ -1203,6 +1321,10 @@ def test_terraform_grants_github_deployer_firestore_admin() -> None:
         in terraform
     )
     assert "google_storage_bucket_iam_member.online_compose_bucket_admin" in terraform
+    assert (
+        "google_storage_bucket_iam_member.online_compose_bucket_metadata_reader"
+        in terraform
+    )
 
 
 def test_bootstrap_gcp_reports_hosted_feast_follow_up_step() -> None:
@@ -1222,6 +1344,46 @@ def test_bootstrap_gcp_requires_curl_for_hosted_runtime_verification() -> None:
     bootstrap = _read_text("scripts/bootstrap-gcp.sh")
 
     assert "require_command curl" in bootstrap
+
+
+def test_bootstrap_gcp_initializes_terraform_with_derived_remote_backend() -> None:
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert "terraform_init_args=(" in bootstrap
+    assert '-backend-config="bucket=$(terraform_remote_state_bucket)"' in bootstrap
+    assert '-backend-config="prefix=$(terraform_remote_state_prefix)"' in bootstrap
+    assert (
+        'if [[ "$BOOTSTRAP_ONLY" == "true" && "$PLAN_ONLY" != "true" ]]; then'
+        in bootstrap
+    )
+    assert "  ensure_remote_state_bucket" in bootstrap
+
+
+def test_bootstrap_gcp_normalizes_custom_env_and_tfvars_paths() -> None:
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert "resolve_invocation_path()" in bootstrap
+    assert 'ENV_FILE="$(resolve_invocation_path "$ENV_FILE")"' in bootstrap
+    assert 'TFVARS_FILE="$(resolve_invocation_path "$TFVARS_FILE")"' in bootstrap
+
+
+def test_bootstrap_gcp_uses_isolated_terraform_dir_for_remote_backend() -> None:
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert (
+        'TEMP_TERRAFORM_DIR="$(mktemp -d "${TMPDIR:-/tmp}/foehncast-terraform.XXXXXX")"'
+        in bootstrap
+    )
+    assert 'cp -R "${ROOT_DIR}/terraform/." "$TEMP_TERRAFORM_DIR/"' in bootstrap
+    assert 'rm -rf "$TEMP_TERRAFORM_DIR/.terraform"' in bootstrap
+    assert (
+        'rm -f "$TEMP_TERRAFORM_DIR/terraform.tfstate" "$TEMP_TERRAFORM_DIR/terraform.tfstate.backup"'
+        in bootstrap
+    )
+    assert (
+        'echo "Using an isolated Terraform working directory so local state files do not interfere with remote backend initialization."'
+        in bootstrap
+    )
 
 
 def test_bootstrap_gcp_reports_online_compose_urls_when_hosted_vm_is_enabled() -> None:

--- a/tests/test_feast_runtime.py
+++ b/tests/test_feast_runtime.py
@@ -126,6 +126,62 @@ def test_render_runtime_config_replaces_non_writable_existing_file(
     assert rendered_path.stat().st_mode & 0o222
 
 
+def test_render_runtime_config_reuses_matching_non_writable_existing_file(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_path = tmp_path / "feature_repo"
+    repo_path.mkdir()
+
+    monkeypatch.setenv("FOEHNCAST_FEAST_REPO_PATH", str(repo_path))
+    monkeypatch.delenv("FOEHNCAST_FEAST_SOURCE", raising=False)
+    monkeypatch.delenv("FOEHNCAST_FEAST_CONFIG_PATH", raising=False)
+
+    destination = tmp_path / ".state" / "feast" / "feature_store.runtime.yaml"
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    destination.write_text(
+        yaml.safe_dump(
+            {
+                "project": "foehncast",
+                "entity_key_serialization_version": 3,
+                "registry": "../.state/feast/registry.db",
+                "provider": "gcp",
+                "offline_store": {"type": "file"},
+                "online_store": {
+                    "type": "datastore",
+                    "project_id": "foehncast-local",
+                },
+            },
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    destination.chmod(0o444)
+
+    real_unlink = Path.unlink
+
+    def fail_unlink(self: Path, missing_ok: bool = False) -> None:
+        if self == destination:
+            raise AssertionError("matching runtime config should not be unlinked")
+        real_unlink(self, missing_ok=missing_ok)
+
+    monkeypatch.setattr(Path, "unlink", fail_unlink)
+
+    rendered_path = feast_runtime.render_runtime_config()
+
+    assert rendered_path == destination
+    assert yaml.safe_load(rendered_path.read_text()) == {
+        "project": "foehncast",
+        "entity_key_serialization_version": 3,
+        "registry": "../.state/feast/registry.db",
+        "provider": "gcp",
+        "offline_store": {"type": "file"},
+        "online_store": {
+            "type": "datastore",
+            "project_id": "foehncast-local",
+        },
+    }
+
+
 def test_render_runtime_config_tolerates_permission_error_on_chmod(
     monkeypatch, tmp_path: Path
 ) -> None:

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -244,8 +244,13 @@ def test_write_features_bigquery_uses_load_job(
             captured["table_id"] = table_id
             captured["frame"] = frame.copy()
             captured["write_disposition"] = job_config.write_disposition
-            captured["time_partitioning"] = job_config.time_partitioning
-            captured["clustering_fields"] = job_config.clustering_fields
+            captured["time_partitioning"] = getattr(
+                job_config, "time_partitioning", None
+            )
+            captured["clustering_fields"] = getattr(
+                job_config, "clustering_fields", None
+            )
+            captured["schema_update_options"] = job_config.schema_update_options
             return FakeLoadJob()
 
         def query(self, query: str, job_config: object | None = None) -> FakeDeleteJob:
@@ -291,6 +296,9 @@ def test_write_features_bigquery_uses_load_job(
             LoadJobConfig=FakeLoadJobConfig,
             QueryJobConfig=FakeQueryJobConfig,
             ScalarQueryParameter=FakeScalarQueryParameter,
+            SchemaUpdateOption=types.SimpleNamespace(
+                ALLOW_FIELD_ADDITION="ALLOW_FIELD_ADDITION"
+            ),
             TimePartitioning=FakeTimePartitioning,
             TimePartitioningType=types.SimpleNamespace(DAY="DAY"),
         ),
@@ -322,11 +330,9 @@ def test_write_features_bigquery_uses_load_job(
     assert captured["project"] == "demo-project"
     assert captured["table_id"] == "demo-project.foehncast.forecast_features"
     assert captured["write_disposition"] == "WRITE_APPEND"
-    assert captured["time_partitioning"].field == "forecast_time"
-    assert captured["time_partitioning"].type_ == "DAY"
-    assert captured["time_partitioning"].expiration_ms == 63072000000
-    assert captured["time_partitioning"].require_partition_filter is False
-    assert captured["clustering_fields"] == ["dataset_name", "spot_id"]
+    assert captured["time_partitioning"] is None
+    assert captured["clustering_fields"] is None
+    assert captured["schema_update_options"] == ["ALLOW_FIELD_ADDITION"]
     assert captured["delete_completed"] is True
     assert captured["job_completed"] is True
     assert (
@@ -341,6 +347,111 @@ def test_write_features_bigquery_uses_load_job(
     assert list(written["spot_id"]) == ["silvaplana", "silvaplana"]
     assert list(written["dataset_name"]) == ["train", "train"]
     assert "forecast_time" in written.columns
+
+
+def test_write_features_bigquery_applies_contract_when_table_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+    isolated_store_env: None,
+    sample_features: pd.DataFrame,
+):
+    captured: dict[str, object] = {}
+
+    class FakeLoadJob:
+        def result(self) -> None:
+            captured["job_completed"] = True
+
+    class FakeClient:
+        def __init__(self, project: str) -> None:
+            captured["project"] = project
+
+        def get_table(self, table_id: str) -> object:
+            captured["missing_table_id"] = table_id
+            raise KeyError(table_id)
+
+        def load_table_from_dataframe(
+            self, frame: pd.DataFrame, table_id: str, job_config: object
+        ) -> FakeLoadJob:
+            captured["table_id"] = table_id
+            captured["frame"] = frame.copy()
+            captured["write_disposition"] = job_config.write_disposition
+            captured["time_partitioning"] = job_config.time_partitioning
+            captured["clustering_fields"] = job_config.clustering_fields
+            captured["schema_update_options"] = job_config.schema_update_options
+            return FakeLoadJob()
+
+        def query(self, query: str, job_config: object | None = None) -> object:
+            captured["unexpected_delete_query"] = query
+            raise AssertionError(
+                "delete should not run when the BigQuery table is absent"
+            )
+
+    class FakeLoadJobConfig:
+        def __init__(self, write_disposition: str, **kwargs: object) -> None:
+            self.write_disposition = write_disposition
+            for name, value in kwargs.items():
+                setattr(self, name, value)
+
+    class FakeTimePartitioning:
+        def __init__(
+            self,
+            *,
+            type_: object,
+            field: str,
+            expiration_ms: int,
+            require_partition_filter: bool,
+        ) -> None:
+            self.type_ = type_
+            self.field = field
+            self.expiration_ms = expiration_ms
+            self.require_partition_filter = require_partition_filter
+
+    monkeypatch.setattr(
+        store,
+        "_bigquery_module",
+        lambda: types.SimpleNamespace(
+            Client=FakeClient,
+            LoadJobConfig=FakeLoadJobConfig,
+            SchemaUpdateOption=types.SimpleNamespace(
+                ALLOW_FIELD_ADDITION="ALLOW_FIELD_ADDITION"
+            ),
+            TimePartitioning=FakeTimePartitioning,
+            TimePartitioningType=types.SimpleNamespace(DAY="DAY"),
+        ),
+    )
+    monkeypatch.setattr(
+        store,
+        "_google_exceptions_module",
+        lambda: types.SimpleNamespace(NotFound=KeyError),
+    )
+    monkeypatch.setattr(
+        store,
+        "get_storage_config",
+        lambda: {
+            "backend": "bigquery",
+            "bigquery_project_id": "demo-project",
+            "bigquery_dataset": "foehncast",
+            "bigquery_table": "forecast_features",
+        },
+    )
+
+    frame = sample_features.copy()
+    frame.index = pd.to_datetime(["2025-01-01T00:00:00", "2025-01-01T01:00:00"])
+    frame.index.name = "time"
+    frame["spot_name"] = ["Silvaplana", "Silvaplana"]
+
+    store.write_features(frame, spot_id="silvaplana", dataset="train")
+
+    assert captured["project"] == "demo-project"
+    assert captured["missing_table_id"] == "demo-project.foehncast.forecast_features"
+    assert captured["table_id"] == "demo-project.foehncast.forecast_features"
+    assert captured["write_disposition"] == "WRITE_APPEND"
+    assert captured["time_partitioning"].field == "forecast_time"
+    assert captured["time_partitioning"].type_ == "DAY"
+    assert captured["time_partitioning"].expiration_ms == 63072000000
+    assert captured["time_partitioning"].require_partition_filter is False
+    assert captured["clustering_fields"] == ["dataset_name", "spot_id"]
+    assert captured["schema_update_options"] == ["ALLOW_FIELD_ADDITION"]
+    assert captured["job_completed"] is True
 
 
 def test_read_features_bigquery_restores_time_index(


### PR DESCRIPTION
What changed:
- restored the hosted Terraform bucket metadata IAM and curated BigQuery schema contract
- hardened the online compose host startup and sync template for writable runtime paths, log rotation, and serving-surface convergence
- normalized bootstrap-gcp remote-backend planning from a clean checkout and avoided redundant Feast runtime rewrites

Why:
- main still drifted from the healthy hosted stack after PR #189, and a clean remote-backend plan would otherwise remove required IAM, change the BigQuery contract, and replace the online compose VM

Verification:
- `uv run pytest tests/test_cloud_operator_contract.py tests/test_feast_runtime.py tests/test_store.py`
- `terraform plan -lock=false -var-file=/tmp/foehncast-190/terraform/terraform.tfvars` against backend `bucket=mlops-hslu-h4izq-foehncast-tfstate`, `prefix=terraform/state` from the isolated branch, resulting in only the online compose VM replacement

Closes: #190