### PR TITLE
chore(config): inventory cloud runtime secrets and ownership

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,7 @@
 # bootstrap-local.sh and bootstrap-gcp.sh create .env from this template.
+# Checked-in values here are local-safe placeholders and structural examples.
+# Shared cloud runtime secrets should be injected at runtime or by a managed
+# secret path, not committed here or copied into GitHub repository variables.
 
 # GCP
 # Use gcloud ADC locally and GitHub OIDC in CI/CD. Do not commit service account keys.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -7,8 +7,10 @@ If you discover a security vulnerability, please report it by opening a private 
 ## Secrets Management
 
 - API keys and credentials must never be committed to the repository.
-- Use `.env` files locally (listed in `.gitignore`).
-- Use GitHub Actions secrets for CI/CD.
+- Use `.env` files locally for disposable or developer-specific secrets, and keep them out of git.
+- Use GitHub repository variables for non-secret cloud identifiers and rollout inputs only.
+- Prefer GitHub OIDC for CI/CD cloud auth instead of stored service account keys.
+- Put shared cloud runtime secrets in the runtime environment or a managed secret path, not in committed examples or repository-variable sync.
 
 ## Dependencies
 

--- a/docs/site/system/configuration-and-contracts.md
+++ b/docs/site/system/configuration-and-contracts.md
@@ -93,6 +93,25 @@ The checked-in `.env.example` shows the kind of values that belong in runtime wi
 
 These values describe one concrete runtime instance. They should stay overridable because the local evaluator, hosted full-stack target, and hosted inference target do not all bind to the same services. The maintainer rollout split for `terraform.tfvars` versus GitHub delivery variables is described in [Delivery and Operator Workflow](delivery-and-operator-workflow.md).
 
+## Cloud Runtime Inventory
+
+The shared cloud path uses four value surfaces plus identity-backed auth. The important split is between structural delivery inputs and secret-bearing runtime inputs.
+
+| Source surface | What shows up there today | Owned by | Consumed by | Secret rule |
+|------|---------------------------|----------|-------------|-------------|
+| checked-in examples and repo defaults | `.env.example` placeholders, `terraform/terraform.tfvars.example`, checked-in operator docs | repository | bootstrap prompts, local operators, reviewers | structural examples only; never live credentials |
+| bootstrap outputs in the working tree | `.env`, `terraform/terraform.tfvars`, Terraform outputs echoed by `./scripts/bootstrap-gcp.sh` | maintainer running bootstrap for one environment | local preview applies, bootstrap verification, `scripts/configure-github-actions.sh` | structural hosted identifiers and toggles only; not a long-term secret store |
+| GitHub repository variables | `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_ARTIFACT_REPOSITORY`, `GCP_BIGQUERY_*`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT_EMAIL`, Cloud Run sizing and enablement flags | GitHub delivery control plane, normally synced from Terraform outputs | `.github/workflows/terraform.yml`, image-publish workflows, repo-config action | structural delivery contract only; do not store runtime passwords, API tokens, or key files here |
+| runtime `.env` and hosted runtime env vars | `MLFLOW_TRACKING_URI`, `AIRFLOW__API_AUTH__JWT_SECRET`, `FOEHNCAST_GRAFANA_ADMIN_*`, `GRAFANA_API_*`, `cloud_run_env_vars`, `online_compose_env_vars` | runtime operator or platform for one running surface | local evaluator, hosted compose stack, Cloud Run service, Grafana and Airflow auth checks | mixed runtime wiring; secret-bearing values should stay local-only or move to Secret Manager or another managed secret path |
+| identity-backed auth surfaces | GitHub OIDC, Cloud Run service account, compose-host VM service account | repository admin plus GCP IAM | GitHub workflows and hosted runtimes | prefer identities over stored cloud credentials; not a secret distribution path |
+
+This inventory keeps the current boundary explicit:
+
+- `config.yaml` keeps workload semantics.
+- `terraform/terraform.tfvars` and GitHub repository variables keep structural hosted rollout inputs.
+- runtime `.env` and hosted env injections carry concrete per-environment wiring.
+- secret-bearing runtime values should not move into committed examples or repository variables just because they are cloud-facing.
+
 ## Storage And Warehouse Contract
 
 The storage boundary is intentionally narrow.

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -103,6 +103,8 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 
 This contract is deliberate. The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as container port, CPU, and memory stay repo-variable-backed instead of becoming more manual workflow inputs.
 
+That same split is also the current ownership boundary for cloud-facing values. Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables remain structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
+
 ## What The Cloud-Operator Tests Enforce
 
 The cloud-operator tests keep the delivery path honest in a few specific ways:

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -178,6 +178,10 @@ The normal shared-environment path is:
 
 In normal operation you should not edit these variables by hand. The bootstrap path seeds the shared contract automatically. Remote applies also attempt to resync it, but GitHub's default workflow token may not be allowed to edit repository variables in every repository configuration.
 
+These repository variables are the structural hosted-delivery contract. They are appropriate for project IDs, regions, resource names, topology toggles, and service-account identifiers. They are not the place for runtime passwords, API tokens, or service-account key files.
+
+If the shared cloud runtime later needs secret-bearing values beyond local-safe placeholders, inject them into the hosted runtime environment or a managed secret path instead of adding them to GitHub repository variables. Endpoints such as `GCP_MLFLOW_TRACKING_URI` should stay credential-free; if auth is required later, inject that secret separately at runtime.
+
 `GCP_CLOUD_RUN_SERVICE` stays unset until Terraform has actually provisioned the Cloud Run service. After that, publish automation can update the service with newly built images.
 
 When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health` plus `/spots`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.


### PR DESCRIPTION
## What changed
- clarify that checked-in examples such as `.env.example` are structural placeholders, not a place to carry shared cloud runtime secrets
- tighten the security guidance so GitHub repository variables are treated as non-secret delivery inputs while secret-bearing runtime values stay in runtime env injection or a managed secret path
- add a reviewed cloud runtime inventory to the public configuration docs, covering checked-in examples, bootstrap outputs, GitHub repository variables, runtime env injection, and identity-backed auth surfaces
- link the delivery workflow and Terraform docs back to that ownership boundary so later Cloud Run and orchestration work has one stable source of truth

## Why
- the project needed one explicit inventory of cloud-facing values before Cloud Run promotion and later orchestration work could build on the shared delivery contract safely
- this separates structural hosted rollout inputs from secret-bearing runtime inputs instead of letting all cloud-facing values drift into the same bucket

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/foehncast && PYTHONPATH="$PWD/src" /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/pytest tests/test_cloud_operator_contract.py`
- `cd /Users/jvr/github/HSLU/MLOPS/foehncast && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #195
