### PR TITLE
feature(security): split hosted runtime identities by responsibility

### DIFF
--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -73,6 +73,14 @@ The hosted full-stack target currently relies on these shared runtime dependenci
 
 That service account is expected to cover BigQuery jobs, BigQuery Storage API read sessions, bucket object access for MLflow and Feast, and Datastore access. The goal is to let the hosted containers read the shared cloud surfaces directly without inventing a separate credential path.
 
+The identity split around this target is deliberate:
+
+- GitHub Actions uses the deployer identity for Terraform apply, image publish, and Cloud Run rollout work.
+- Cloud Run uses its own narrower runtime identity for the inference-only service.
+- the online compose host uses a separate runtime identity because it still bundles Airflow, training, MLflow, Feast preparation, and the app on one VM.
+
+That online compose runtime identity is the current transition contract, not the preferred steady-state shape for every managed runtime. It remains broader than the Cloud Run identity only because the host still owns more responsibilities today.
+
 ## Bootstrap And Day-2 Delivery
 
 The hosted full-stack target is not part of the default contributor path. Its lifecycle is split into two layers:

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -215,6 +215,9 @@ read_tfvars_value() {
 
     echo "Local auth: browser-based gcloud ADC on this machine"
     echo "Cloud Run runtime service account: ${FOEHNCAST_TF_RUNTIME_SERVICE_ACCOUNT}"
+    if [[ "$FOEHNCAST_TF_PROVISION_ONLINE_COMPOSE_HOST" == "true" && -n "$FOEHNCAST_TF_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT" ]]; then
+      echo "Online compose runtime service account: ${FOEHNCAST_TF_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT}"
+    fi
     echo "GitHub deployer service account: ${FOEHNCAST_TF_SERVICE_ACCOUNT_EMAIL}"
 
     if [[ -n "$FOEHNCAST_TF_CLOUD_RUN_SERVICE" ]]; then
@@ -368,6 +371,9 @@ read_tfvars_value() {
 
     echo "Bootstrap-only remote state bucket: gs://${state_bucket}"
     echo "Bootstrap-only remote state prefix: ${state_prefix}"
+    if [[ "$FOEHNCAST_TF_PROVISION_ONLINE_COMPOSE_HOST" == "true" && -n "$FOEHNCAST_TF_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT" ]]; then
+      echo "Online compose runtime service account: ${FOEHNCAST_TF_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT}"
+    fi
     echo "GitHub deployer service account: ${FOEHNCAST_TF_SERVICE_ACCOUNT_EMAIL}"
     echo "GitHub workload identity provider: ${FOEHNCAST_TF_WORKLOAD_IDENTITY_PROVIDER}"
     echo "Next step: run ./scripts/terraform-remote.sh apply to provision the broader platform through the remote backend."

--- a/scripts/terraform-platform-state.sh
+++ b/scripts/terraform-platform-state.sh
@@ -197,6 +197,7 @@ load_terraform_platform_state() {
   FOEHNCAST_TF_WORKLOAD_IDENTITY_PROVIDER="$(optional_terraform_output_value "$terraform_dir" github_workload_identity_provider)"
   FOEHNCAST_TF_SERVICE_ACCOUNT_EMAIL="$(optional_terraform_output_value "$terraform_dir" github_deployer_service_account)"
   FOEHNCAST_TF_RUNTIME_SERVICE_ACCOUNT="$(optional_terraform_output_value "$terraform_dir" cloud_run_runtime_service_account)"
+  FOEHNCAST_TF_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT="$(optional_terraform_output_value "$terraform_dir" online_compose_runtime_service_account)"
   FOEHNCAST_TF_PROVISION_CLOUD_RUN_SERVICE="$(terraform_output_or_tfvars_value "$terraform_dir" provision_cloud_run_service provision_cloud_run_service)"
   FOEHNCAST_TF_CLOUD_RUN_SERVICE_NAME="$(terraform_output_or_tfvars_value "$terraform_dir" configured_cloud_run_service_name cloud_run_service_name)"
   FOEHNCAST_TF_CLOUD_RUN_CONTAINER_PORT="$(terraform_output_or_tfvars_value "$terraform_dir" configured_cloud_run_container_port cloud_run_container_port)"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -72,6 +72,8 @@ Terraform already injects the default BigQuery storage environment for the Cloud
 That runtime service account includes both BigQuery job access and BigQuery Storage API read-session access so pandas-backed BigQuery reads can succeed without falling back to mounted credentials.
 Terraform also injects the Feast runtime env contract for the hosted app path: the service gets `FOEHNCAST_FEAST_SOURCE=bigquery`, the managed bucket-backed registry and staging paths, the fully-qualified curated BigQuery table reference used by the rendered Feast runtime config, and the named Datastore-mode database used for Feast online serving.
 
+This Cloud Run runtime identity is intentionally narrower than the other hosted identities. It exists to serve the inference API, not to act as the general operator or deployment account.
+
 ## Hosted Full-Stack Target Inputs
 
 When `provision_online_compose_host = true`, provide:
@@ -91,6 +93,8 @@ The app exposes that status through Prometheus `/metrics`, and Grafana shows it 
 Terraform also creates a Firestore Datastore-mode database for Feast online serving. Using a named database keeps this setup separate from any default Firestore state in the project.
 
 The VM uses a dedicated service account with access to BigQuery jobs, BigQuery Storage API read sessions, BigQuery dataset edits, bucket objects for MLflow and Feast, and Datastore. This lets the Airflow, training, Feast, app, and MLflow containers use Application Default Credentials instead of key files.
+
+That broader VM identity is transitional by design. GitHub delivery uses the separate `github-actions-deployer` identity, and Cloud Run uses the separate `foehncast-cloud-run` runtime identity. The online compose host keeps the broader `foehncast-online-compose` identity only because the current VM still combines operator, training, and serving responsibilities on one machine.
 
 When curated BigQuery rows are ready, run `./scripts/prepare-feast-cloud.sh` on the host, or from another shell with ADC, to apply the Feast repo and materialize the hosted online store.
 

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -63,6 +63,11 @@ output "cloud_run_runtime_service_account" {
   value       = try(google_service_account.cloud_run_runtime.email, "foehncast-cloud-run@${var.project_id}.iam.gserviceaccount.com")
 }
 
+output "online_compose_runtime_service_account" {
+  description = "Service account intended for the online compose host runtime when that target is enabled."
+  value       = var.provision_online_compose_host ? try(google_service_account.online_compose_runtime[0].email, "foehncast-online-compose@${var.project_id}.iam.gserviceaccount.com") : null
+}
+
 output "provision_cloud_run_service" {
   description = "Whether Terraform is configured to provision the Cloud Run inference service."
   value       = var.provision_cloud_run_service

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -1071,6 +1071,37 @@ def test_terraform_grants_hosted_runtime_identities_bigquery_storage_and_bucket_
     assert "google_storage_bucket_iam_member.online_compose_bucket_admin," in terraform
 
 
+def test_terraform_outputs_split_runtime_identity_contract() -> None:
+    outputs = _read_text("terraform/outputs.tf")
+
+    assert 'output "github_deployer_service_account"' in outputs
+    assert 'output "cloud_run_runtime_service_account"' in outputs
+    assert 'output "online_compose_runtime_service_account"' in outputs
+    assert (
+        'value       = var.provision_online_compose_host ? try(google_service_account.online_compose_runtime[0].email, "foehncast-online-compose@${var.project_id}.iam.gserviceaccount.com") : null'
+        in outputs
+    )
+
+
+def test_platform_state_tracks_online_compose_identity_without_repo_var_sync() -> None:
+    load_body = _function_body(
+        "scripts/terraform-platform-state.sh", "load_terraform_platform_state"
+    )
+    names_body = _function_body(
+        "scripts/terraform-platform-state.sh", "terraform_repo_variable_names"
+    )
+    pairs_body = _function_body(
+        "scripts/terraform-platform-state.sh", "terraform_repo_variable_pairs"
+    )
+
+    assert (
+        'FOEHNCAST_TF_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT="$(optional_terraform_output_value "$terraform_dir" online_compose_runtime_service_account)"'
+        in load_body
+    )
+    assert "GCP_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT" not in names_body
+    assert "GCP_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT" not in pairs_body
+
+
 def test_online_compose_startup_template_prepares_writable_runtime_dirs() -> None:
     template = _read_text("terraform/templates/online-compose-host.sh.tftpl")
 
@@ -1258,6 +1289,27 @@ def test_bootstrap_gcp_reports_cloud_run_url_when_service_is_enabled() -> None:
     assert 'echo "Cloud Run service URL: ${service_url}"' in bootstrap
     assert (
         'echo "Cloud Run allows unauthenticated access: ${FOEHNCAST_TF_CLOUD_RUN_ALLOW_UNAUTHENTICATED}"'
+        in bootstrap
+    )
+
+
+def test_bootstrap_gcp_reports_split_runtime_identities() -> None:
+    bootstrap = _read_text("scripts/bootstrap-gcp.sh")
+
+    assert (
+        'echo "Cloud Run runtime service account: ${FOEHNCAST_TF_RUNTIME_SERVICE_ACCOUNT}"'
+        in bootstrap
+    )
+    assert (
+        'echo "GitHub deployer service account: ${FOEHNCAST_TF_SERVICE_ACCOUNT_EMAIL}"'
+        in bootstrap
+    )
+    assert (
+        'echo "Online compose runtime service account: ${FOEHNCAST_TF_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT}"'
+        in bootstrap
+    )
+    assert (
+        'if [[ "$FOEHNCAST_TF_PROVISION_ONLINE_COMPOSE_HOST" == "true" && -n "$FOEHNCAST_TF_ONLINE_COMPOSE_RUNTIME_SERVICE_ACCOUNT" ]]; then'
         in bootstrap
     )
 


### PR DESCRIPTION
## What changed
- tighten the hosted runtime identity contract in the operator docs, bootstrap helpers, Terraform outputs, and cloud-operator regression checks
- make the current online compose host identity an explicit transition contract instead of an accidental shared runtime default
- expose the hosted identity state through Terraform outputs and platform-state wiring so the operator surface can verify the intended split

## Why
- GitHub apply, Cloud Run serving, and the retained operator host should not all depend on one broad runtime identity by default
- this locks the current transition shape into an explicit reviewed contract before later serving and orchestration work narrows the public runtime boundary further

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-196 && PYTHONPATH="$PWD/src" /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/pytest tests/test_cloud_operator_contract.py`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-196 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #196
