### PR TITLE
feature(feast): confirm hosted cloud-serving contract

### DIFF
--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -81,6 +81,13 @@ The identity split around this target is deliberate:
 
 That online compose runtime identity is the current transition contract, not the preferred steady-state shape for every managed runtime. It remains broader than the Cloud Run identity only because the host still owns more responsibilities today.
 
+For Feast specifically, the hosted full-stack target is expected to stay aligned with the Cloud Run path on one logical contract:
+
+- both hosted targets render `.state/feast/feature_store.runtime.yaml` from environment instead of carrying separate handwritten hosted configs
+- both hosted targets use the same registry and staging layout under `gs://<artifact-bucket>/feast/`
+- both hosted targets point Feast offline reads at the same curated BigQuery table contract
+- both hosted targets point Feast online serving at the same named Datastore-mode database unless an environment override is intentional
+
 ## Bootstrap And Day-2 Delivery
 
 The hosted full-stack target is not part of the default contributor path. Its lifecycle is split into two layers:

--- a/feature_repo/README.md
+++ b/feature_repo/README.md
@@ -77,6 +77,20 @@ The current cloud contract is:
 - the bootstrap and Terraform-managed hosted runtimes normally populate the project, registry, staging, and Datastore settings for the shared environment
 - `./scripts/prepare-feast-cloud.sh` renders the active runtime config, applies the repo, and materializes the hosted online store
 
+The hosted VM and Cloud Run targets are expected to share these bindings:
+
+| Binding | Shared hosted value |
+|------|----------------------|
+| runtime source | `FOEHNCAST_FEAST_SOURCE=bigquery` |
+| rendered config path | `.state/feast/feature_store.runtime.yaml` |
+| registry | `gs://<artifact-bucket>/feast/registry.db` |
+| staging | `gs://<artifact-bucket>/feast/staging` |
+| offline source | curated BigQuery table `<project>.<dataset>.<table>` |
+| default curated dataset | `foehncast` unless the environment overrides it |
+| online store | Datastore-mode database `feast-online` unless the environment overrides it |
+
+The checked-in `feature_store.gcp.yaml.example` is a reference for that same hosted contract. The running hosted targets do not consume it directly; they consume the rendered runtime config produced from environment.
+
 If another environment needs different defaults, override the Feast-specific BigQuery, registry, staging, or Datastore settings through the corresponding environment variables.
 
 Keep the storage roles separate:

--- a/feature_repo/feature_store.gcp.yaml.example
+++ b/feature_repo/feature_store.gcp.yaml.example
@@ -4,7 +4,7 @@ provider: gcp
 offline_store:
   type: bigquery
   project_id: your-gcp-project
-  dataset: feast
+  dataset: foehncast
   location: EU
   gcs_staging_location: gs://your-gcp-bucket/feast/staging
 online_store:
@@ -17,3 +17,6 @@ entity_key_serialization_version: 3
 # BigQuery table or view that exposes curated feature rows with spot_id and
 # forecast_time. A filtered view for the intended dataset split is the simplest
 # cloud hand-off from the current storage layer.
+# This checked-in example mirrors the shared hosted contract defaults. The
+# active hosted VM and Cloud Run targets render their real runtime config from
+# environment into .state/feast/feature_store.runtime.yaml instead.

--- a/src/foehncast/feast_runtime.py
+++ b/src/foehncast/feast_runtime.py
@@ -14,7 +14,7 @@ from foehncast.paths import project_root
 _DEFAULT_PROJECT = "foehncast"
 _DEFAULT_LOCAL_REGISTRY = "../.state/feast/registry.db"
 _DEFAULT_LOCAL_DATASTORE_PROJECT_ID = "foehncast-local"
-_DEFAULT_BIGQUERY_DATASET = "feast"
+_DEFAULT_BIGQUERY_DATASET = "foehncast"
 _DEFAULT_BIGQUERY_LOCATION = "EU"
 _DEFAULT_DATASTORE_DATABASE = "feast-online"
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -1037,9 +1037,54 @@ def test_terraform_injects_feast_runtime_contract_into_both_hosted_targets() -> 
     assert cloud_run_block is not None
     assert online_compose_block is not None
 
+    def extract_assignments(body: str) -> dict[str, str]:
+        assignments: dict[str, str] = {}
+        for line in body.splitlines():
+            match = re.match(r"\s*([A-Z0-9_]+)\s*=\s*(.+)$", line)
+            if match and match.group(1) in FEAST_CLOUD_ENV_KEYS:
+                assignments[match.group(1)] = match.group(2).rstrip()
+        return assignments
+
+    cloud_run_assignments = extract_assignments(cloud_run_block.group("body"))
+    online_compose_assignments = extract_assignments(online_compose_block.group("body"))
+
     for key in FEAST_CLOUD_ENV_KEYS:
-        assert key in cloud_run_block.group("body")
-        assert key in online_compose_block.group("body")
+        assert key in cloud_run_assignments
+        assert key in online_compose_assignments
+
+    assert cloud_run_assignments == online_compose_assignments
+    assert cloud_run_assignments == {
+        "FOEHNCAST_FEAST_SOURCE": '"bigquery"',
+        "FOEHNCAST_FEAST_PROJECT": '"foehncast"',
+        "FOEHNCAST_FEAST_PROJECT_ID": "var.project_id",
+        "FOEHNCAST_FEAST_REGISTRY": "local.feast_registry_uri",
+        "FOEHNCAST_FEAST_GCS_BUCKET": "var.artifact_bucket_name",
+        "FOEHNCAST_FEAST_GCS_STAGING_LOCATION": "local.feast_staging_uri",
+        "FOEHNCAST_FEAST_BIGQUERY_DATASET": "var.bigquery_dataset_id",
+        "FOEHNCAST_FEAST_BIGQUERY_LOCATION": "var.bigquery_location",
+        "FOEHNCAST_FEAST_BIGQUERY_TABLE": "local.feast_bigquery_table",
+        "FOEHNCAST_FEAST_DATASTORE_DATABASE": "var.feast_online_store_database_name",
+    }
+
+
+def test_feature_store_gcp_example_matches_hosted_contract_defaults() -> None:
+    config = _read_yaml("feature_repo/feature_store.gcp.yaml.example")
+
+    assert config["project"] == "foehncast"
+    assert config["registry"] == "gs://your-gcp-bucket/feast/registry.db"
+    assert config["provider"] == "gcp"
+    assert config["offline_store"] == {
+        "type": "bigquery",
+        "project_id": "your-gcp-project",
+        "dataset": "foehncast",
+        "location": "EU",
+        "gcs_staging_location": "gs://your-gcp-bucket/feast/staging",
+    }
+    assert config["online_store"] == {
+        "type": "datastore",
+        "project_id": "your-gcp-project",
+        "database": "feast-online",
+    }
 
 
 def test_terraform_grants_hosted_runtime_identities_bigquery_storage_and_bucket_access() -> (

--- a/tests/test_feast_runtime.py
+++ b/tests/test_feast_runtime.py
@@ -70,6 +70,38 @@ def test_render_runtime_config_uses_bigquery_bindings(
     }
 
 
+def test_render_runtime_config_uses_hosted_contract_defaults(
+    monkeypatch, tmp_path: Path
+) -> None:
+    repo_path = tmp_path / "feature_repo"
+    repo_path.mkdir()
+
+    monkeypatch.setenv("FOEHNCAST_FEAST_REPO_PATH", str(repo_path))
+    monkeypatch.setenv("FOEHNCAST_FEAST_SOURCE", "bigquery")
+    monkeypatch.setenv("GCP_PROJECT_ID", "demo-project")
+    monkeypatch.setenv("GCP_BUCKET_NAME", "demo-bucket")
+    monkeypatch.delenv("FOEHNCAST_FEAST_BIGQUERY_DATASET", raising=False)
+    monkeypatch.delenv("FOEHNCAST_FEAST_BIGQUERY_LOCATION", raising=False)
+    monkeypatch.delenv("FOEHNCAST_FEAST_DATASTORE_DATABASE", raising=False)
+
+    destination = feast_runtime.render_runtime_config()
+
+    rendered = yaml.safe_load(destination.read_text())
+    assert rendered["registry"] == "gs://demo-bucket/feast/registry.db"
+    assert rendered["offline_store"] == {
+        "type": "bigquery",
+        "project_id": "demo-project",
+        "dataset": "foehncast",
+        "location": "EU",
+        "gcs_staging_location": "gs://demo-bucket/feast/staging",
+    }
+    assert rendered["online_store"] == {
+        "type": "datastore",
+        "project_id": "demo-project",
+        "database": "feast-online",
+    }
+
+
 def test_render_runtime_config_allows_datastore_overrides(
     monkeypatch, tmp_path: Path
 ) -> None:


### PR DESCRIPTION
## What changed
- confirm that the hosted VM and Cloud Run targets share one logical Feast runtime contract instead of drifting through separate handwritten hosted configs
- document the shared registry, staging, BigQuery offline source, and Datastore online-store defaults in the Feast docs and hosted runtime docs
- align the runtime defaults in `src/foehncast/feast_runtime.py` and the checked-in GCP example with the shared hosted contract
- extend the cloud-operator and Feast runtime regression coverage to assert that both hosted targets render the same Feast environment bindings

## Why
- later storage, serving, and orchestration changes needed the Feast cloud-serving boundary locked down first
- this keeps the hosted full-stack target and Cloud Run on one reviewed serving contract instead of letting the hosted paths drift separately

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-197 && PYTHONPATH="$PWD/src" /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/pytest tests/test_cloud_operator_contract.py tests/test_feast_runtime.py`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-197 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #197
