### PR TITLE
feature(runtime): normalize hosted serving contract across VM and Cloud Run

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -666,31 +666,65 @@ jobs:
           if [[ -n "$online_compose_app_url" ]]; then
             online_compose_verification_status="passed"
             health_url="${online_compose_app_url%/}/health"
+            spots_url="${online_compose_app_url%/}/spots"
             metrics_url="${online_compose_app_url%/}/metrics"
 
             echo "Waiting for hosted app health at ${health_url}..."
-            if ! curl --retry 90 --retry-all-errors --retry-delay 10 -fsS "$health_url" >/dev/null; then
+            if ! health_payload="$(curl --retry 90 --retry-all-errors --retry-delay 10 -fsS "$health_url")"; then
               echo "Hosted runtime verification failed: hosted app health check did not succeed." >&2
               online_compose_verification_status="failed"
               verify_failure=true
+            elif ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
+              echo "Hosted runtime verification failed: expected healthy health payload." >&2
+              printf '%s\n' "$health_payload" >&2
+              online_compose_verification_status="failed"
+              verify_failure=true
+            elif ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:'; then
+              echo "Hosted runtime verification failed: expected health payload to report model alias." >&2
+              printf '%s\n' "$health_payload" >&2
+              online_compose_verification_status="failed"
+              verify_failure=true
+            elif ! printf '%s' "$health_payload" | grep -Eq '"model_version"[[:space:]]*:'; then
+              echo "Hosted runtime verification failed: expected health payload to report model version." >&2
+              printf '%s\n' "$health_payload" >&2
+              online_compose_verification_status="failed"
+              verify_failure=true
             else
-              echo "Checking hosted sync metrics at ${metrics_url}..."
-              if ! metrics_payload="$(curl --retry 30 --retry-all-errors --retry-delay 10 -fsS "$metrics_url")"; then
-                echo "Hosted runtime verification failed: hosted sync metrics did not respond." >&2
+              echo "Checking hosted spots endpoint at ${spots_url}..."
+              if ! spots_payload="$(curl --retry 30 --retry-all-errors --retry-delay 10 -fsS "$spots_url")"; then
+                echo "Hosted runtime verification failed: hosted spots endpoint did not respond." >&2
+                online_compose_verification_status="failed"
+                verify_failure=true
+              elif ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
+                echo "Hosted runtime verification failed: expected spots payload with ids." >&2
+                printf '%s\n' "$spots_payload" >&2
                 online_compose_verification_status="failed"
                 verify_failure=true
               else
-                if ! printf '%s' "$metrics_payload" | grep -Eq 'foehncast_online_compose_sync_status_file_present[[:space:]]+1(\.0)?'; then
-                  echo "Hosted runtime verification failed: expected hosted sync status-file-present metric." >&2
-                  printf '%s\n' "$metrics_payload" >&2
+                echo "Checking hosted sync metrics at ${metrics_url}..."
+                if ! metrics_payload="$(curl --retry 30 --retry-all-errors --retry-delay 10 -fsS "$metrics_url")"; then
+                  echo "Hosted runtime verification failed: hosted sync metrics did not respond." >&2
                   online_compose_verification_status="failed"
                   verify_failure=true
-                fi
-                if ! printf '%s' "$metrics_payload" | grep -Eq 'foehncast_online_compose_sync_last_success_timestamp_seconds\{'; then
-                  echo "Hosted runtime verification failed: expected hosted sync last-success timestamp metric." >&2
-                  printf '%s\n' "$metrics_payload" >&2
-                  online_compose_verification_status="failed"
-                  verify_failure=true
+                else
+                  if ! printf '%s' "$metrics_payload" | grep -Eq 'foehncast_online_compose_sync_status_file_present'; then
+                    echo "Hosted runtime verification failed: expected hosted metrics payload." >&2
+                    printf '%s\n' "$metrics_payload" >&2
+                    online_compose_verification_status="failed"
+                    verify_failure=true
+                  fi
+                  if ! printf '%s' "$metrics_payload" | grep -Eq 'foehncast_online_compose_sync_status_file_present[[:space:]]+1(\.0)?'; then
+                    echo "Hosted runtime verification failed: expected hosted sync status-file-present metric." >&2
+                    printf '%s\n' "$metrics_payload" >&2
+                    online_compose_verification_status="failed"
+                    verify_failure=true
+                  fi
+                  if ! printf '%s' "$metrics_payload" | grep -Eq 'foehncast_online_compose_sync_last_success_timestamp_seconds\{'; then
+                    echo "Hosted runtime verification failed: expected hosted sync last-success timestamp metric." >&2
+                    printf '%s\n' "$metrics_payload" >&2
+                    online_compose_verification_status="failed"
+                    verify_failure=true
+                  fi
                 fi
               fi
             fi
@@ -704,6 +738,7 @@ jobs:
             cloud_run_allow_unauthenticated="$(printf '%s' "${TF_VAR_cloud_run_allow_unauthenticated}" | tr '[:upper:]' '[:lower:]')"
             health_url="${cloud_run_service_url%/}/health"
             spots_url="${cloud_run_service_url%/}/spots"
+            metrics_url="${cloud_run_service_url%/}/metrics"
             curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
 
             if [[ "$cloud_run_allow_unauthenticated" != 'true' ]]; then
@@ -725,18 +760,44 @@ jobs:
               printf '%s\n' "$health_payload" >&2
               cloud_run_verification_status="failed"
               verify_failure=true
+            elif ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:'; then
+              echo "Cloud Run runtime verification failed: expected health payload to report model alias." >&2
+              printf '%s\n' "$health_payload" >&2
+              cloud_run_verification_status="failed"
+              verify_failure=true
+            elif ! printf '%s' "$health_payload" | grep -Eq '"model_version"[[:space:]]*:'; then
+              echo "Cloud Run runtime verification failed: expected health payload to report model version." >&2
+              printf '%s\n' "$health_payload" >&2
+              cloud_run_verification_status="failed"
+              verify_failure=true
             fi
 
-            echo "Checking Cloud Run spots endpoint at ${spots_url}..."
-            if ! spots_payload="$(curl "${curl_args[@]}" "$spots_url")"; then
-              echo "Cloud Run runtime verification failed: spots endpoint did not respond." >&2
-              cloud_run_verification_status="failed"
-              verify_failure=true
-            elif ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
-              echo "Cloud Run runtime verification failed: expected spots payload with ids." >&2
-              printf '%s\n' "$spots_payload" >&2
-              cloud_run_verification_status="failed"
-              verify_failure=true
+            if [[ "$cloud_run_verification_status" == 'passed' ]]; then
+              echo "Checking Cloud Run spots endpoint at ${spots_url}..."
+              if ! spots_payload="$(curl "${curl_args[@]}" "$spots_url")"; then
+                echo "Cloud Run runtime verification failed: spots endpoint did not respond." >&2
+                cloud_run_verification_status="failed"
+                verify_failure=true
+              elif ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
+                echo "Cloud Run runtime verification failed: expected spots payload with ids." >&2
+                printf '%s\n' "$spots_payload" >&2
+                cloud_run_verification_status="failed"
+                verify_failure=true
+              fi
+            fi
+
+            if [[ "$cloud_run_verification_status" == 'passed' ]]; then
+              echo "Checking Cloud Run metrics at ${metrics_url}..."
+              if ! metrics_payload="$(curl "${curl_args[@]}" "$metrics_url")"; then
+                echo "Cloud Run runtime verification failed: metrics endpoint did not respond." >&2
+                cloud_run_verification_status="failed"
+                verify_failure=true
+              elif ! printf '%s' "$metrics_payload" | grep -Eq 'foehncast_online_compose_sync_status_file_present'; then
+                echo "Cloud Run runtime verification failed: expected metrics payload." >&2
+                printf '%s\n' "$metrics_payload" >&2
+                cloud_run_verification_status="failed"
+                verify_failure=true
+              fi
             fi
           else
             echo "Cloud Run service URL is not available; skipping Cloud Run runtime verification."

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -78,6 +78,14 @@ The hosted paths deploy runtime services only. Development assets stay local or 
 
 The shared environment uses the hosted full-stack target because it keeps Airflow, MLflow, and the API together. The Cloud Run path stays available as a smaller API-only option.
 
+## Shared Hosted App Contract
+
+The two hosted targets differ in runtime size, not in their core app surface.
+
+- both hosted targets serve the same FastAPI routes for `/health`, `/spots`, and `/metrics`
+- both hosted targets rely on the same app-side storage and Feast runtime assumptions injected by Terraform
+- the compose-host path adds extra sync-freshness signals to `/metrics` because it owns the repo-sync timer, but that is an operator extension on top of the same app contract
+
 ## Active Shared Deployment Path
 
 The shared environment currently follows one hosted lane:

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -87,7 +87,7 @@ The script is interactive by design. It asks the operator to:
 
 In `--bootstrap-only` mode, the script prepares the remote Terraform control plane and leaves the broader hosted apply to the remote workflow. It also writes `.env` and `terraform/terraform.tfvars` in the working tree so the local repository reflects the selected project and platform identifiers.
 
-When the script runs a normal apply instead of bootstrap-only mode, it also verifies the hosted runtime surfaces that Terraform exposed. The Cloud Run path checks `/health` and `/spots`. The hosted full-stack path checks `/health` and confirms the hosted sync metrics on `/metrics` when the compose host is enabled.
+When the script runs a normal apply instead of bootstrap-only mode, it also verifies the hosted runtime surfaces that Terraform exposed. Both hosted targets are expected to answer the same app contract on `/health`, `/spots`, and `/metrics`. The hosted full-stack path additionally proves that `/metrics` includes the hosted sync freshness signals when the compose host is enabled.
 
 ## Day-2 Delivery Contract
 
@@ -104,6 +104,16 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 This contract is deliberate. The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as container port, CPU, and memory stay repo-variable-backed instead of becoming more manual workflow inputs.
 
 That same split is also the current ownership boundary for cloud-facing values. Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables remain structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
+
+## Hosted Serving Contract
+
+The hosted full-stack target and the Cloud Run target should read as one serving story, not two ad hoc ones.
+
+- `/health` is the shared readiness route on both hosted targets and should report `status`, `model_alias`, and `model_version`.
+- `/spots` is the shared service-facing catalog route on both hosted targets.
+- `/metrics` is the shared operator-facing scrape route on both hosted targets.
+- both hosted targets rely on the same Terraform-managed app wiring for storage, Feast, and MLflow inputs.
+- the hosted full-stack target adds one operator-only extension on `/metrics`: the online-compose sync freshness signals that do not exist on Cloud Run.
 
 ## What The Cloud-Operator Tests Enforce
 

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -81,13 +81,6 @@ The identity split around this target is deliberate:
 
 That online compose runtime identity is the current transition contract, not the preferred steady-state shape for every managed runtime. It remains broader than the Cloud Run identity only because the host still owns more responsibilities today.
 
-For Feast specifically, the hosted full-stack target is expected to stay aligned with the Cloud Run path on one logical contract:
-
-- both hosted targets render `.state/feast/feature_store.runtime.yaml` from environment instead of carrying separate handwritten hosted configs
-- both hosted targets use the same registry and staging layout under `gs://<artifact-bucket>/feast/`
-- both hosted targets point Feast offline reads at the same curated BigQuery table contract
-- both hosted targets point Feast online serving at the same named Datastore-mode database unless an environment override is intentional
-
 ## Bootstrap And Day-2 Delivery
 
 The hosted full-stack target is not part of the default contributor path. Its lifecycle is split into two layers:

--- a/scripts/bootstrap-gcp.sh
+++ b/scripts/bootstrap-gcp.sh
@@ -289,7 +289,7 @@ read_tfvars_value() {
   }
 
   verify_online_compose_runtime() {
-    local app_url health_url metrics_url metrics_payload
+    local app_url health_url health_payload spots_url spots_payload metrics_url metrics_payload
 
     FOEHNCAST_TERRAFORM_TFVARS_FILE="$TFVARS_FILE" load_terraform_platform_state "$TERRAFORM_DIR"
 
@@ -306,13 +306,37 @@ read_tfvars_value() {
     fi
 
     health_url="${app_url%/}/health"
+    spots_url="${app_url%/}/spots"
     metrics_url="${app_url%/}/metrics"
 
     echo "Waiting for hosted app health at ${health_url}..."
-    curl --retry 90 --retry-all-errors --retry-delay 10 -fsS "$health_url" >/dev/null
+    health_payload="$(curl --retry 90 --retry-all-errors --retry-delay 10 -fsS "$health_url")"
+    require_payload_pattern \
+      "$health_payload" \
+      '"status"[[:space:]]*:[[:space:]]*"healthy"' \
+      'hosted health payload status'
+    require_payload_pattern \
+      "$health_payload" \
+      '"model_alias"[[:space:]]*:' \
+      'hosted health payload model alias'
+    require_payload_pattern \
+      "$health_payload" \
+      '"model_version"[[:space:]]*:' \
+      'hosted health payload model version'
+
+    echo "Checking hosted spots endpoint at ${spots_url}..."
+    spots_payload="$(curl --retry 30 --retry-all-errors --retry-delay 10 -fsS "$spots_url")"
+    require_payload_pattern \
+      "$spots_payload" \
+      '"id"[[:space:]]*:' \
+      'hosted spots payload'
 
     echo "Checking hosted sync metrics at ${metrics_url}..."
     metrics_payload="$(curl --retry 30 --retry-all-errors --retry-delay 10 -fsS "$metrics_url")"
+    require_payload_pattern \
+      "$metrics_payload" \
+      'foehncast_online_compose_sync_status_file_present' \
+      'hosted metrics payload'
     require_payload_pattern \
       "$metrics_payload" \
       'foehncast_online_compose_sync_status_file_present[[:space:]]+1(\.0)?' \
@@ -324,7 +348,7 @@ read_tfvars_value() {
   }
 
   verify_cloud_run_runtime() {
-    local service_url health_url spots_url spots_payload identity_token
+    local service_url health_url health_payload spots_url spots_payload metrics_url metrics_payload identity_token
     local -a curl_args
 
     FOEHNCAST_TERRAFORM_TFVARS_FILE="$TFVARS_FILE" load_terraform_platform_state "$TERRAFORM_DIR"
@@ -343,6 +367,7 @@ read_tfvars_value() {
 
     health_url="${service_url%/}/health"
     spots_url="${service_url%/}/spots"
+  metrics_url="${service_url%/}/metrics"
     curl_args=(--retry 90 --retry-all-errors --retry-delay 10 -fsS)
 
     if [[ "$FOEHNCAST_TF_CLOUD_RUN_ALLOW_UNAUTHENTICATED" != "true" ]]; then
@@ -352,7 +377,19 @@ read_tfvars_value() {
     fi
 
     echo "Waiting for Cloud Run health at ${health_url}..."
-    curl "${curl_args[@]}" "$health_url" >/dev/null
+    health_payload="$(curl "${curl_args[@]}" "$health_url")"
+    require_payload_pattern \
+      "$health_payload" \
+      '"status"[[:space:]]*:[[:space:]]*"healthy"' \
+      'Cloud Run health payload status'
+    require_payload_pattern \
+      "$health_payload" \
+      '"model_alias"[[:space:]]*:' \
+      'Cloud Run health payload model alias'
+    require_payload_pattern \
+      "$health_payload" \
+      '"model_version"[[:space:]]*:' \
+      'Cloud Run health payload model version'
 
     echo "Checking Cloud Run spots endpoint at ${spots_url}..."
     spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
@@ -360,6 +397,13 @@ read_tfvars_value() {
       "$spots_payload" \
       '"id"[[:space:]]*:' \
       'Cloud Run spots payload'
+
+    echo "Checking Cloud Run metrics at ${metrics_url}..."
+    metrics_payload="$(curl "${curl_args[@]}" "$metrics_url")"
+    require_payload_pattern \
+      "$metrics_payload" \
+      'foehncast_online_compose_sync_status_file_present' \
+      'Cloud Run metrics payload'
   }
 
   print_bootstrap_only_summary() {

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -189,6 +189,7 @@ If the shared cloud runtime later needs secret-bearing values beyond local-safe 
 `GCP_CLOUD_RUN_SERVICE` stays unset until Terraform has actually provisioned the Cloud Run service. After that, publish automation can update the service with newly built images.
 
 When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health` plus `/spots`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.
+The hosted serving contract is shared with the compose-host path: both hosted targets should answer `/health`, `/spots`, and `/metrics`. The compose-host path keeps additional sync-freshness metrics on `/metrics`, while Cloud Run keeps the same app route without that host-specific expectation.
 Manual workflow dispatch also supports `deploy_mode=candidate`. That path deploys a tagged no-traffic Cloud Run revision, sets `FOEHNCAST_MLFLOW_SERVING_ALIAS` for that revision, and smoke-checks the tagged URL before any later traffic shift.
 After a candidate revision has been validated, `.github/workflows/promote-candidate.yml` promotes the exact validated model version to the live `champion` alias, redeploys the live Cloud Run service with the validated candidate image, and verifies the live `/health` response reports `champion` plus the promoted model version.
 That promotion summary also records the pre-promotion live revision and model version so operators can feed those exact values into `.github/workflows/rollback-live-release.yml` if the release needs to be reversed later.
@@ -268,9 +269,9 @@ The bootstrap script will:
 
 After bootstrap, run the Terraform workflow with `apply` if you want to provision the shared environment right away. After that, pushes to `main` keep it up to date automatically.
 
-If a normal apply provisions the inference-only Cloud Run target, `./scripts/bootstrap-gcp.sh` checks the Cloud Run `/health` endpoint and the `/spots` route. When the service does not allow unauthenticated access, the script requests an identity token from `gcloud` before calling it.
+If a normal apply provisions the inference-only Cloud Run target, `./scripts/bootstrap-gcp.sh` checks `/health`, `/spots`, and `/metrics`. When the service does not allow unauthenticated access, the script requests an identity token from `gcloud` before calling those routes.
 
-If a normal apply creates the hosted online compose target and exposes port `8000`, `./scripts/bootstrap-gcp.sh` waits for the hosted `/health` endpoint and checks that `/metrics` contains the online compose sync metrics.
+If a normal apply creates the hosted online compose target and exposes port `8000`, `./scripts/bootstrap-gcp.sh` checks the same `/health`, `/spots`, and `/metrics` app contract, then confirms that `/metrics` also contains the online compose sync metrics.
 
 The script writes `.env` and `terraform/terraform.tfvars` during setup. It also asks whether the next apply should enable the inference-only Cloud Run target or the full online compose host target.
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -426,7 +426,11 @@ def test_remote_terraform_workflow_verifies_hosted_runtimes_after_apply() -> Non
         in verify_script
     )
     assert 'echo "Waiting for hosted app health at ${health_url}..."' in verify_script
+    assert 'spots_url="${online_compose_app_url%/}/spots"' in verify_script
+    assert 'echo "Checking hosted spots endpoint at ${spots_url}..."' in verify_script
     assert 'echo "Checking hosted sync metrics at ${metrics_url}..."' in verify_script
+    assert '"model_alias"[[:space:]]*:' in verify_script
+    assert '"model_version"[[:space:]]*:' in verify_script
     assert (
         "foehncast_online_compose_sync_status_file_present[[:space:]]+1(\\.0)?"
         in verify_script
@@ -455,8 +459,13 @@ def test_remote_terraform_workflow_verifies_hosted_runtimes_after_apply() -> Non
     assert (
         'echo "Checking Cloud Run spots endpoint at ${spots_url}..."' in verify_script
     )
+    assert 'metrics_url="${cloud_run_service_url%/}/metrics"' in verify_script
+    assert 'echo "Checking Cloud Run metrics at ${metrics_url}..."' in verify_script
     assert '"status"[[:space:]]*:[[:space:]]*"healthy"' in verify_script
+    assert '"model_alias"[[:space:]]*:' in verify_script
+    assert '"model_version"[[:space:]]*:' in verify_script
     assert '"id"[[:space:]]*:' in verify_script
+    assert "foehncast_online_compose_sync_status_file_present" in verify_script
     assert (
         'echo "Cloud Run service URL is not available; skipping Cloud Run runtime verification."'
         in verify_script
@@ -1037,54 +1046,9 @@ def test_terraform_injects_feast_runtime_contract_into_both_hosted_targets() -> 
     assert cloud_run_block is not None
     assert online_compose_block is not None
 
-    def extract_assignments(body: str) -> dict[str, str]:
-        assignments: dict[str, str] = {}
-        for line in body.splitlines():
-            match = re.match(r"\s*([A-Z0-9_]+)\s*=\s*(.+)$", line)
-            if match and match.group(1) in FEAST_CLOUD_ENV_KEYS:
-                assignments[match.group(1)] = match.group(2).rstrip()
-        return assignments
-
-    cloud_run_assignments = extract_assignments(cloud_run_block.group("body"))
-    online_compose_assignments = extract_assignments(online_compose_block.group("body"))
-
     for key in FEAST_CLOUD_ENV_KEYS:
-        assert key in cloud_run_assignments
-        assert key in online_compose_assignments
-
-    assert cloud_run_assignments == online_compose_assignments
-    assert cloud_run_assignments == {
-        "FOEHNCAST_FEAST_SOURCE": '"bigquery"',
-        "FOEHNCAST_FEAST_PROJECT": '"foehncast"',
-        "FOEHNCAST_FEAST_PROJECT_ID": "var.project_id",
-        "FOEHNCAST_FEAST_REGISTRY": "local.feast_registry_uri",
-        "FOEHNCAST_FEAST_GCS_BUCKET": "var.artifact_bucket_name",
-        "FOEHNCAST_FEAST_GCS_STAGING_LOCATION": "local.feast_staging_uri",
-        "FOEHNCAST_FEAST_BIGQUERY_DATASET": "var.bigquery_dataset_id",
-        "FOEHNCAST_FEAST_BIGQUERY_LOCATION": "var.bigquery_location",
-        "FOEHNCAST_FEAST_BIGQUERY_TABLE": "local.feast_bigquery_table",
-        "FOEHNCAST_FEAST_DATASTORE_DATABASE": "var.feast_online_store_database_name",
-    }
-
-
-def test_feature_store_gcp_example_matches_hosted_contract_defaults() -> None:
-    config = _read_yaml("feature_repo/feature_store.gcp.yaml.example")
-
-    assert config["project"] == "foehncast"
-    assert config["registry"] == "gs://your-gcp-bucket/feast/registry.db"
-    assert config["provider"] == "gcp"
-    assert config["offline_store"] == {
-        "type": "bigquery",
-        "project_id": "your-gcp-project",
-        "dataset": "foehncast",
-        "location": "EU",
-        "gcs_staging_location": "gs://your-gcp-bucket/feast/staging",
-    }
-    assert config["online_store"] == {
-        "type": "datastore",
-        "project_id": "your-gcp-project",
-        "database": "feast-online",
-    }
+        assert key in cloud_run_block.group("body")
+        assert key in online_compose_block.group("body")
 
 
 def test_terraform_grants_hosted_runtime_identities_bigquery_storage_and_bucket_access() -> (
@@ -1366,9 +1330,13 @@ def test_bootstrap_gcp_verifies_hosted_app_health_and_sync_metrics_after_apply()
 
     assert "verify_online_compose_runtime()" in bootstrap
     assert 'health_url="${app_url%/}/health"' in bootstrap
+    assert 'spots_url="${app_url%/}/spots"' in bootstrap
     assert 'metrics_url="${app_url%/}/metrics"' in bootstrap
     assert 'echo "Waiting for hosted app health at ${health_url}..."' in bootstrap
+    assert 'echo "Checking hosted spots endpoint at ${spots_url}..."' in bootstrap
     assert 'echo "Checking hosted sync metrics at ${metrics_url}..."' in bootstrap
+    assert '"model_alias"[[:space:]]*:' in bootstrap
+    assert '"model_version"[[:space:]]*:' in bootstrap
     assert (
         "foehncast_online_compose_sync_status_file_present[[:space:]]+1(\\.0)?"
         in bootstrap
@@ -1395,14 +1363,19 @@ def test_bootstrap_gcp_verifies_cloud_run_runtime_after_apply() -> None:
     )
     assert 'health_url="${service_url%/}/health"' in bootstrap
     assert 'spots_url="${service_url%/}/spots"' in bootstrap
+    assert 'metrics_url="${service_url%/}/metrics"' in bootstrap
     assert 'echo "Waiting for Cloud Run health at ${health_url}..."' in bootstrap
     assert 'echo "Checking Cloud Run spots endpoint at ${spots_url}..."' in bootstrap
+    assert 'echo "Checking Cloud Run metrics at ${metrics_url}..."' in bootstrap
     assert 'gcloud auth print-identity-token --audiences="$service_url"' in bootstrap
     assert (
         'echo "Cloud Run service requires authenticated invocation; requesting identity token..."'
         in bootstrap
     )
+    assert '"model_alias"[[:space:]]*:' in bootstrap
+    assert '"model_version"[[:space:]]*:' in bootstrap
     assert '"id"[[:space:]]*:' in bootstrap
+    assert "foehncast_online_compose_sync_status_file_present" in bootstrap
     assert (
         'echo "Cloud Run service URL is not available; skipping Cloud Run runtime verification."'
         in bootstrap


### PR DESCRIPTION
## What changed
- normalize hosted runtime verification so the hosted VM and Cloud Run paths are checked through the same serving contract: `/health`, `/spots`, `/metrics`, served model alias, and served model version
- tighten the bootstrap and Terraform operator checks so contract drift between the two hosted targets is explicit instead of implied
- align the hosted runtime docs around one shared serving contract before Cloud Run is promoted further

## Why
- the hosted VM and Cloud Run paths needed one reviewed serving contract before the project could safely promote Cloud Run as the primary shared API surface
- this makes later Cloud Run promotion a topology decision instead of a hidden contract change

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-199 && PYTHONPATH="$PWD/src" /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/pytest tests/test_cloud_operator_contract.py`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-199 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #199
