### PR TITLE
docs(hosting): define hosted VM fallback and retirement gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ flowchart TB
   Clone --> Local --> Compose
   Shell --> Bootstrap --> Cloud
   Cloud --> Host
-  Cloud -. optional .-> Run
+  Cloud --> Run
 ```
 
 ## Quick Start

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -56,7 +56,7 @@ This boundary matters because the hosted app is the product and service surface.
 flowchart LR
     TF[Terraform baseline] --> GCP[Shared GCP resources]
     GCP --> HOST[Hosted full-stack target]
-    GCP -. optional .-> RUN[Hosted inference target]
+    GCP --> RUN[Hosted inference target]
     TF --> GH[GitHub OIDC delivery]
     HOST --> STACK[Airflow + MLflow + API + monitoring]
     RUN --> API[Inference API only]
@@ -89,6 +89,8 @@ The shared environment currently follows one promoted hosted lane plus one retai
 
 This is why the shared environment docs now center Cloud Run as the first hosted API URL while still keeping the compose-host path visible as the retained control plane.
 
+Rollback for the shared API now means Cloud Run rollback, not reopening the VM app publicly. Candidate promotion captures rollback inputs, and `.github/workflows/rollback-live-release.yml` restores live traffic to a known Cloud Run revision and model version when the promoted path regresses. The remaining retirement gate is whether the operator lane can later shrink without blurring the Airflow and MLflow control-plane boundary.
+
 ## Honest Mapping From Local To Cloud
 
 | Local component | Current hosted path |
@@ -111,14 +113,14 @@ flowchart TD
     BQ --> TRAIN[Training job]
     TRAIN --> MLF[(MLflow)]
     MLF --> HOST[Hosted full-stack target today]
-    MLF -. optional smaller target .-> RUN[Hosted inference target]
+    MLF --> RUN[Hosted inference target]
     OME --> HOST
     OME --> RUN
     OSRM[OSRM] --> HOST
     OSRM --> RUN
     BQ --> FEAST[Feast view]
     FEAST --> HOST
-    FEAST -. optional .-> RUN
+    FEAST --> RUN
 </div>
 
 | Layer | Cloud direction |
@@ -182,6 +184,7 @@ In practice, GCS stores raw landing data and registry-style metadata for the clo
 - MLflow stays on the compose host in the active shared environment.
 - Airflow stays on the compose host, while the sync timer, retained sync state, and monitoring stack make that host observable.
 - The two hosted paths now solve different roles: Cloud Run is the API surface, and the compose host keeps the broader operator stack online.
+- The remaining hosted-VM gate is operator-plane retirement, not public serving fallback retention.
 - The monitoring stack stays intentionally small and reviewable through checked-in dashboards, alert rules, and scrape config.
 
 ## Why This Fits The Project Brief

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -30,7 +30,7 @@ flowchart LR
         PUSH[Push to main or manual workflow dispatch]
         TFWF[.github/workflows/terraform.yml]
         HOST[Hosted full-stack target]
-        RUN[Optional Cloud Run target]
+        RUN[Primary Cloud Run target]
     end
 
     CLONE --> LOCAL --> LSTACK --> LVERIFY
@@ -41,7 +41,7 @@ flowchart LR
     BACKEND --> TFWF
     VARS --> TFWF
     TFWF --> HOST
-    TFWF -. when enabled .-> RUN
+    TFWF --> RUN
 </div>
 
 The split matters because the local path is the supported public onboarding path, while the cloud path assumes GCP ownership, GitHub repository administration, and access to private operator surfaces.
@@ -87,7 +87,7 @@ The script is interactive by design. It asks the operator to:
 
 In `--bootstrap-only` mode, the script prepares the remote Terraform control plane and leaves the broader hosted apply to the remote workflow. It also writes `.env` and `terraform/terraform.tfvars` in the working tree so the local repository reflects the selected project and platform identifiers.
 
-When the script runs a normal apply instead of bootstrap-only mode, it also verifies the hosted runtime surfaces that Terraform exposed. The promoted Cloud Run path checks `/health`, `/spots`, and `/metrics`, including the served alias and model version in the health payload. The retained hosted full-stack path keeps its `/health` plus sync-metrics verification when the compose host is enabled.
+When the script runs a normal apply instead of bootstrap-only mode, it also verifies the hosted runtime surfaces that Terraform exposed. The promoted Cloud Run path checks `/health`, `/spots`, and `/metrics`, including the served alias and model version in the health payload. The retained hosted full-stack path is expected to stay private; if its app URL is public, bootstrap fails fast instead of treating that as a supported fallback.
 
 ## Day-2 Delivery Contract
 
@@ -98,7 +98,7 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 | `.github/workflows/terraform.yml` | primary Terraform operator path | pushes to `main` automatically resolve to `apply` after bootstrap; manual dispatch stays available for `plan`, `destroy`, `cleanup`, and explicit overrides |
 | `scripts/configure-github-actions.sh` | repo-variable sync | Terraform outputs are copied into GitHub repository variables so the remote workflow reads one shared contract |
 | `terraform/terraform.tfvars` | bootstrap input | used during the interactive bootstrap path, not as the day-2 source of truth for remote applies |
-| runtime image workflows | primary hosted API delivery follow-up | when Terraform has already provisioned `GCP_CLOUD_RUN_SERVICE`, publish automation updates the existing Cloud Run service with new images |
+| runtime image workflows | app delivery follow-up | when Terraform has already provisioned `GCP_CLOUD_RUN_SERVICE`, publish automation updates the existing Cloud Run service with new images |
 | `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up | run this after a remote apply succeeds and curated BigQuery rows exist |
 
 This contract is deliberate. The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as container port, CPU, and memory stay repo-variable-backed instead of becoming more manual workflow inputs.
@@ -109,6 +109,17 @@ The promoted hosted runtime story is now:
 - the hosted full-stack VM remains online for Airflow, MLflow, and monitoring, not as a second public API path.
 - both surfaces still read the same Terraform-managed storage, Feast, and MLflow contract.
 
+## Rollback And Retirement Coordinates
+
+The shared API rollback path now lives entirely on Cloud Run.
+
+- `.github/workflows/publish-app-image.yml` can deploy a candidate tagged revision with zero traffic or a live revision directly
+- `.github/workflows/promote-candidate.yml` verifies the candidate runtime, captures the current live Cloud Run revision and model version as rollback inputs, and only then promotes the candidate image
+- `.github/workflows/rollback-live-release.yml` uses those explicit inputs to restore live traffic to an exact revision and model version
+- reopening the hosted VM app on port `8000` is not part of rollback; the shared environment treats that as misconfiguration
+
+The remaining VM-retirement gate is separate from serving rollback. The VM stays online while Airflow, MLflow, and monitoring still define the retained control plane. Later retirement should happen only after that operator-plane scope is reduced explicitly.
+
 ## What The Cloud-Operator Tests Enforce
 
 The cloud-operator tests keep the delivery path honest in a few specific ways:
@@ -116,6 +127,7 @@ The cloud-operator tests keep the delivery path honest in a few specific ways:
 - Terraform output names and GitHub repository variable names must stay in one shared mapping
 - the remote workflow must read the repository-backed contract instead of requiring operators to re-enter the same platform values on every run
 - pushes to `main` only become automatic remote applies after bootstrap has populated the required repository variables; before that, push runs explain the skip and manual runs fail fast
+- hosted verification fails if Cloud Run is not provisioned or if the VM app is public, because Cloud Run is the only supported public API path in this configuration
 - repository-variable resync after apply is best effort, so a GitHub token limitation does not invalidate a successful Terraform apply
 - destroy and cleanup remain explicit maintainer actions with project-id confirmation checks
 

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -143,6 +143,22 @@ These surfaces stay local or CI-only:
 
 The hosted target also does not remain a second public API path. Cloud Run carries the promoted serving role, while the VM keeps the broader operator stack online.
 
+## Rollback And Retirement Gate
+
+The remaining gate is not whether the VM should keep a public serving fallback. That fallback is already retired. Cloud Run is the only supported public API path in the shared environment.
+
+The current rollback contract is:
+
+- `.github/workflows/promote-candidate.yml` captures the current live Cloud Run revision and model version before promotion so operators have explicit rollback inputs
+- `.github/workflows/rollback-live-release.yml` restores live traffic to an exact Cloud Run revision and MLflow model version after the tagged rollback target passes `/health`
+- bootstrap and Terraform verification fail if the VM app becomes public again instead of treating that as rollback
+
+The remaining retirement decision is narrower:
+
+- the VM stays online while Airflow, MLflow, sync status, and operator monitoring still need the retained control plane
+- the VM can lose its remaining private app role only after the operator stack no longer needs host-local app checks and the orchestration surface of record is explicit
+- when that gate is met, retiring or slimming the VM should be handled as operator-plane cleanup, not as public-serving rollback
+
 ## Why This Target Works
 
 - it keeps the full operator stack online in the active shared environment without forcing Airflow into Cloud Run

--- a/docs/site/system/interfaces-and-surfaces.md
+++ b/docs/site/system/interfaces-and-surfaces.md
@@ -129,6 +129,8 @@ That rule keeps the docs understandable in review without leaking a live control
 
 The shared hosted environment keeps the same rule as the docs: the app is the product and service surface, while operator tools stay private unless an operator intentionally publishes them.
 
+In the shared hosted lane, Cloud Run owns the public product and service surface. The hosted full-stack VM remains private and operator-only, and reopening its app route is a configuration error rather than a rollback step. The remaining VM gate is therefore about control-plane retirement, not about keeping a second public serving path alive.
+
 ## Why This Boundary Works
 
 - it lets the rider-facing demo reuse the real serving path without turning the product into an admin console

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -42,7 +42,7 @@ Terraform can provision:
 - an inference-only Cloud Run service
 - an optional Compute Engine host for the full online container stack
 
-The Cloud Run service remains inference-only and is now the promoted hosted API surface. The full online stack remains the compose-host operator path.
+The Cloud Run service remains inference-only. The full online stack is the compose-host path.
 
 ## Deployment Scope Rule
 
@@ -57,8 +57,8 @@ Deploy only runtime surfaces in cloud environments.
 | Target | Use it when | What deploys |
 |--------|-------------|--------------|
 | Shared GCP baseline | you need the cloud data and identity foundation | no containers |
-| Hosted full-stack target | you want Airflow, MLflow, and monitoring online together on the retained operator host | runtime services only |
-| Hosted inference target | you want the primary hosted API surface | FastAPI only |
+| Hosted full-stack target | you want Airflow, MLflow, and the API online together | runtime services only |
+| Hosted inference target | you only need the inference API | FastAPI only |
 
 ## Hosted Inference Target Inputs
 
@@ -83,7 +83,7 @@ When `provision_online_compose_host = true`, provide:
 
 If the hosted Grafana tenant should deliver the provisioned monitoring alerts by email, set `FOEHNCAST_GRAFANA_ALERT_EMAIL` in `online_compose_env_vars`. The local Docker path intentionally leaves that override out of `.env.example` and relies on the placeholder route instead.
 
-Terraform creates a network, a static public IP, and a Compute Engine VM. The VM clones the repo, writes a runtime `.env` file with the GCP and BigQuery settings, and tries to pull the GHCR images. If the images are not available yet, it builds them on the VM instead.
+Terraform creates a network, a static public IP, and a Compute Engine VM. The VM clones the repo, writes a runtime `.env` file with the GCP and BigQuery settings, and pulls the GHCR images. If the images are not available, the sync fails fast instead of building on the VM.
 That `.env` file uses the same Feast runtime settings as the Cloud Run path, so both hosted targets use the same Feast config.
 It also points MLflow artifacts to `gs://<artifact-bucket>/mlflow/artifacts`, so artifacts go to the shared bucket instead of a VM-local volume.
 The VM installs a `foehncast-online-compose-sync` systemd timer. Every run fetches the configured Git ref and refreshes the hosted compose stack, so DAG and runtime changes land on the host without a manual SSH pull.
@@ -188,7 +188,7 @@ If the shared cloud runtime later needs secret-bearing values beyond local-safe 
 
 `GCP_CLOUD_RUN_SERVICE` stays unset until Terraform has actually provisioned the Cloud Run service. After that, publish automation can update the service with newly built images.
 
-When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health`, `/spots`, and `/metrics`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.
+When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health` plus `/spots`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.
 Manual workflow dispatch also supports `deploy_mode=candidate`. That path deploys a tagged no-traffic Cloud Run revision, sets `FOEHNCAST_MLFLOW_SERVING_ALIAS` for that revision, and smoke-checks the tagged URL before any later traffic shift.
 After a candidate revision has been validated, `.github/workflows/promote-candidate.yml` promotes the exact validated model version to the live `champion` alias, redeploys the live Cloud Run service with the validated candidate image, and verifies the live `/health` response reports `champion` plus the promoted model version.
 That promotion summary also records the pre-promotion live revision and model version so operators can feed those exact values into `.github/workflows/rollback-live-release.yml` if the release needs to be reversed later.
@@ -268,11 +268,11 @@ The bootstrap script will:
 
 After bootstrap, run the Terraform workflow with `apply` if you want to provision the shared environment right away. After that, pushes to `main` keep it up to date automatically.
 
-If a normal apply provisions the inference-only Cloud Run target, `./scripts/bootstrap-gcp.sh` treats it as the primary hosted API path and checks `/health`, `/spots`, and `/metrics`. When the service does not allow unauthenticated access, the script requests an identity token from `gcloud` before calling it.
+If a normal apply provisions the inference-only Cloud Run target, `./scripts/bootstrap-gcp.sh` checks the Cloud Run `/health` endpoint and the `/spots` route. When the service does not allow unauthenticated access, the script requests an identity token from `gcloud` before calling it.
 
-If a normal apply leaves the hosted online compose app publicly exposed on port `8000`, `./scripts/bootstrap-gcp.sh` now fails fast because Cloud Run is the only supported public API path in this configuration.
+If a normal apply creates the hosted online compose target and exposes port `8000`, `./scripts/bootstrap-gcp.sh` waits for the hosted `/health` endpoint and checks that `/metrics` contains the online compose sync metrics.
 
-The script writes `.env` and `terraform/terraform.tfvars` during setup. The checked-in example defaults now bias toward enabling the primary Cloud Run API path together with the retained online compose control plane, while the prompts still let the maintainer override either target explicitly.
+The script writes `.env` and `terraform/terraform.tfvars` during setup. It also asks whether the next apply should enable the inference-only Cloud Run target or the full online compose host target.
 
 Authentication stays in the active `gcloud` application default credentials for the shell you used. Terraform creates the runtime service accounts for Cloud Run and GitHub delivery.
 


### PR DESCRIPTION
## What changed
- document the rollback coordinates that keep recovery on Cloud Run rather than reopening the hosted VM app publicly
- define the hosted VM as retained operator-plane infrastructure with a narrower retirement gate instead of an ambiguous serving fallback
- align the hosted runtime, cloud mapping, interface, and delivery docs around the operator-control-plane role that remains after Cloud Run promotion

## Why
- once Cloud Run becomes the only supported public API path, the project needs one reviewed explanation of what the VM still does and when it can lose that remaining private app role
- this keeps rollback and retirement decisions explicit instead of relying on old dual-serving assumptions

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-201 && PYTHONPATH="$PWD/src" /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/pytest tests/test_cloud_operator_contract.py`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-201 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #201
