### PR TITLE
docs(architecture): decide hosted orchestration surface

### DIFF
--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -7,6 +7,7 @@ FoehnCast keeps the same Feature-Training-Inference split in every runtime mode.
     The validated baseline is the local Compose stack.
     The shared cloud path now promotes the hosted inference target as the primary API surface.
     The hosted full-stack target remains online as the retained operator control plane.
+    Hosted Airflow remains the orchestration surface of record for the next delivery horizon.
     The hosted paths use the same feature, training, and inference modules, but move storage, auth, and runtime services onto GCP in different ways.
     The rider-facing demo and prediction outputs are not the same thing as operator dashboards, and Grafana is not treated as the main product UI.
 
@@ -64,6 +65,7 @@ Grafana stays on the operator side of that boundary. The rider-facing experience
 | Feature pipeline | Collect data, engineer curated rows, validate them, and store the result | local Airflow DAG plus the configured storage backend |
 | Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
 | Inference pipeline | Serve health, predict, rank, and spot-list responses | FastAPI app container |
+| Orchestration | Schedule runtime DAGs, retries, backfills, and operator inspection | local Airflow plus the retained hosted Airflow control plane |
 | Online features | Surface curated fields through an online lookup route | Feast-backed service path plus demo page |
 | Monitoring | Scrape runtime metrics, collect pushed gauges, and visualize starter alerts | Prometheus, StatsD exporter, and Grafana operator stack |
 
@@ -82,13 +84,24 @@ flowchart LR
 | Target | Deploys | Leaves out | Primary use |
 |------|---------|------------|-------------|
 | Local evaluator target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, Grafana, MinIO, the Feast Datastore emulator, and optional `development_env` tooling | shared GCP baseline | default development and evaluation |
-| Hosted full-stack target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, and Grafana on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | retained operator control plane |
+| Hosted full-stack target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, and Grafana on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | retained operator control plane and orchestration surface of record |
 | Hosted inference target | FastAPI only, backed by shared GCP services | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | primary hosted API surface |
 | GitHub automation | image publishing and Terraform workflows | runtime services | shared cloud day-2 delivery, not a runtime target |
 
 The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. The hosted full-stack target stays private by default. Airflow, MLflow, Prometheus, and Grafana stay private unless you open them on purpose for your own operator workflow.
 
 The shared cloud path now promotes Cloud Run as the primary hosted API. The hosted full-stack target remains available when the operator stack needs to stay online together.
+
+## Orchestration Surface Of Record
+
+For the next delivery horizon, the runtime orchestration surface is the current hosted Airflow control plane on the retained operator host.
+
+- It matches the validated local DAG and asset model already used for feature and training flows.
+- It keeps runtime scheduling, retries, and backfills out of GitHub Actions.
+- It avoids a Composer migration before the delivery-versus-runtime boundary cleanup is complete.
+- It avoids a lighter trigger redesign that would replace Airflow-owned behavior instead of clarifying ownership.
+
+Composer and lighter managed trigger models stay valid future options, but they are deferred until the operator-plane reduction or course-evidence needs justify the change explicitly.
 
 ## Current Local Architecture
 

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -91,6 +91,18 @@ This is why the shared environment docs now center Cloud Run as the first hosted
 
 Rollback for the shared API now means Cloud Run rollback, not reopening the VM app publicly. Candidate promotion captures rollback inputs, and `.github/workflows/rollback-live-release.yml` restores live traffic to a known Cloud Run revision and model version when the promoted path regresses. The remaining retirement gate is whether the operator lane can later shrink without blurring the Airflow and MLflow control-plane boundary.
 
+## Orchestration Surface Of Record
+
+The runtime orchestration surface of record is the current hosted Airflow control plane on the retained operator host.
+
+| Option | Fit against current scope | Decision |
+|------|---------------------------|----------|
+| Current hosted Airflow control plane | Reuses the validated local Airflow DAG and asset model, keeps retries and backfills on the same operator surface, and avoids introducing another platform migration before the boundary cleanup lands | chosen now |
+| Composer | Offers a stronger managed-service story, but adds service cost, IAM work, and migration churn before the team has finished clarifying the GitHub-versus-runtime split | deferred |
+| Lighter managed trigger model | Could narrow the hosted footprint, but would replace Airflow-owned runtime behavior instead of simply clarifying ownership boundaries | not chosen for this horizon |
+
+GitHub therefore remains the delivery plane, while hosted Airflow remains the runtime scheduling plane. The later retry and backfill runbooks should assume Airflow as the operator surface until a future decision changes that explicitly.
+
 ## Honest Mapping From Local To Cloud
 
 | Local component | Current hosted path |
@@ -183,8 +195,8 @@ In practice, GCS stores raw landing data and registry-style metadata for the clo
 
 - MLflow stays on the compose host in the active shared environment.
 - Airflow stays on the compose host, while the sync timer, retained sync state, and monitoring stack make that host observable.
+- Hosted Airflow remains the orchestration surface of record for runtime scheduling, retries, and backfills.
 - The two hosted paths now solve different roles: Cloud Run is the API surface, and the compose host keeps the broader operator stack online.
-- The remaining hosted-VM gate is operator-plane retirement, not public serving fallback retention.
 - The monitoring stack stays intentionally small and reviewable through checked-in dashboards, alert rules, and scrape config.
 
 ## Why This Fits The Project Brief

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -109,6 +109,23 @@ The promoted hosted runtime story is now:
 - the hosted full-stack VM remains online for Airflow, MLflow, and monitoring, not as a second public API path.
 - both surfaces still read the same Terraform-managed storage, Feast, and MLflow contract.
 
+## Hosted Orchestration Surface Decision
+
+The orchestration surface of record for the next delivery horizon is the current hosted Airflow control plane on the retained operator host.
+
+| Option | Fit against current constraints | Decision |
+|------|----------------------------------|----------|
+| Current hosted Airflow control plane | Matches the validated local Airflow DAG and asset model, already exists on the retained operator host, and supports runtime scheduling, retries, backfills, and operator inspection without another platform migration | chosen now |
+| Composer / Managed Airflow | Stronger managed-service story, but adds cost, IAM surface area, and migration churn before the GitHub-versus-runtime boundary cleanup is complete | deferred |
+| Lighter managed trigger model | Could reduce infrastructure, but the current feature and training paths already depend on Airflow-owned scheduling, asset hand-offs, retries, and backfills | not chosen for this horizon |
+
+This means:
+
+- GitHub Actions stays responsible for lint, test, build, publish, and Terraform-driven delivery.
+- hosted Airflow stays responsible for runtime DAG execution, scheduling, retries, and backfills.
+- Cloud Run stays responsible for serving the public API, not for taking over orchestration duties.
+- Composer or a lighter managed alternative can be revisited later only if the operator-plane reduction justifies the migration.
+
 ## Rollback And Retirement Coordinates
 
 The shared API rollback path now lives entirely on Cloud Run.
@@ -140,6 +157,7 @@ Several boundaries stay explicit across the scripts, Terraform reference, and te
 - the local Docker evaluator remains the only default contributor path
 - the shared cloud environment stays operator-owned, even though the repository and images are public
 - `terraform/terraform.tfvars` belongs to bootstrap and local preview work, while day-2 remote runs read GitHub repository variables
+- runtime scheduling, retry, and backfill belong to hosted Airflow for this horizon rather than to GitHub Actions
 - Grafana, Airflow, MLflow, and Prometheus remain operator surfaces rather than rider-facing product surfaces
 - public docs should explain those surfaces with rendered evidence and checked-in configuration, not live control-plane embeds
 


### PR DESCRIPTION
## What changed
- document hosted Airflow on the retained operator host as the orchestration surface of record for the next delivery horizon
- add the decision criteria and rejected alternatives to the public architecture, cloud mapping, and delivery workflow docs
- make the runtime boundary explicit: GitHub stays the delivery plane, Cloud Run stays the serving plane, and hosted Airflow keeps scheduling, retries, and backfills

## Why
- downstream workflow and runtime changes needed one reviewed orchestration decision instead of inheriting an implied preference
- this locks the next horizon to the current hosted Airflow control plane while deferring Composer and lighter managed trigger models until the operator-plane footprint changes materially

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-202 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #202
