### PR TITLE
docs(architecture): define GitHub and GCP delivery boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ The shared hosted environment is not part of normal contributor setup.
 
 The current shared environment uses Cloud Run as the only promoted public API path. The hosted full-stack target stays online for Airflow, MLflow, and operator monitoring, but it is not treated as a second public serving surface.
 
+The delivery boundary is explicit: GitHub Actions handles reviewed delivery and infrastructure change, while GCP runtime surfaces handle serving, scheduling, retries, and backfills.
+
 Start with [docs/site/system/delivery-and-operator-workflow.md](docs/site/system/delivery-and-operator-workflow.md) for the maintainer workflow split and use `terraform/README.md` for operator detail.
 
 Hosted deployment keeps a narrow scope. The cloud targets deploy runtime services only. `development_env`, notebooks, docs build tooling, the local objectstore, and the local Datastore emulator stay local or CI-only.

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -103,6 +103,16 @@ The runtime orchestration surface of record is the current hosted Airflow contro
 
 GitHub therefore remains the delivery plane, while hosted Airflow remains the runtime scheduling plane. The later retry and backfill runbooks should assume Airflow as the operator surface until a future decision changes that explicitly.
 
+## GitHub Versus GCP Delivery Boundary
+
+The current delivery story is split intentionally:
+
+- GitHub owns reviewed artifacts, CI validation, image publication, and Terraform-driven infrastructure changes.
+- GCP owns runtime execution: Cloud Run serving, hosted Airflow scheduling, retries, backfills, runtime secrets and identities, and hosted telemetry.
+- Terraform outputs, repository variables, and published images form the handoff contract between the two planes.
+
+For this horizon, hosted Airflow on the retained operator host remains the orchestration surface of record. That means Cloud Run is the serving surface, not the scheduler, and GitHub Actions is the delivery plane, not the runtime orchestrator.
+
 ## Honest Mapping From Local To Cloud
 
 | Local component | Current hosted path |

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -126,6 +126,18 @@ This means:
 - Cloud Run stays responsible for serving the public API, not for taking over orchestration duties.
 - Composer or a lighter managed alternative can be revisited later only if the operator-plane reduction justifies the migration.
 
+## GitHub Versus GCP Boundary
+
+The reviewed delivery plane and the runtime execution plane have different responsibilities.
+
+| Plane | Current owner | What it owns | What it must not own |
+|------|---------------|--------------|----------------------|
+| Reviewed delivery | GitHub Actions plus Terraform | lint, test, build, image publish, Terraform plan/apply/destroy, and reviewed deploy workflows | runtime scheduling, retries, backfills, and long-lived operator state |
+| Runtime execution | GCP-hosted runtime surfaces | Cloud Run serving, hosted Airflow scheduling, retries, backfills, runtime environment injection, and operator telemetry | source control, CI review, and infrastructure policy review |
+| Shared handoff | repository variables, published images, and Terraform outputs | reviewed contract from GitHub into GCP runtime surfaces | ad hoc operator-only divergence from the declared contract |
+
+For the next delivery horizon, hosted Airflow on the retained operator host remains the orchestration surface of record. GitHub Actions may trigger reviewed delivery workflows, but it is not the runtime orchestrator.
+
 ## Rollback And Retirement Coordinates
 
 The shared API rollback path now lives entirely on Cloud Run.
@@ -157,7 +169,7 @@ Several boundaries stay explicit across the scripts, Terraform reference, and te
 - the local Docker evaluator remains the only default contributor path
 - the shared cloud environment stays operator-owned, even though the repository and images are public
 - `terraform/terraform.tfvars` belongs to bootstrap and local preview work, while day-2 remote runs read GitHub repository variables
-- runtime scheduling, retry, and backfill belong to hosted Airflow for this horizon rather than to GitHub Actions
+- runtime scheduling, retries, and backfills belong to hosted Airflow for this horizon rather than to GitHub Actions
 - Grafana, Airflow, MLflow, and Prometheus remain operator surfaces rather than rider-facing product surfaces
 - public docs should explain those surfaces with rendered evidence and checked-in configuration, not live control-plane embeds
 

--- a/docs/site/system/interfaces-and-surfaces.md
+++ b/docs/site/system/interfaces-and-surfaces.md
@@ -1,6 +1,6 @@
 # Interfaces and Surfaces
 
-FoehnCast exposes several different kinds of surfaces, but they do not all serve the same audience or carry the same exposure expectations. This page records the current boundary between rider-facing demos, service endpoints, operator tools, and public-safe docs evidence so readers do not have to reconstruct that split from the landing page, architecture page, inference page, and monitoring page.
+FoehnCast exposes several different kinds of surfaces, but they do not all serve the same audience or carry the same exposure expectations. This page records the current boundary between rider-facing demos, service endpoints, operator tools, delivery surfaces, and public-safe docs evidence so readers do not have to reconstruct that split from the landing page, architecture page, inference page, workflow docs, and monitoring page.
 
 !!! note "Scope"
 
@@ -33,6 +33,12 @@ flowchart LR
         GRAF[Grafana]
     end
 
+    subgraph Delivery["Delivery surfaces"]
+        GHA[GitHub Actions]
+        TF[Terraform]
+        BSTR[Bootstrap scripts]
+    end
+
     subgraph PublicSafe["Public-safe docs and evidence"]
         DOCS[Docs pages]
         EVID[Rendered summaries and screenshots]
@@ -45,6 +51,7 @@ flowchart LR
     RANK --> MET
     MET --> PROM
     PROM --> GRAF
+    GHA --> TF
 </div>
 
 The important split is that not every HTTP route is rider-facing, and not every visible screen is safe to treat as public documentation.
@@ -56,6 +63,7 @@ The important split is that not every HTTP route is rider-facing, and not every 
 | Rider-facing demo surfaces | Streamlit live demo and `/features/online/demo` | rider, reviewer, contributor | public-safe when shown as screenshots, rendered examples, or a deliberate local demo |
 | Service endpoints | `/health`, `/spots`, `/predict`, `/rank`, and `/features/online` | clients, smoke tests, support services, and app-side integrations | service-only |
 | Operator dashboards and control planes | `/metrics`, Airflow, MLflow, Prometheus, and Grafana | maintainer or deployment operator | private by default, except for the hosted app route itself |
+| Delivery surfaces | GitHub Actions workflows, Terraform apply paths, and bootstrap helpers | maintainer | review-controlled and not runtime-facing |
 | Public-safe docs and evidence | docs pages, rendered markdown, summary JSON-derived charts, and screenshots | reviewer, fork reader, course audience | public-safe |
 
 This means a surface can be technically reachable without being part of the rider-facing product boundary. The clearest example is `/metrics`: it is an application endpoint, but it belongs to the operator monitoring contract rather than to the public product surface.
@@ -99,6 +107,18 @@ The operator layer is where orchestration, tracking, monitoring, and review live
 
 This operator layer stays separate from the rider-facing and public-docs layers on purpose. The checked-in monitoring config disables anonymous Grafana access, public dashboards, and embedding by default. The local bootstrap applies local-only overrides only so a local run can verify provisioning without changing the hosted policy.
 
+## Delivery Surfaces
+
+The delivery layer is separate from the runtime operator layer.
+
+| Surface | Current role |
+|------|--------------|
+| GitHub Actions | lint, test, build, publish, and reviewed deploy or Terraform workflows |
+| Terraform | declare the cloud contract and apply reviewed infrastructure changes |
+| Bootstrap helpers | perform one-time environment setup and repository-variable seeding |
+
+These surfaces are not the runtime orchestrator. For the current horizon, GitHub Actions advances reviewed delivery, while hosted Airflow on GCP remains the runtime scheduling, retry, and backfill surface.
+
 ## Public-Safe Docs And Evidence
 
 The public docs site is a separate surface class, not a mirror of the live control plane.
@@ -130,6 +150,8 @@ That rule keeps the docs understandable in review without leaking a live control
 The shared hosted environment keeps the same rule as the docs: the app is the product and service surface, while operator tools stay private unless an operator intentionally publishes them.
 
 In the shared hosted lane, Cloud Run owns the public product and service surface. The hosted full-stack VM remains private and operator-only, and reopening its app route is a configuration error rather than a rollback step. The remaining VM gate is therefore about control-plane retirement, not about keeping a second public serving path alive.
+
+GitHub Actions and Terraform sit outside those runtime modes as delivery surfaces. They publish reviewed artifacts and infrastructure changes, but they do not become a public product surface or a runtime orchestration plane.
 
 ## Why This Boundary Works
 


### PR DESCRIPTION
## What changed
- add the explicit GitHub-versus-GCP delivery boundary to the public workflow and cloud-mapping docs
- update the README shared-hosted summary so reviewed delivery and runtime execution are described as separate planes
- extend the Interfaces and Surfaces page with a dedicated delivery-surface class so GitHub Actions, Terraform, and bootstrap helpers are not conflated with runtime operator surfaces

## Why
- the architecture story needed one concise public statement of what GitHub owns versus what the hosted runtime owns after the orchestration decision was made explicit
- this gives the later workflow refactor and runtime trigger work a stable acceptance boundary instead of relying on inferred wording across several docs pages

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-198 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #198
