### PR TITLE
refactor(ci): remove runtime orchestration from GitHub workflows

### DIFF
--- a/.github/workflows/promote-candidate.yml
+++ b/.github/workflows/promote-candidate.yml
@@ -21,27 +21,16 @@ on:
 
 permissions:
   contents: read
-  id-token: write
 
 jobs:
   config:
     runs-on: ubuntu-latest
     outputs:
       owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
-      project_id: ${{ steps.repo_config.outputs.project_id }}
-      location: ${{ steps.repo_config.outputs.location }}
-      cloud_run_service: ${{ steps.repo_config.outputs.cloud_run_service }}
-      cloud_run_allow_unauthenticated: ${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}
-      mlflow_tracking_uri: ${{ steps.repo_config.outputs.mlflow_tracking_uri }}
-      workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
-      service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
       candidate_revision_tag: ${{ steps.derived.outputs.candidate_revision_tag }}
       candidate_alias: ${{ steps.derived.outputs.candidate_alias }}
       target_alias: ${{ steps.derived.outputs.target_alias }}
-      promote_ready: ${{ steps.derived.outputs.promote_ready }}
     steps:
-      - uses: actions/checkout@v6.0.2
-
       - id: flags
         env:
           ACTOR: ${{ github.actor }}
@@ -57,27 +46,13 @@ jobs:
 
           echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
 
-      - id: repo_config
-        uses: ./.github/actions/load-gcp-repo-config
-        with:
-          repo-vars-json: ${{ toJson(vars) }}
-
       - id: derived
         env:
-          CLOUD_RUN_SERVICE: ${{ steps.repo_config.outputs.cloud_run_service }}
-          MLFLOW_TRACKING_URI: ${{ steps.repo_config.outputs.mlflow_tracking_uri }}
-          WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
-          SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
           CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
           CANDIDATE_ALIAS_INPUT: ${{ github.event.inputs.candidate_alias }}
           TARGET_ALIAS_INPUT: ${{ github.event.inputs.target_alias }}
         run: |
           set -euo pipefail
-
-          promote_ready=false
-          if [[ -n "$CLOUD_RUN_SERVICE" && -n "$MLFLOW_TRACKING_URI" && -n "$WORKLOAD_IDENTITY_PROVIDER" && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
-            promote_ready=true
-          fi
 
           candidate_revision_tag="$(printf '%s' "${CANDIDATE_REVISION_TAG_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
           candidate_revision_tag="${candidate_revision_tag#-}"
@@ -100,334 +75,29 @@ jobs:
             echo "candidate_revision_tag=$candidate_revision_tag"
             echo "candidate_alias=$candidate_alias"
             echo "target_alias=$target_alias"
-            echo "promote_ready=$promote_ready"
           } >> "$GITHUB_OUTPUT"
 
-  promote:
+  blocked:
     needs: config
-    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.promote_ready == 'true' }}
+    if: ${{ needs.config.outputs.owner_allowed == 'true' }}
     runs-on: ubuntu-latest
-    environment: cloud-run-production
     env:
-      GCP_PROJECT_ID: ${{ needs.config.outputs.project_id }}
-      GCP_LOCATION: ${{ needs.config.outputs.location }}
-      CLOUD_RUN_SERVICE: ${{ needs.config.outputs.cloud_run_service }}
-      CLOUD_RUN_ALLOW_UNAUTHENTICATED: ${{ needs.config.outputs.cloud_run_allow_unauthenticated }}
-      MLFLOW_TRACKING_URI: ${{ needs.config.outputs.mlflow_tracking_uri }}
       CANDIDATE_REVISION_TAG: ${{ needs.config.outputs.candidate_revision_tag }}
       CANDIDATE_ALIAS: ${{ needs.config.outputs.candidate_alias }}
       TARGET_ALIAS: ${{ needs.config.outputs.target_alias }}
     steps:
-      - uses: actions/checkout@v6.0.2
-
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
-          service_account: ${{ needs.config.outputs.service_account_email }}
-
-      - uses: google-github-actions/setup-gcloud@v2
-
-      - uses: astral-sh/setup-uv@v8.1.0
-
-      - name: Install runtime dependencies
-        run: uv sync --frozen --no-default-groups
-
-      - name: Confirm Cloud Run service exists
-        run: |
-          gcloud run services describe "$CLOUD_RUN_SERVICE" \
-            --project "$GCP_PROJECT_ID" \
-            --region "$GCP_LOCATION" \
-            --format='value(metadata.name)' >/dev/null
-
-      - id: resolve_candidate
-        name: Resolve candidate revision
-        run: |
-          set -euo pipefail
-
-          service_description="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format=json)"
-          candidate_revision_name="$(printf '%s' "$service_description" | jq -r --arg tag "$CANDIDATE_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .revisionName' | head -n1)"
-          candidate_url="$(printf '%s' "$service_description" | jq -r --arg tag "$CANDIDATE_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .url' | head -n1)"
-          candidate_traffic_percent="$(printf '%s' "$service_description" | jq -r --arg tag "$CANDIDATE_REVISION_TAG" 'first(.status.traffic[] | select(.tag == $tag) | (.percent // 0))')"
-
-          if [[ -z "$candidate_revision_name" || "$candidate_revision_name" == 'null' ]]; then
-            echo "Candidate revision tag ${CANDIDATE_REVISION_TAG} was not found on the Cloud Run service." >&2
-            exit 1
-          fi
-
-          if [[ -z "$candidate_url" || "$candidate_url" == 'null' ]]; then
-            echo "Candidate revision URL is empty for tag ${CANDIDATE_REVISION_TAG}." >&2
-            exit 1
-          fi
-
-          if [[ -z "$candidate_traffic_percent" || "$candidate_traffic_percent" == 'null' ]]; then
-            candidate_traffic_percent='0'
-          fi
-
-          if [[ "$candidate_traffic_percent" != '0' ]]; then
-            echo "Candidate revision must remain at 0% traffic before promotion." >&2
-            exit 1
-          fi
-
-          candidate_image="$(gcloud run revisions describe "$candidate_revision_name" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(spec.containers[0].image)')"
-          if [[ -z "$candidate_image" ]]; then
-            echo "Candidate revision image could not be resolved." >&2
-            exit 1
-          fi
-
-          {
-            echo "candidate_revision_name=${candidate_revision_name}"
-            echo "candidate_url=${candidate_url}"
-            echo "candidate_traffic_percent=${candidate_traffic_percent}"
-            echo "candidate_image=${candidate_image}"
-          } >> "$GITHUB_OUTPUT"
-
-      - id: verify_candidate
-        name: Verify candidate Cloud Run runtime
-        env:
-          SERVICE_URL: ${{ steps.resolve_candidate.outputs.candidate_url }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "$SERVICE_URL" ]]; then
-            echo "Candidate service URL is empty." >&2
-            exit 1
-          fi
-
-          health_url="${SERVICE_URL%/}/health"
-          allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
-          curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
-          invocation_mode="anonymous"
-
-          if [[ "$allow_unauthenticated" != 'true' ]]; then
-            invocation_mode="identity-token"
-            identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
-            curl_args+=(-H "Authorization: Bearer ${identity_token}")
-          fi
-
-          echo "Waiting for candidate health at ${health_url}..."
-          health_payload="$(curl "${curl_args[@]}" "$health_url")"
-          if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
-            echo "Candidate health verification failed." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${CANDIDATE_ALIAS}"'"'; then
-            echo "Candidate health verification did not report serving alias ${CANDIDATE_ALIAS}." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          candidate_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
-          if [[ -z "$candidate_model_version" ]]; then
-            echo "Candidate health payload did not include model_version." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          {
-            echo "candidate_model_version=${candidate_model_version}"
-            echo "candidate_invocation_mode=${invocation_mode}"
-          } >> "$GITHUB_OUTPUT"
-
-      - id: capture_live
-        name: Capture current live rollback inputs
-        run: |
-          set -euo pipefail
-
-          service_description="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format=json)"
-          live_service_url="$(printf '%s' "$service_description" | jq -r '.status.url // empty')"
-          if [[ -z "$live_service_url" ]]; then
-            echo "Current live service URL is empty." >&2
-            exit 1
-          fi
-
-          live_revision_name="$(printf '%s' "$service_description" | jq -r 'first(.status.traffic[] | select((.tag | not) and (.percent // 0) > 0) | .revisionName)')"
-          if [[ -z "$live_revision_name" || "$live_revision_name" == 'null' ]]; then
-            live_revision_name="$(printf '%s' "$service_description" | jq -r 'first(.status.traffic[] | select((.percent // 0) > 0) | .revisionName)')"
-          fi
-
-          if [[ -z "$live_revision_name" || "$live_revision_name" == 'null' ]]; then
-            echo "Current live revision could not be resolved before promotion." >&2
-            exit 1
-          fi
-
-          health_url="${live_service_url%/}/health"
-          allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
-          curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
-          invocation_mode="anonymous"
-
-          if [[ "$allow_unauthenticated" != 'true' ]]; then
-            invocation_mode="identity-token"
-            identity_token="$(gcloud auth print-identity-token --audiences="$live_service_url")"
-            curl_args+=(-H "Authorization: Bearer ${identity_token}")
-          fi
-
-          echo "Waiting for current live health at ${health_url}..."
-          health_payload="$(curl "${curl_args[@]}" "$health_url")"
-          if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
-            echo "Current live health verification failed before promotion." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          live_model_alias="$(printf '%s' "$health_payload" | jq -r '.model_alias // empty')"
-          if [[ -z "$live_model_alias" ]]; then
-            echo "Current live health payload did not include model_alias." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          live_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
-          if [[ -z "$live_model_version" ]]; then
-            echo "Current live health payload did not include model_version." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          {
-            echo "live_service_url=${live_service_url}"
-            echo "live_revision_name=${live_revision_name}"
-            echo "live_model_alias=${live_model_alias}"
-            echo "live_model_version=${live_model_version}"
-            echo "live_invocation_mode=${invocation_mode}"
-          } >> "$GITHUB_OUTPUT"
-
-      - id: promote_model
-        name: Promote candidate model version to champion
-        env:
-          CANDIDATE_MODEL_VERSION: ${{ steps.verify_candidate.outputs.candidate_model_version }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "$MLFLOW_TRACKING_URI" || -z "$CANDIDATE_MODEL_VERSION" ]]; then
-            echo "MLflow tracking URI and candidate model version are required for promotion." >&2
-            exit 1
-          fi
-
-          promoted_model_version="$(uv run python -m foehncast.training_pipeline.promote --version "$CANDIDATE_MODEL_VERSION" --target-stage Production)"
-          if [[ -z "$promoted_model_version" ]]; then
-            echo "Promoted model version output is empty." >&2
-            exit 1
-          fi
-
-          if [[ "$promoted_model_version" != "$CANDIDATE_MODEL_VERSION" ]]; then
-            echo "Promoted model version does not match the validated candidate model version." >&2
-            exit 1
-          fi
-
-          echo "promoted_model_version=${promoted_model_version}" >> "$GITHUB_OUTPUT"
-
-      - id: deploy_live
-        name: Deploy promoted image to live Cloud Run service
-        env:
-          CANDIDATE_IMAGE: ${{ steps.resolve_candidate.outputs.candidate_image }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "$CANDIDATE_IMAGE" ]]; then
-            echo "Candidate image is empty." >&2
-            exit 1
-          fi
-
-          gcloud run services update "$CLOUD_RUN_SERVICE" \
-            --project "$GCP_PROJECT_ID" \
-            --region "$GCP_LOCATION" \
-            --image "$CANDIDATE_IMAGE" \
-            --update-env-vars "FOEHNCAST_MLFLOW_SERVING_ALIAS=$TARGET_ALIAS" \
-            --quiet
-
-          live_service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
-          if [[ -z "$live_service_url" ]]; then
-            echo "Live Cloud Run service URL is empty after promotion deploy." >&2
-            exit 1
-          fi
-
-          echo "service_url=${live_service_url}" >> "$GITHUB_OUTPUT"
-
-      - id: verify_live
-        name: Verify promoted live Cloud Run runtime
-        env:
-          SERVICE_URL: ${{ steps.deploy_live.outputs.service_url }}
-          PROMOTED_MODEL_VERSION: ${{ steps.promote_model.outputs.promoted_model_version }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "$SERVICE_URL" || -z "$PROMOTED_MODEL_VERSION" ]]; then
-            echo "Live service URL and promoted model version are required for verification." >&2
-            exit 1
-          fi
-
-          health_url="${SERVICE_URL%/}/health"
-          spots_url="${SERVICE_URL%/}/spots"
-          allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
-          curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
-          invocation_mode="anonymous"
-
-          if [[ "$allow_unauthenticated" != 'true' ]]; then
-            invocation_mode="identity-token"
-            identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
-            curl_args+=(-H "Authorization: Bearer ${identity_token}")
-          fi
-
-          echo "Waiting for live health at ${health_url}..."
-          health_payload="$(curl "${curl_args[@]}" "$health_url")"
-          if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
-            echo "Live health verification failed." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${TARGET_ALIAS}"'"'; then
-            echo "Live health verification did not report serving alias ${TARGET_ALIAS}." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          live_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
-          if [[ "$live_model_version" != "$PROMOTED_MODEL_VERSION" ]]; then
-            echo "Live service model version does not match the promoted model version." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          echo "Checking live Cloud Run spots endpoint at ${spots_url}..."
-          spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
-          if ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
-            echo "Live Cloud Run spots verification failed." >&2
-            printf '%s\n' "$spots_payload" >&2
-            exit 1
-          fi
-
-          echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"
-
-      - name: Summarize promotion
-        run: |
-          {
-            echo "## Candidate promotion"
-            echo
-            echo "- Service: $CLOUD_RUN_SERVICE"
-            echo "- Candidate tag: $CANDIDATE_REVISION_TAG"
-            echo "- Candidate revision: ${{ steps.resolve_candidate.outputs.candidate_revision_name }}"
-            echo "- Candidate image: ${{ steps.resolve_candidate.outputs.candidate_image }}"
-            echo "- Promoted model version: ${{ steps.promote_model.outputs.promoted_model_version }}"
-            echo "- Live alias: $TARGET_ALIAS"
-            echo "- URL: ${{ steps.deploy_live.outputs.service_url }}"
-            echo "- Invocation: ${{ steps.verify_live.outputs.invocation_mode }}"
-            echo
-            echo "### Rollback inputs"
-            echo "- Revision: ${{ steps.capture_live.outputs.live_revision_name }}"
-            echo "- Model alias: ${{ steps.capture_live.outputs.live_model_alias }}"
-            echo "- Model version: ${{ steps.capture_live.outputs.live_model_version }}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  blocked:
-    needs: config
-    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.promote_ready != 'true' }}
-    runs-on: ubuntu-latest
-    steps:
       - name: Explain blocked promotion workflow
         run: |
           set -euo pipefail
-          echo 'Candidate promotion requires GCP_CLOUD_RUN_SERVICE, GCP_MLFLOW_TRACKING_URI, GCP_WORKLOAD_IDENTITY_PROVIDER, and GCP_SERVICE_ACCOUNT_EMAIL repository variables.' >&2
+          {
+            echo "## Candidate promotion moved out of GitHub"
+            echo
+            echo "- Candidate tag: $CANDIDATE_REVISION_TAG"
+            echo "- Candidate alias: $CANDIDATE_ALIAS"
+            echo "- Target alias: $TARGET_ALIAS"
+            echo
+            echo "GitHub Actions no longer promotes live runtime state directly."
+            echo "Use the runtime-side operator path until the explicit GitHub-to-runtime trigger contract lands."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo 'Candidate promotion is no longer executed directly from GitHub Actions. Use the runtime-side operator path until the explicit GitHub-to-runtime trigger contract is implemented.' >&2
           exit 1

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -10,26 +10,7 @@ on:
       - pyproject.toml
       - uv.lock
       - config.yaml
-  workflow_dispatch:
-    inputs:
-      deploy_mode:
-        description: Cloud Run deploy mode (`live` or `candidate`)
-        required: false
-        default: live
-        type: choice
-        options:
-          - live
-          - candidate
-      candidate_revision_tag:
-        description: Tagged Cloud Run revision name when deploy_mode=`candidate`
-        required: false
-        default: candidate
-        type: string
-      serving_alias:
-        description: Serving alias override (blank defaults to champion for live and candidate for candidate mode)
-        required: false
-        default: ""
-        type: string
+  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -40,20 +21,11 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
-      project_id: ${{ steps.repo_config.outputs.project_id }}
-      location: ${{ steps.repo_config.outputs.location }}
-      artifact_repository: ${{ steps.repo_config.outputs.artifact_repository }}
       workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
       service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
-      cloud_run_service: ${{ steps.repo_config.outputs.cloud_run_service }}
-      cloud_run_allow_unauthenticated: ${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}
-      deploy_mode: ${{ steps.derived.outputs.deploy_mode }}
-      cloud_run_revision_tag: ${{ steps.derived.outputs.cloud_run_revision_tag }}
-      serving_alias: ${{ steps.derived.outputs.serving_alias }}
       registry_host: ${{ steps.derived.outputs.registry_host }}
       image_repository: ${{ steps.derived.outputs.image_repository }}
       publish_ready: ${{ steps.derived.outputs.publish_ready }}
-      deploy_ready: ${{ steps.derived.outputs.deploy_ready }}
     env:
       IMAGE_NAME: foehncast-app
     steps:
@@ -86,10 +58,6 @@ jobs:
           ARTIFACT_REPOSITORY: ${{ steps.repo_config.outputs.artifact_repository }}
           WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
           SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
-          CLOUD_RUN_SERVICE: ${{ steps.repo_config.outputs.cloud_run_service }}
-          DEPLOY_MODE_INPUT: ${{ github.event.inputs.deploy_mode }}
-          CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
-          SERVING_ALIAS_INPUT: ${{ github.event.inputs.serving_alias }}
           IMAGE_NAME: ${{ env.IMAGE_NAME }}
         run: |
           set -euo pipefail
@@ -109,40 +77,10 @@ jobs:
             publish_ready=true
           fi
 
-          deploy_ready=false
-          if [[ "$publish_ready" == 'true' && -n "$CLOUD_RUN_SERVICE" ]]; then
-            deploy_ready=true
-          fi
-
-          deploy_mode="$(printf '%s' "${DEPLOY_MODE_INPUT:-}" | tr '[:upper:]' '[:lower:]')"
-          if [[ "$deploy_mode" != 'candidate' ]]; then
-            deploy_mode='live'
-          fi
-
-          cloud_run_revision_tag="$(printf '%s' "${CANDIDATE_REVISION_TAG_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
-          cloud_run_revision_tag="${cloud_run_revision_tag#-}"
-          cloud_run_revision_tag="${cloud_run_revision_tag%-}"
-          if [[ -z "$cloud_run_revision_tag" ]]; then
-            cloud_run_revision_tag='candidate'
-          fi
-
-          serving_alias="$(printf '%s' "${SERVING_ALIAS_INPUT:-}" | tr '[:upper:]' '[:lower:]')"
-          if [[ -z "$serving_alias" ]]; then
-            if [[ "$deploy_mode" == 'candidate' ]]; then
-              serving_alias='candidate'
-            else
-              serving_alias='champion'
-            fi
-          fi
-
           {
-            echo "deploy_mode=$deploy_mode"
-            echo "cloud_run_revision_tag=$cloud_run_revision_tag"
-            echo "serving_alias=$serving_alias"
             echo "registry_host=$registry_host"
             echo "image_repository=$image_repository"
             echo "publish_ready=$publish_ready"
-            echo "deploy_ready=$deploy_ready"
           } >> "$GITHUB_OUTPUT"
 
   publish:
@@ -200,163 +138,8 @@ jobs:
             echo
             echo "- Immutable: ${{ steps.image.outputs.immutable_tag }}"
             echo "- Floating: ${{ steps.image.outputs.latest_tag }}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  deploy:
-    needs: [config, publish]
-    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.publish.result == 'success' && needs.config.outputs.deploy_ready == 'true' }}
-    runs-on: ubuntu-latest
-    environment: cloud-run-production
-    env:
-      GCP_PROJECT_ID: ${{ needs.config.outputs.project_id }}
-      GCP_LOCATION: ${{ needs.config.outputs.location }}
-      CLOUD_RUN_SERVICE: ${{ needs.config.outputs.cloud_run_service }}
-      CLOUD_RUN_ALLOW_UNAUTHENTICATED: ${{ needs.config.outputs.cloud_run_allow_unauthenticated }}
-      DEPLOY_MODE: ${{ needs.config.outputs.deploy_mode }}
-      CLOUD_RUN_REVISION_TAG: ${{ needs.config.outputs.cloud_run_revision_tag }}
-      SERVING_ALIAS: ${{ needs.config.outputs.serving_alias }}
-      IMAGE_URI: ${{ needs.publish.outputs.image_uri }}
-    steps:
-      - uses: google-github-actions/auth@v2
-        with:
-          workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
-          service_account: ${{ needs.config.outputs.service_account_email }}
-
-      - uses: google-github-actions/setup-gcloud@v2
-
-      - name: Confirm Cloud Run service exists
-        run: |
-          gcloud run services describe "$CLOUD_RUN_SERVICE" \
-            --project "$GCP_PROJECT_ID" \
-            --region "$GCP_LOCATION" \
-            --format='value(metadata.name)' >/dev/null
-
-      - id: deploy
-        name: Deploy published image to Cloud Run
-        run: |
-          set -euo pipefail
-
-          if [[ "$DEPLOY_MODE" == 'candidate' ]]; then
-            gcloud run deploy "$CLOUD_RUN_SERVICE" \
-              --project "$GCP_PROJECT_ID" \
-              --region "$GCP_LOCATION" \
-              --image "$IMAGE_URI" \
-              --no-traffic \
-              --tag "$CLOUD_RUN_REVISION_TAG" \
-              --update-env-vars "FOEHNCAST_MLFLOW_SERVING_ALIAS=$SERVING_ALIAS" \
-              --quiet
-
-            service_description="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format=json)"
-            service_url="$(printf '%s' "$service_description" | jq -r --arg tag "$CLOUD_RUN_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .url' | head -n1)"
-            traffic_percent="$(printf '%s' "$service_description" | jq -r --arg tag "$CLOUD_RUN_REVISION_TAG" 'first(.status.traffic[] | select(.tag == $tag) | (.percent // 0))')"
-
-            if [[ -z "$service_url" || "$service_url" == 'null' ]]; then
-              echo "Candidate tagged revision URL is empty after deploy." >&2
-              exit 1
-            fi
-
-            if [[ -z "$traffic_percent" || "$traffic_percent" == 'null' ]]; then
-              traffic_percent='0'
-            fi
-
-            if [[ "$traffic_percent" != '0' ]]; then
-              echo "Candidate deployment must keep traffic at 0%." >&2
-              exit 1
-            fi
-          else
-            gcloud run services update "$CLOUD_RUN_SERVICE" \
-              --project "$GCP_PROJECT_ID" \
-              --region "$GCP_LOCATION" \
-              --image "$IMAGE_URI" \
-              --update-env-vars "FOEHNCAST_MLFLOW_SERVING_ALIAS=$SERVING_ALIAS" \
-              --quiet
-
-            service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
-            traffic_percent='100'
-          fi
-
-          {
-            echo "deploy_mode=$DEPLOY_MODE"
-            echo "service_url=${service_url}"
-            echo "traffic_percent=${traffic_percent}"
-          } >> "$GITHUB_OUTPUT"
-
-      - id: verify
-        name: Verify deployed Cloud Run runtime
-        env:
-          SERVICE_URL: ${{ steps.deploy.outputs.service_url }}
-        run: |
-          set -euo pipefail
-
-          if [[ -z "$SERVICE_URL" ]]; then
-            echo "Cloud Run service URL is empty after deploy." >&2
-            exit 1
-          fi
-
-          health_url="${SERVICE_URL%/}/health"
-          spots_url="${SERVICE_URL%/}/spots"
-          allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
-          curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
-          invocation_mode="anonymous"
-
-          if [[ "$allow_unauthenticated" != 'true' ]]; then
-            invocation_mode="identity-token"
-            identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
-            curl_args+=(-H "Authorization: Bearer ${identity_token}")
-          fi
-
-          echo "Waiting for Cloud Run health at ${health_url}..."
-          health_payload="$(curl "${curl_args[@]}" "$health_url")"
-          if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
-            echo "Cloud Run health verification failed." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-          if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${SERVING_ALIAS}"'"'; then
-            echo "Cloud Run health verification did not report serving alias ${SERVING_ALIAS}." >&2
-            printf '%s\n' "$health_payload" >&2
-            exit 1
-          fi
-
-          echo "Checking Cloud Run spots endpoint at ${spots_url}..."
-          spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
-          if ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
-            echo "Cloud Run spots verification failed." >&2
-            printf '%s\n' "$spots_payload" >&2
-            exit 1
-          fi
-
-          echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"
-
-      - name: Summarize Cloud Run deployment
-        run: |
-          {
-            echo "## Cloud Run deployment"
-            echo
-            echo "- Mode: $DEPLOY_MODE"
-            echo "- Service: $CLOUD_RUN_SERVICE"
-            echo "- Image: $IMAGE_URI"
-            echo "- URL: ${{ steps.deploy.outputs.service_url }}"
-            echo "- Serving alias: $SERVING_ALIAS"
-            echo "- Traffic: ${{ steps.deploy.outputs.traffic_percent }}%"
-            if [[ "$DEPLOY_MODE" == 'candidate' ]]; then
-              echo "- Tagged revision: $CLOUD_RUN_REVISION_TAG"
-            fi
-            echo "- Smoke check: passed"
-            echo "- Invocation: ${{ steps.verify.outputs.invocation_mode }}"
-          } >> "$GITHUB_STEP_SUMMARY"
-
-  deploy_skipped:
-    needs: [config, publish]
-    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.publish.result == 'success' && needs.config.outputs.deploy_ready != 'true' }}
-    runs-on: ubuntu-latest
-    steps:
-      - name: Explain skipped Cloud Run deploy
-        run: |
-          {
-            echo "## Cloud Run deploy skipped"
-            echo
-            echo "Set GCP_CLOUD_RUN_SERVICE to the Terraform-managed Cloud Run service name to enable automatic deploys after image publish."
+            echo "- Runtime handoff: not executed from GitHub in this workflow"
+            echo "- Next step: use the runtime-side trigger contract or operator path to deploy this image"
           } >> "$GITHUB_STEP_SUMMARY"
 
   skipped:
@@ -376,6 +159,5 @@ jobs:
             echo "- GCP_WORKLOAD_IDENTITY_PROVIDER"
             echo "- GCP_SERVICE_ACCOUNT_EMAIL"
             echo
-            echo "Optional for automatic Cloud Run deploys after publish:"
-            echo "- GCP_CLOUD_RUN_SERVICE"
+            echo "This workflow stops at image publication and does not deploy or promote runtime state."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/rollback-live-release.yml
+++ b/.github/workflows/rollback-live-release.yml
@@ -1,414 +1,118 @@
 name: Roll Back Live Release
 
 on:
-    workflow_dispatch:
-        inputs:
-            rollback_revision:
-                description: Exact Cloud Run revision to restore live traffic to
-                required: true
-                type: string
-            rollback_model_version:
-                description: Exact MLflow model version to restore to the live alias
-                required: true
-                type: string
-            rollback_revision_tag:
-                description: Temporary tag used to verify the rollback target before traffic is restored
-                required: false
-                default: rollback
-                type: string
-            target_alias:
-                description: MLflow alias the live service should use after rollback
-                required: false
-                default: champion
-                type: string
+  workflow_dispatch:
+    inputs:
+      rollback_revision:
+        description: Exact Cloud Run revision to restore live traffic to
+        required: true
+        type: string
+      rollback_model_version:
+        description: Exact MLflow model version to restore to the live alias
+        required: true
+        type: string
+      rollback_revision_tag:
+        description: Temporary tag used to verify the rollback target before traffic is restored
+        required: false
+        default: rollback
+        type: string
+      target_alias:
+        description: MLflow alias the live service should use after rollback
+        required: false
+        default: champion
+        type: string
 
 permissions:
-    contents: read
-    id-token: write
+  contents: read
 
 jobs:
-    config:
-        runs-on: ubuntu-latest
-        outputs:
-            owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
-            project_id: ${{ steps.repo_config.outputs.project_id }}
-            location: ${{ steps.repo_config.outputs.location }}
-            cloud_run_service: ${{ steps.repo_config.outputs.cloud_run_service }}
-            cloud_run_allow_unauthenticated: ${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}
-            mlflow_tracking_uri: ${{ steps.repo_config.outputs.mlflow_tracking_uri }}
-            workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
-            service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
-            rollback_revision: ${{ steps.derived.outputs.rollback_revision }}
-            rollback_model_version: ${{ steps.derived.outputs.rollback_model_version }}
-            rollback_revision_tag: ${{ steps.derived.outputs.rollback_revision_tag }}
-            target_alias: ${{ steps.derived.outputs.target_alias }}
-            rollback_ready: ${{ steps.derived.outputs.rollback_ready }}
-        steps:
-            - uses: actions/checkout@v6.0.2
-
-            - id: flags
-              env:
-                  ACTOR: ${{ github.actor }}
-                  TRIGGERING_ACTOR: ${{ github.triggering_actor }}
-                  REPOSITORY_OWNER: ${{ github.repository_owner }}
-              run: |
-                  set -euo pipefail
-
-                  owner_allowed=false
-                  if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
-                    owner_allowed=true
-                  fi
-
-                  echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
-
-            - id: repo_config
-              uses: ./.github/actions/load-gcp-repo-config
-              with:
-                  repo-vars-json: ${{ toJson(vars) }}
-
-            - id: derived
-              env:
-                  CLOUD_RUN_SERVICE: ${{ steps.repo_config.outputs.cloud_run_service }}
-                  MLFLOW_TRACKING_URI: ${{ steps.repo_config.outputs.mlflow_tracking_uri }}
-                  WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
-                  SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
-                  ROLLBACK_REVISION_INPUT: ${{ github.event.inputs.rollback_revision }}
-                  ROLLBACK_MODEL_VERSION_INPUT: ${{ github.event.inputs.rollback_model_version }}
-                  ROLLBACK_REVISION_TAG_INPUT: ${{ github.event.inputs.rollback_revision_tag }}
-                  TARGET_ALIAS_INPUT: ${{ github.event.inputs.target_alias }}
-              run: |
-                  set -euo pipefail
-
-                  rollback_ready=false
-                  if [[ -n "$CLOUD_RUN_SERVICE" && -n "$MLFLOW_TRACKING_URI" && -n "$WORKLOAD_IDENTITY_PROVIDER" && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
-                    rollback_ready=true
-                  fi
-
-                  rollback_revision="$(printf '%s' "${ROLLBACK_REVISION_INPUT:-}" | tr -d '[:space:]')"
-                  if [[ -z "$rollback_revision" ]]; then
-                    echo "rollback_revision is required." >&2
-                    exit 1
-                  fi
-
-                  rollback_model_version="$(printf '%s' "${ROLLBACK_MODEL_VERSION_INPUT:-}" | tr -d '[:space:]')"
-                  if [[ -z "$rollback_model_version" ]]; then
-                    echo "rollback_model_version is required." >&2
-                    exit 1
-                  fi
-
-                  rollback_revision_tag="$(printf '%s' "${ROLLBACK_REVISION_TAG_INPUT:-rollback}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
-                  rollback_revision_tag="${rollback_revision_tag#-}"
-                  rollback_revision_tag="${rollback_revision_tag%-}"
-                  if [[ -z "$rollback_revision_tag" ]]; then
-                    rollback_revision_tag='rollback'
-                  fi
-
-                  target_alias="$(printf '%s' "${TARGET_ALIAS_INPUT:-champion}" | tr '[:upper:]' '[:lower:]')"
-                  if [[ -z "$target_alias" ]]; then
-                    target_alias='champion'
-                  fi
-
-                  {
-                    echo "rollback_revision=$rollback_revision"
-                    echo "rollback_model_version=$rollback_model_version"
-                    echo "rollback_revision_tag=$rollback_revision_tag"
-                    echo "target_alias=$target_alias"
-                    echo "rollback_ready=$rollback_ready"
-                  } >> "$GITHUB_OUTPUT"
-
-    rollback:
-        needs: config
-        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.rollback_ready == 'true' }}
-        runs-on: ubuntu-latest
-        environment: cloud-run-production
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
+      rollback_revision: ${{ steps.derived.outputs.rollback_revision }}
+      rollback_model_version: ${{ steps.derived.outputs.rollback_model_version }}
+      rollback_revision_tag: ${{ steps.derived.outputs.rollback_revision_tag }}
+      target_alias: ${{ steps.derived.outputs.target_alias }}
+    steps:
+      - id: flags
         env:
-            GCP_PROJECT_ID: ${{ needs.config.outputs.project_id }}
-            GCP_LOCATION: ${{ needs.config.outputs.location }}
-            CLOUD_RUN_SERVICE: ${{ needs.config.outputs.cloud_run_service }}
-            CLOUD_RUN_ALLOW_UNAUTHENTICATED: ${{ needs.config.outputs.cloud_run_allow_unauthenticated }}
-            MLFLOW_TRACKING_URI: ${{ needs.config.outputs.mlflow_tracking_uri }}
-            ROLLBACK_REVISION: ${{ needs.config.outputs.rollback_revision }}
-            ROLLBACK_MODEL_VERSION: ${{ needs.config.outputs.rollback_model_version }}
-            ROLLBACK_REVISION_TAG: ${{ needs.config.outputs.rollback_revision_tag }}
-            TARGET_ALIAS: ${{ needs.config.outputs.target_alias }}
-        steps:
-            - uses: actions/checkout@v6.0.2
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
 
-            - uses: google-github-actions/auth@v2
-              with:
-                  workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
-                  service_account: ${{ needs.config.outputs.service_account_email }}
+          owner_allowed=false
+          if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
+            owner_allowed=true
+          fi
 
-            - uses: google-github-actions/setup-gcloud@v2
+          echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
 
-            - uses: astral-sh/setup-uv@v8.1.0
+      - id: derived
+        env:
+          ROLLBACK_REVISION_INPUT: ${{ github.event.inputs.rollback_revision }}
+          ROLLBACK_MODEL_VERSION_INPUT: ${{ github.event.inputs.rollback_model_version }}
+          ROLLBACK_REVISION_TAG_INPUT: ${{ github.event.inputs.rollback_revision_tag }}
+          TARGET_ALIAS_INPUT: ${{ github.event.inputs.target_alias }}
+        run: |
+          set -euo pipefail
 
-            - name: Install runtime dependencies
-              run: uv sync --frozen --no-default-groups
+          rollback_revision="$(printf '%s' "${ROLLBACK_REVISION_INPUT:-}" | tr -d '[:space:]')"
+          if [[ -z "$rollback_revision" ]]; then
+            echo "rollback_revision is required." >&2
+            exit 1
+          fi
 
-            - name: Confirm Cloud Run service exists
-              run: |
-                  gcloud run services describe "$CLOUD_RUN_SERVICE" \
-                    --project "$GCP_PROJECT_ID" \
-                    --region "$GCP_LOCATION" \
-                    --format='value(metadata.name)' >/dev/null
+          rollback_model_version="$(printf '%s' "${ROLLBACK_MODEL_VERSION_INPUT:-}" | tr -d '[:space:]')"
+          if [[ -z "$rollback_model_version" ]]; then
+            echo "rollback_model_version is required." >&2
+            exit 1
+          fi
 
-            - id: resolve_rollback
-              name: Resolve rollback revision
-              run: |
-                  set -euo pipefail
+          rollback_revision_tag="$(printf '%s' "${ROLLBACK_REVISION_TAG_INPUT:-rollback}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+          rollback_revision_tag="${rollback_revision_tag#-}"
+          rollback_revision_tag="${rollback_revision_tag%-}"
+          if [[ -z "$rollback_revision_tag" ]]; then
+            rollback_revision_tag='rollback'
+          fi
 
-                  rollback_revision_name="$(gcloud run revisions describe "$ROLLBACK_REVISION" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(metadata.name)')"
-                  if [[ -z "$rollback_revision_name" ]]; then
-                    echo "Rollback revision ${ROLLBACK_REVISION} could not be resolved." >&2
-                    exit 1
-                  fi
+          target_alias="$(printf '%s' "${TARGET_ALIAS_INPUT:-champion}" | tr '[:upper:]' '[:lower:]')"
+          if [[ -z "$target_alias" ]]; then
+            target_alias='champion'
+          fi
 
-                  rollback_image="$(gcloud run revisions describe "$ROLLBACK_REVISION" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(spec.containers[0].image)')"
-                  if [[ -z "$rollback_image" ]]; then
-                    echo "Rollback revision image could not be resolved." >&2
-                    exit 1
-                  fi
+          {
+            echo "rollback_revision=$rollback_revision"
+            echo "rollback_model_version=$rollback_model_version"
+            echo "rollback_revision_tag=$rollback_revision_tag"
+            echo "target_alias=$target_alias"
+          } >> "$GITHUB_OUTPUT"
 
-                  gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
-                    --project "$GCP_PROJECT_ID" \
-                    --region "$GCP_LOCATION" \
-                    --update-tags "$ROLLBACK_REVISION_TAG=$ROLLBACK_REVISION" \
-                    --quiet
-
-                  service_description="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format=json)"
-                  rollback_tag_url="$(printf '%s' "$service_description" | jq -r --arg tag "$ROLLBACK_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .url' | head -n1)"
-                  rollback_tag_revision="$(printf '%s' "$service_description" | jq -r --arg tag "$ROLLBACK_REVISION_TAG" '.status.traffic[] | select(.tag == $tag) | .revisionName' | head -n1)"
-
-                  if [[ -z "$rollback_tag_url" || "$rollback_tag_url" == 'null' ]]; then
-                    echo "Rollback tag URL is empty after tagging revision ${ROLLBACK_REVISION}." >&2
-                    exit 1
-                  fi
-
-                  if [[ "$rollback_tag_revision" != "$ROLLBACK_REVISION" ]]; then
-                    echo "Rollback tag does not point at the requested revision." >&2
-                    exit 1
-                  fi
-
-                  {
-                    echo "rollback_revision_name=${rollback_revision_name}"
-                    echo "rollback_image=${rollback_image}"
-                    echo "rollback_tag_url=${rollback_tag_url}"
-                  } >> "$GITHUB_OUTPUT"
-
-            - id: verify_rollback_target
-              name: Verify rollback target runtime
-              env:
-                  SERVICE_URL: ${{ steps.resolve_rollback.outputs.rollback_tag_url }}
-              run: |
-                  set -euo pipefail
-
-                  if [[ -z "$SERVICE_URL" ]]; then
-                    echo "Rollback target service URL is empty." >&2
-                    exit 1
-                  fi
-
-                  health_url="${SERVICE_URL%/}/health"
-                  allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
-                  curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
-                  invocation_mode="anonymous"
-
-                  if [[ "$allow_unauthenticated" != 'true' ]]; then
-                    invocation_mode="identity-token"
-                    identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
-                    curl_args+=(-H "Authorization: Bearer ${identity_token}")
-                  fi
-
-                  echo "Waiting for rollback target health at ${health_url}..."
-                  health_payload="$(curl "${curl_args[@]}" "$health_url")"
-                  if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
-                    echo "Rollback target health verification failed." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${TARGET_ALIAS}"'"'; then
-                    echo "Rollback target health verification did not report serving alias ${TARGET_ALIAS}." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  rollback_target_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
-                  if [[ -z "$rollback_target_model_version" ]]; then
-                    echo "Rollback target health payload did not include model_version." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  {
-                    echo "rollback_target_model_version=${rollback_target_model_version}"
-                    echo "rollback_target_invocation_mode=${invocation_mode}"
-                  } >> "$GITHUB_OUTPUT"
-
-            - id: restore_model
-              name: Restore champion alias to rollback model version
-              run: |
-                  set -euo pipefail
-
-                  restored_model_version="$(uv run python -m foehncast.training_pipeline.rollback --version "$ROLLBACK_MODEL_VERSION" --target-alias "$TARGET_ALIAS")"
-                  if [[ -z "$restored_model_version" ]]; then
-                    echo "Rollback helper returned an empty model version." >&2
-                    exit 1
-                  fi
-
-                  if [[ "$restored_model_version" != "$ROLLBACK_MODEL_VERSION" ]]; then
-                    echo "Rollback helper did not restore the requested model version." >&2
-                    exit 1
-                  fi
-
-                  echo "restored_model_version=${restored_model_version}" >> "$GITHUB_OUTPUT"
-
-            - id: reverify_rollback_target
-              name: Reverify rollback target with restored model version
-              env:
-                  SERVICE_URL: ${{ steps.resolve_rollback.outputs.rollback_tag_url }}
-                  RESTORED_MODEL_VERSION: ${{ steps.restore_model.outputs.restored_model_version }}
-              run: |
-                  set -euo pipefail
-
-                  if [[ -z "$SERVICE_URL" || -z "$RESTORED_MODEL_VERSION" ]]; then
-                    echo "Rollback target service URL and restored model version are required for pre-traffic revalidation." >&2
-                    exit 1
-                  fi
-
-                  health_url="${SERVICE_URL%/}/health"
-                  allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
-                  curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
-                  invocation_mode="anonymous"
-
-                  if [[ "$allow_unauthenticated" != 'true' ]]; then
-                    invocation_mode="identity-token"
-                    identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
-                    curl_args+=(-H "Authorization: Bearer ${identity_token}")
-                  fi
-
-                  echo "Waiting for rollback target health after alias restore at ${health_url}..."
-                  health_payload="$(curl "${curl_args[@]}" "$health_url")"
-                  if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
-                    echo "Rollback target health revalidation failed after alias restore." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${TARGET_ALIAS}"'"'; then
-                    echo "Rollback target revalidation did not report serving alias ${TARGET_ALIAS}." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  rollback_target_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
-                  if [[ "$rollback_target_model_version" != "$RESTORED_MODEL_VERSION" ]]; then
-                    echo "Rollback target revalidation did not report the restored model version." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"
-
-            - id: shift_traffic
-              name: Restore live traffic to rollback revision
-              run: |
-                  set -euo pipefail
-
-                  gcloud run services update-traffic "$CLOUD_RUN_SERVICE" \
-                    --project "$GCP_PROJECT_ID" \
-                    --region "$GCP_LOCATION" \
-                    --update-tags "$ROLLBACK_REVISION_TAG=$ROLLBACK_REVISION" \
-                    --to-revisions "$ROLLBACK_REVISION=100" \
-                    --quiet
-
-                  service_url="$(gcloud run services describe "$CLOUD_RUN_SERVICE" --project "$GCP_PROJECT_ID" --region "$GCP_LOCATION" --format='value(status.url)')"
-                  if [[ -z "$service_url" ]]; then
-                    echo "Live Cloud Run service URL is empty after rollback." >&2
-                    exit 1
-                  fi
-
-                  echo "service_url=${service_url}" >> "$GITHUB_OUTPUT"
-
-            - id: verify_live
-              name: Verify rolled back live runtime
-              env:
-                  SERVICE_URL: ${{ steps.shift_traffic.outputs.service_url }}
-                  RESTORED_MODEL_VERSION: ${{ steps.restore_model.outputs.restored_model_version }}
-              run: |
-                  set -euo pipefail
-
-                  if [[ -z "$SERVICE_URL" || -z "$RESTORED_MODEL_VERSION" ]]; then
-                    echo "Live service URL and restored model version are required for rollback verification." >&2
-                    exit 1
-                  fi
-
-                  health_url="${SERVICE_URL%/}/health"
-                  spots_url="${SERVICE_URL%/}/spots"
-                  allow_unauthenticated="$(printf '%s' "${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}" | tr '[:upper:]' '[:lower:]')"
-                  curl_args=(--retry 30 --retry-all-errors --retry-delay 10 -fsS)
-                  invocation_mode="anonymous"
-
-                  if [[ "$allow_unauthenticated" != 'true' ]]; then
-                    invocation_mode="identity-token"
-                    identity_token="$(gcloud auth print-identity-token --audiences="$SERVICE_URL")"
-                    curl_args+=(-H "Authorization: Bearer ${identity_token}")
-                  fi
-
-                  echo "Waiting for live rollback health at ${health_url}..."
-                  health_payload="$(curl "${curl_args[@]}" "$health_url")"
-                  if ! printf '%s' "$health_payload" | grep -Eq '"status"[[:space:]]*:[[:space:]]*"healthy"'; then
-                    echo "Live rollback health verification failed." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  if ! printf '%s' "$health_payload" | grep -Eq '"model_alias"[[:space:]]*:[[:space:]]*"'"${TARGET_ALIAS}"'"'; then
-                    echo "Live rollback health verification did not report serving alias ${TARGET_ALIAS}." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  live_model_version="$(printf '%s' "$health_payload" | jq -r '.model_version // empty')"
-                  if [[ "$live_model_version" != "$RESTORED_MODEL_VERSION" ]]; then
-                    echo "Live rollback model version does not match the restored model version." >&2
-                    printf '%s\n' "$health_payload" >&2
-                    exit 1
-                  fi
-
-                  echo "Checking live Cloud Run spots endpoint at ${spots_url}..."
-                  spots_payload="$(curl "${curl_args[@]}" "$spots_url")"
-                  if ! printf '%s' "$spots_payload" | grep -Eq '"id"[[:space:]]*:'; then
-                    echo "Live Cloud Run spots verification failed after rollback." >&2
-                    printf '%s\n' "$spots_payload" >&2
-                    exit 1
-                  fi
-
-                  echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"
-
-            - name: Summarize rollback
-              run: |
-                  {
-                    echo "## Live rollback"
-                    echo
-                    echo "- Service: $CLOUD_RUN_SERVICE"
-                    echo "- Rollback revision: $ROLLBACK_REVISION"
-                    echo "- Rollback tag: $ROLLBACK_REVISION_TAG"
-                    echo "- Rollback image: ${{ steps.resolve_rollback.outputs.rollback_image }}"
-                    echo "- Restored model version: ${{ steps.restore_model.outputs.restored_model_version }}"
-                    echo "- Live alias: $TARGET_ALIAS"
-                    echo "- URL: ${{ steps.shift_traffic.outputs.service_url }}"
-                    echo "- Tagged revalidation: passed"
-                    echo "- Invocation: ${{ steps.verify_live.outputs.invocation_mode }}"
-                  } >> "$GITHUB_STEP_SUMMARY"
-
-    blocked:
-        needs: config
-        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.rollback_ready != 'true' }}
-        runs-on: ubuntu-latest
-        steps:
-            - name: Explain blocked rollback workflow
-              run: |
-                  set -euo pipefail
-                  echo 'Live rollback requires GCP_CLOUD_RUN_SERVICE, GCP_MLFLOW_TRACKING_URI, GCP_WORKLOAD_IDENTITY_PROVIDER, and GCP_SERVICE_ACCOUNT_EMAIL repository variables.' >&2
-                  exit 1
+  blocked:
+    needs: config
+    if: ${{ needs.config.outputs.owner_allowed == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      ROLLBACK_REVISION: ${{ needs.config.outputs.rollback_revision }}
+      ROLLBACK_MODEL_VERSION: ${{ needs.config.outputs.rollback_model_version }}
+      ROLLBACK_REVISION_TAG: ${{ needs.config.outputs.rollback_revision_tag }}
+      TARGET_ALIAS: ${{ needs.config.outputs.target_alias }}
+    steps:
+      - name: Explain blocked rollback workflow
+        run: |
+          set -euo pipefail
+          {
+            echo "## Live rollback moved out of GitHub"
+            echo
+            echo "- Rollback revision: $ROLLBACK_REVISION"
+            echo "- Rollback model version: $ROLLBACK_MODEL_VERSION"
+            echo "- Rollback tag: $ROLLBACK_REVISION_TAG"
+            echo "- Target alias: $TARGET_ALIAS"
+            echo
+            echo "GitHub Actions no longer restores live runtime state directly."
+            echo "Use the runtime-side operator path until the explicit GitHub-to-runtime trigger contract lands."
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo 'Live rollback is no longer executed directly from GitHub Actions. Use the runtime-side operator path until the explicit GitHub-to-runtime trigger contract is implemented.' >&2
+          exit 1

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -515,178 +515,100 @@ def test_remote_terraform_workflow_verifies_hosted_runtimes_after_apply() -> Non
     assert '} >> "$GITHUB_OUTPUT"' in verify_script
 
 
-def test_publish_app_image_uses_provisioned_cloud_run_service_for_deploys() -> None:
+def test_publish_app_image_stops_at_image_publish_boundary() -> None:
     workflow = _workflow_yaml(".github/workflows/publish-app-image.yml")
     config_job = workflow["jobs"]["config"]
-    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
 
-    assert dispatch_inputs["deploy_mode"]["type"] == "choice"
-    assert dispatch_inputs["deploy_mode"]["options"] == ["live", "candidate"]
-    assert dispatch_inputs["candidate_revision_tag"]["default"] == "candidate"
-    assert dispatch_inputs["serving_alias"]["default"] == ""
-
+    assert workflow["on"]["workflow_dispatch"] == {}
     assert (
-        config_job["outputs"]["cloud_run_service"]
-        == "${{ steps.repo_config.outputs.cloud_run_service }}"
+        config_job["outputs"]["workload_identity_provider"]
+        == "${{ steps.repo_config.outputs.workload_identity_provider }}"
     )
     assert (
-        config_job["outputs"]["cloud_run_allow_unauthenticated"]
-        == "${{ steps.repo_config.outputs.cloud_run_allow_unauthenticated }}"
+        config_job["outputs"]["service_account_email"]
+        == "${{ steps.repo_config.outputs.service_account_email }}"
     )
     assert (
-        config_job["outputs"]["deploy_mode"]
-        == "${{ steps.derived.outputs.deploy_mode }}"
+        config_job["outputs"]["registry_host"]
+        == "${{ steps.derived.outputs.registry_host }}"
     )
     assert (
-        config_job["outputs"]["cloud_run_revision_tag"]
-        == "${{ steps.derived.outputs.cloud_run_revision_tag }}"
+        config_job["outputs"]["image_repository"]
+        == "${{ steps.derived.outputs.image_repository }}"
     )
     assert (
-        config_job["outputs"]["serving_alias"]
-        == "${{ steps.derived.outputs.serving_alias }}"
+        config_job["outputs"]["publish_ready"]
+        == "${{ steps.derived.outputs.publish_ready }}"
     )
+    assert "cloud_run_service" not in config_job["outputs"]
+    assert "cloud_run_allow_unauthenticated" not in config_job["outputs"]
+    assert "deploy_mode" not in config_job["outputs"]
+    assert "cloud_run_revision_tag" not in config_job["outputs"]
+    assert "serving_alias" not in config_job["outputs"]
+    assert "deploy_ready" not in config_job["outputs"]
 
     derived_step = _workflow_step(workflow, "config", "derived")
-    assert (
-        derived_step["env"]["CLOUD_RUN_SERVICE"]
-        == "${{ steps.repo_config.outputs.cloud_run_service }}"
-    )
-    assert (
-        derived_step["env"]["DEPLOY_MODE_INPUT"]
-        == "${{ github.event.inputs.deploy_mode }}"
-    )
-    assert (
-        derived_step["env"]["CANDIDATE_REVISION_TAG_INPUT"]
-        == "${{ github.event.inputs.candidate_revision_tag }}"
-    )
-    assert (
-        derived_step["env"]["SERVING_ALIAS_INPUT"]
-        == "${{ github.event.inputs.serving_alias }}"
-    )
-    assert '-n "$CLOUD_RUN_SERVICE"' in derived_step["run"]
-    assert "deploy_mode='live'" in derived_step["run"]
-    assert "cloud_run_revision_tag='candidate'" in derived_step["run"]
-    assert "serving_alias='candidate'" in derived_step["run"]
-    assert "serving_alias='champion'" in derived_step["run"]
+    assert "CLOUD_RUN_SERVICE" not in derived_step["env"]
+    assert "DEPLOY_MODE_INPUT" not in derived_step["env"]
+    assert "CANDIDATE_REVISION_TAG_INPUT" not in derived_step["env"]
+    assert "SERVING_ALIAS_INPUT" not in derived_step["env"]
+    assert "deploy_ready" not in derived_step["run"]
+    assert "deploy_mode" not in derived_step["run"]
+    assert "cloud_run_revision_tag" not in derived_step["run"]
+    assert "serving_alias" not in derived_step["run"]
 
-    deploy_job = workflow["jobs"]["deploy"]
+    publish_job = workflow["jobs"]["publish"]
     assert (
-        deploy_job["env"]["CLOUD_RUN_SERVICE"]
-        == "${{ needs.config.outputs.cloud_run_service }}"
-    )
-    assert (
-        deploy_job["env"]["CLOUD_RUN_ALLOW_UNAUTHENTICATED"]
-        == "${{ needs.config.outputs.cloud_run_allow_unauthenticated }}"
-    )
-    assert deploy_job["env"]["DEPLOY_MODE"] == "${{ needs.config.outputs.deploy_mode }}"
-    assert (
-        deploy_job["env"]["CLOUD_RUN_REVISION_TAG"]
-        == "${{ needs.config.outputs.cloud_run_revision_tag }}"
-    )
-    assert (
-        deploy_job["env"]["SERVING_ALIAS"]
-        == "${{ needs.config.outputs.serving_alias }}"
+        publish_job["outputs"]["image_uri"]
+        == "${{ steps.image.outputs.immutable_tag }}"
     )
 
-    deploy_step = _workflow_step(
-        workflow, "deploy", "Deploy published image to Cloud Run"
-    )
-    deploy_script = deploy_step["run"]
-
-    assert "if [[ \"$DEPLOY_MODE\" == 'candidate' ]]; then" in deploy_script
-    assert 'gcloud run deploy "$CLOUD_RUN_SERVICE"' in deploy_script
-    assert "--no-traffic" in deploy_script
-    assert ' --tag "$CLOUD_RUN_REVISION_TAG"' in deploy_script
-    assert "FOEHNCAST_MLFLOW_SERVING_ALIAS=$SERVING_ALIAS" in deploy_script
-    assert "traffic_percent='100'" in deploy_script
-    assert 'echo "traffic_percent=${traffic_percent}"' in deploy_script
-
-    verify_step = _workflow_step(
-        workflow, "deploy", "Verify deployed Cloud Run runtime"
-    )
-    verify_script = verify_step["run"]
-
+    summary_step = _workflow_step(workflow, "publish", "Summarize published image")
     assert (
-        verify_step["env"]["SERVICE_URL"] == "${{ steps.deploy.outputs.service_url }}"
-    )
-    assert 'health_url="${SERVICE_URL%/}/health"' in verify_script
-    assert 'spots_url="${SERVICE_URL%/}/spots"' in verify_script
-    assert (
-        "allow_unauthenticated=\"$(printf '%s' \"${CLOUD_RUN_ALLOW_UNAUTHENTICATED:-}\" | tr '[:upper:]' '[:lower:]')\""
-        in verify_script
-    )
-    assert (
-        'gcloud auth print-identity-token --audiences="$SERVICE_URL"' in verify_script
-    )
-    assert (
-        'grep -Eq \x27"status"[[:space:]]*:[[:space:]]*"healthy"\x27' in verify_script
-    )
-    assert '"model_alias"' in verify_script
-    assert (
-        "Cloud Run health verification did not report serving alias ${SERVING_ALIAS}."
-        in verify_script
-    )
-    assert 'grep -Eq \x27"id"[[:space:]]*:\x27' in verify_script
-    assert (
-        'echo "invocation_mode=${invocation_mode}" >> "$GITHUB_OUTPUT"' in verify_script
-    )
-
-    summary_step = _workflow_step(workflow, "deploy", "Summarize Cloud Run deployment")
-    assert 'echo "- Mode: $DEPLOY_MODE"' in summary_step["run"]
-    assert 'echo "- Serving alias: $SERVING_ALIAS"' in summary_step["run"]
-    assert (
-        'echo "- Traffic: ${{ steps.deploy.outputs.traffic_percent }}%"'
+        'echo "- Runtime handoff: not executed from GitHub in this workflow"'
         in summary_step["run"]
     )
-    assert 'echo "- Tagged revision: $CLOUD_RUN_REVISION_TAG"' in summary_step["run"]
-    assert 'echo "- Smoke check: passed"' in summary_step["run"]
     assert (
-        'echo "- Invocation: ${{ steps.verify.outputs.invocation_mode }}"'
+        'echo "- Next step: use the runtime-side trigger contract or operator path to deploy this image"'
         in summary_step["run"]
     )
 
+    assert "deploy" not in workflow["jobs"]
+    assert "deploy_skipped" not in workflow["jobs"]
 
-def test_promote_candidate_workflow_reuses_validated_candidate_for_live_promotion() -> (
+    skipped_step = _workflow_step(workflow, "skipped", "Explain skipped publish")
+    assert (
+        "This workflow stops at image publication and does not deploy or promote runtime state."
+        in skipped_step["run"]
+    )
+    assert "GCP_CLOUD_RUN_SERVICE" not in skipped_step["run"]
+
+
+def test_promote_candidate_workflow_is_blocked_pending_runtime_trigger_contract() -> (
     None
 ):
     workflow = _workflow_yaml(".github/workflows/promote-candidate.yml")
     config_job = workflow["jobs"]["config"]
     dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    config_steps = {
+        step.get("id") or step.get("name")
+        for step in workflow["jobs"]["config"]["steps"]
+    }
 
+    assert workflow["permissions"] == {"contents": "read"}
     assert dispatch_inputs["candidate_revision_tag"]["default"] == "candidate"
     assert dispatch_inputs["candidate_alias"]["default"] == "candidate"
     assert dispatch_inputs["target_alias"]["default"] == "champion"
 
-    assert (
-        config_job["outputs"]["cloud_run_service"]
-        == "${{ steps.repo_config.outputs.cloud_run_service }}"
-    )
-    assert (
-        config_job["outputs"]["mlflow_tracking_uri"]
-        == "${{ steps.repo_config.outputs.mlflow_tracking_uri }}"
-    )
-    assert (
-        config_job["outputs"]["candidate_revision_tag"]
-        == "${{ steps.derived.outputs.candidate_revision_tag }}"
-    )
-    assert (
-        config_job["outputs"]["candidate_alias"]
-        == "${{ steps.derived.outputs.candidate_alias }}"
-    )
-    assert (
-        config_job["outputs"]["target_alias"]
-        == "${{ steps.derived.outputs.target_alias }}"
-    )
-    assert (
-        config_job["outputs"]["promote_ready"]
-        == "${{ steps.derived.outputs.promote_ready }}"
-    )
+    assert set(config_job["outputs"]) == {
+        "owner_allowed",
+        "candidate_revision_tag",
+        "candidate_alias",
+        "target_alias",
+    }
+    assert "repo_config" not in config_steps
 
     derived_step = _workflow_step(workflow, "config", "derived")
-    assert (
-        derived_step["env"]["MLFLOW_TRACKING_URI"]
-        == "${{ steps.repo_config.outputs.mlflow_tracking_uri }}"
-    )
     assert (
         derived_step["env"]["CANDIDATE_REVISION_TAG_INPUT"]
         == "${{ github.event.inputs.candidate_revision_tag }}"
@@ -699,194 +621,66 @@ def test_promote_candidate_workflow_reuses_validated_candidate_for_live_promotio
         derived_step["env"]["TARGET_ALIAS_INPUT"]
         == "${{ github.event.inputs.target_alias }}"
     )
-    assert "promote_ready=true" in derived_step["run"]
     assert "candidate_revision_tag='candidate'" in derived_step["run"]
     assert "candidate_alias='candidate'" in derived_step["run"]
     assert "target_alias='champion'" in derived_step["run"]
+    assert "promote_ready" not in derived_step["run"]
 
-    promote_job = workflow["jobs"]["promote"]
-    assert promote_job["environment"] == "cloud-run-production"
+    assert "promote" not in workflow["jobs"]
+
+    blocked_job = workflow["jobs"]["blocked"]
+    assert "environment" not in blocked_job
     assert (
-        promote_job["env"]["MLFLOW_TRACKING_URI"]
-        == "${{ needs.config.outputs.mlflow_tracking_uri }}"
-    )
-    assert (
-        promote_job["env"]["CANDIDATE_REVISION_TAG"]
+        blocked_job["env"]["CANDIDATE_REVISION_TAG"]
         == "${{ needs.config.outputs.candidate_revision_tag }}"
     )
     assert (
-        promote_job["env"]["CANDIDATE_ALIAS"]
+        blocked_job["env"]["CANDIDATE_ALIAS"]
         == "${{ needs.config.outputs.candidate_alias }}"
     )
     assert (
-        promote_job["env"]["TARGET_ALIAS"] == "${{ needs.config.outputs.target_alias }}"
-    )
-
-    install_step = _workflow_step(workflow, "promote", "Install runtime dependencies")
-    assert install_step["run"] == "uv sync --frozen --no-default-groups"
-
-    resolve_step = _workflow_step(workflow, "promote", "Resolve candidate revision")
-    resolve_script = resolve_step["run"]
-    assert 'gcloud run services describe "$CLOUD_RUN_SERVICE"' in resolve_script
-    assert 'gcloud run revisions describe "$candidate_revision_name"' in resolve_script
-    assert (
-        "Candidate revision must remain at 0% traffic before promotion."
-        in resolve_script
-    )
-    assert 'echo "candidate_image=${candidate_image}"' in resolve_script
-
-    verify_candidate_step = _workflow_step(
-        workflow, "promote", "Verify candidate Cloud Run runtime"
-    )
-    verify_candidate_script = verify_candidate_step["run"]
-    assert (
-        verify_candidate_step["env"]["SERVICE_URL"]
-        == "${{ steps.resolve_candidate.outputs.candidate_url }}"
-    )
-    assert (
-        'gcloud auth print-identity-token --audiences="$SERVICE_URL"'
-        in verify_candidate_script
-    )
-    assert (
-        "Candidate health verification did not report serving alias ${CANDIDATE_ALIAS}."
-        in verify_candidate_script
-    )
-    assert "candidate_model_version" in verify_candidate_script
-
-    capture_live_step = _workflow_step(
-        workflow, "promote", "Capture current live rollback inputs"
-    )
-    capture_live_script = capture_live_step["run"]
-    assert 'gcloud run services describe "$CLOUD_RUN_SERVICE"' in capture_live_script
-    assert (
-        'gcloud auth print-identity-token --audiences="$live_service_url"'
-        in capture_live_script
-    )
-    assert (
-        "Current live revision could not be resolved before promotion."
-        in capture_live_script
-    )
-    assert "live_model_alias" in capture_live_script
-    assert "live_model_version" in capture_live_script
-
-    promote_model_step = _workflow_step(
-        workflow, "promote", "Promote candidate model version to champion"
-    )
-    promote_model_script = promote_model_step["run"]
-    assert (
-        promote_model_step["env"]["CANDIDATE_MODEL_VERSION"]
-        == "${{ steps.verify_candidate.outputs.candidate_model_version }}"
-    )
-    assert (
-        'uv run python -m foehncast.training_pipeline.promote --version "$CANDIDATE_MODEL_VERSION" --target-stage Production'
-        in promote_model_script
-    )
-    assert (
-        "Promoted model version does not match the validated candidate model version."
-        in promote_model_script
-    )
-
-    deploy_live_step = _workflow_step(
-        workflow, "promote", "Deploy promoted image to live Cloud Run service"
-    )
-    deploy_live_script = deploy_live_step["run"]
-    assert (
-        deploy_live_step["env"]["CANDIDATE_IMAGE"]
-        == "${{ steps.resolve_candidate.outputs.candidate_image }}"
-    )
-    assert 'gcloud run services update "$CLOUD_RUN_SERVICE"' in deploy_live_script
-    assert ' --image "$CANDIDATE_IMAGE"' in deploy_live_script
-    assert "FOEHNCAST_MLFLOW_SERVING_ALIAS=$TARGET_ALIAS" in deploy_live_script
-
-    verify_live_step = _workflow_step(
-        workflow, "promote", "Verify promoted live Cloud Run runtime"
-    )
-    verify_live_script = verify_live_step["run"]
-    assert (
-        verify_live_step["env"]["SERVICE_URL"]
-        == "${{ steps.deploy_live.outputs.service_url }}"
-    )
-    assert (
-        verify_live_step["env"]["PROMOTED_MODEL_VERSION"]
-        == "${{ steps.promote_model.outputs.promoted_model_version }}"
-    )
-    assert (
-        "Live health verification did not report serving alias ${TARGET_ALIAS}."
-        in verify_live_script
-    )
-    assert (
-        "Live service model version does not match the promoted model version."
-        in verify_live_script
-    )
-    assert (
-        'echo "Checking live Cloud Run spots endpoint at ${spots_url}..."'
-        in verify_live_script
-    )
-
-    summary_step = _workflow_step(workflow, "promote", "Summarize promotion")
-    assert 'echo "## Candidate promotion"' in summary_step["run"]
-    assert 'echo "- Candidate tag: $CANDIDATE_REVISION_TAG"' in summary_step["run"]
-    assert (
-        'echo "- Promoted model version: ${{ steps.promote_model.outputs.promoted_model_version }}"'
-        in summary_step["run"]
-    )
-    assert 'echo "### Rollback inputs"' in summary_step["run"]
-    assert (
-        'echo "- Revision: ${{ steps.capture_live.outputs.live_revision_name }}"'
-        in summary_step["run"]
-    )
-    assert (
-        'echo "- Model version: ${{ steps.capture_live.outputs.live_model_version }}"'
-        in summary_step["run"]
+        blocked_job["env"]["TARGET_ALIAS"] == "${{ needs.config.outputs.target_alias }}"
     )
 
     blocked_step = _workflow_step(
         workflow, "blocked", "Explain blocked promotion workflow"
     )
-    assert "GCP_CLOUD_RUN_SERVICE" in blocked_step["run"]
-    assert "GCP_MLFLOW_TRACKING_URI" in blocked_step["run"]
+    assert "Candidate promotion moved out of GitHub" in blocked_step["run"]
+    assert (
+        "Candidate promotion is no longer executed directly from GitHub Actions."
+        in blocked_step["run"]
+    )
+    assert (
+        "explicit GitHub-to-runtime trigger contract is implemented"
+        in blocked_step["run"]
+    )
 
 
-def test_rollback_live_release_workflow_restores_explicit_revision_and_model_version() -> (
+def test_rollback_live_release_workflow_is_blocked_pending_runtime_trigger_contract() -> (
     None
 ):
     workflow = _workflow_yaml(".github/workflows/rollback-live-release.yml")
     config_job = workflow["jobs"]["config"]
     dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+    config_steps = {
+        step.get("id") or step.get("name")
+        for step in workflow["jobs"]["config"]["steps"]
+    }
 
+    assert workflow["permissions"] == {"contents": "read"}
     assert dispatch_inputs["rollback_revision"]["required"] is True
     assert dispatch_inputs["rollback_model_version"]["required"] is True
     assert dispatch_inputs["rollback_revision_tag"]["default"] == "rollback"
     assert dispatch_inputs["target_alias"]["default"] == "champion"
 
-    assert (
-        config_job["outputs"]["cloud_run_service"]
-        == "${{ steps.repo_config.outputs.cloud_run_service }}"
-    )
-    assert (
-        config_job["outputs"]["mlflow_tracking_uri"]
-        == "${{ steps.repo_config.outputs.mlflow_tracking_uri }}"
-    )
-    assert (
-        config_job["outputs"]["rollback_revision"]
-        == "${{ steps.derived.outputs.rollback_revision }}"
-    )
-    assert (
-        config_job["outputs"]["rollback_model_version"]
-        == "${{ steps.derived.outputs.rollback_model_version }}"
-    )
-    assert (
-        config_job["outputs"]["rollback_revision_tag"]
-        == "${{ steps.derived.outputs.rollback_revision_tag }}"
-    )
-    assert (
-        config_job["outputs"]["target_alias"]
-        == "${{ steps.derived.outputs.target_alias }}"
-    )
-    assert (
-        config_job["outputs"]["rollback_ready"]
-        == "${{ steps.derived.outputs.rollback_ready }}"
-    )
+    assert set(config_job["outputs"]) == {
+        "owner_allowed",
+        "rollback_revision",
+        "rollback_model_version",
+        "rollback_revision_tag",
+        "target_alias",
+    }
+    assert "repo_config" not in config_steps
 
     derived_step = _workflow_step(workflow, "config", "derived")
     assert (
@@ -911,140 +705,40 @@ def test_rollback_live_release_workflow_restores_explicit_revision_and_model_ver
     )
     assert "rollback_revision_tag='rollback'" in derived_step["run"]
     assert "target_alias='champion'" in derived_step["run"]
+    assert "rollback_ready" not in derived_step["run"]
 
-    rollback_job = workflow["jobs"]["rollback"]
-    assert rollback_job["environment"] == "cloud-run-production"
+    assert "rollback" not in workflow["jobs"]
+
+    blocked_job = workflow["jobs"]["blocked"]
+    assert "environment" not in blocked_job
     assert (
-        rollback_job["env"]["ROLLBACK_REVISION"]
+        blocked_job["env"]["ROLLBACK_REVISION"]
         == "${{ needs.config.outputs.rollback_revision }}"
     )
     assert (
-        rollback_job["env"]["ROLLBACK_MODEL_VERSION"]
+        blocked_job["env"]["ROLLBACK_MODEL_VERSION"]
         == "${{ needs.config.outputs.rollback_model_version }}"
     )
     assert (
-        rollback_job["env"]["ROLLBACK_REVISION_TAG"]
+        blocked_job["env"]["ROLLBACK_REVISION_TAG"]
         == "${{ needs.config.outputs.rollback_revision_tag }}"
     )
     assert (
-        rollback_job["env"]["TARGET_ALIAS"]
-        == "${{ needs.config.outputs.target_alias }}"
+        blocked_job["env"]["TARGET_ALIAS"] == "${{ needs.config.outputs.target_alias }}"
     )
-
-    resolve_step = _workflow_step(workflow, "rollback", "Resolve rollback revision")
-    resolve_script = resolve_step["run"]
-    assert 'gcloud run revisions describe "$ROLLBACK_REVISION"' in resolve_script
-    assert 'gcloud run services update-traffic "$CLOUD_RUN_SERVICE"' in resolve_script
-    assert (
-        ' --update-tags "$ROLLBACK_REVISION_TAG=$ROLLBACK_REVISION"' in resolve_script
-    )
-    assert "Rollback tag does not point at the requested revision." in resolve_script
-
-    verify_target_step = _workflow_step(
-        workflow, "rollback", "Verify rollback target runtime"
-    )
-    verify_target_script = verify_target_step["run"]
-    assert (
-        verify_target_step["env"]["SERVICE_URL"]
-        == "${{ steps.resolve_rollback.outputs.rollback_tag_url }}"
-    )
-    assert (
-        'gcloud auth print-identity-token --audiences="$SERVICE_URL"'
-        in verify_target_script
-    )
-    assert (
-        "Rollback target health verification did not report serving alias ${TARGET_ALIAS}."
-        in verify_target_script
-    )
-    assert "rollback_target_model_version" in verify_target_script
-
-    restore_model_step = _workflow_step(
-        workflow, "rollback", "Restore champion alias to rollback model version"
-    )
-    restore_model_script = restore_model_step["run"]
-    assert (
-        'uv run python -m foehncast.training_pipeline.rollback --version "$ROLLBACK_MODEL_VERSION" --target-alias "$TARGET_ALIAS"'
-        in restore_model_script
-    )
-    assert (
-        "Rollback helper did not restore the requested model version."
-        in restore_model_script
-    )
-
-    reverify_target_step = _workflow_step(
-        workflow, "rollback", "Reverify rollback target with restored model version"
-    )
-    reverify_target_script = reverify_target_step["run"]
-    assert (
-        reverify_target_step["env"]["SERVICE_URL"]
-        == "${{ steps.resolve_rollback.outputs.rollback_tag_url }}"
-    )
-    assert (
-        reverify_target_step["env"]["RESTORED_MODEL_VERSION"]
-        == "${{ steps.restore_model.outputs.restored_model_version }}"
-    )
-    assert (
-        'gcloud auth print-identity-token --audiences="$SERVICE_URL"'
-        in reverify_target_script
-    )
-    assert (
-        "Rollback target revalidation did not report serving alias ${TARGET_ALIAS}."
-        in reverify_target_script
-    )
-    assert (
-        "Rollback target revalidation did not report the restored model version."
-        in reverify_target_script
-    )
-
-    shift_traffic_step = _workflow_step(
-        workflow, "rollback", "Restore live traffic to rollback revision"
-    )
-    shift_traffic_script = shift_traffic_step["run"]
-    assert (
-        'gcloud run services update-traffic "$CLOUD_RUN_SERVICE"'
-        in shift_traffic_script
-    )
-    assert ' --to-revisions "$ROLLBACK_REVISION=100"' in shift_traffic_script
-
-    verify_live_step = _workflow_step(
-        workflow, "rollback", "Verify rolled back live runtime"
-    )
-    verify_live_script = verify_live_step["run"]
-    assert (
-        verify_live_step["env"]["SERVICE_URL"]
-        == "${{ steps.shift_traffic.outputs.service_url }}"
-    )
-    assert (
-        verify_live_step["env"]["RESTORED_MODEL_VERSION"]
-        == "${{ steps.restore_model.outputs.restored_model_version }}"
-    )
-    assert (
-        "Live rollback health verification did not report serving alias ${TARGET_ALIAS}."
-        in verify_live_script
-    )
-    assert (
-        "Live rollback model version does not match the restored model version."
-        in verify_live_script
-    )
-    assert (
-        'echo "Checking live Cloud Run spots endpoint at ${spots_url}..."'
-        in verify_live_script
-    )
-
-    summary_step = _workflow_step(workflow, "rollback", "Summarize rollback")
-    assert 'echo "## Live rollback"' in summary_step["run"]
-    assert 'echo "- Rollback revision: $ROLLBACK_REVISION"' in summary_step["run"]
-    assert (
-        'echo "- Restored model version: ${{ steps.restore_model.outputs.restored_model_version }}"'
-        in summary_step["run"]
-    )
-    assert 'echo "- Tagged revalidation: passed"' in summary_step["run"]
 
     blocked_step = _workflow_step(
         workflow, "blocked", "Explain blocked rollback workflow"
     )
-    assert "GCP_CLOUD_RUN_SERVICE" in blocked_step["run"]
-    assert "GCP_MLFLOW_TRACKING_URI" in blocked_step["run"]
+    assert "Live rollback moved out of GitHub" in blocked_step["run"]
+    assert (
+        "Live rollback is no longer executed directly from GitHub Actions."
+        in blocked_step["run"]
+    )
+    assert (
+        "explicit GitHub-to-runtime trigger contract is implemented"
+        in blocked_step["run"]
+    )
 
 
 def test_publish_runtime_images_excludes_local_only_development_env() -> None:


### PR DESCRIPTION
## What changed
- reduce `.github/workflows/publish-app-image.yml` to reviewed image publication only and stop treating it as a runtime deploy path
- keep `.github/workflows/promote-candidate.yml` and `.github/workflows/rollback-live-release.yml` as blocked redirect workflows instead of direct runtime mutators
- align the public delivery-boundary docs with the chosen GitHub-delivery versus hosted-runtime split
- update `tests/test_cloud_operator_contract.py` to enforce the narrower GitHub workflow responsibility

## Why
- GitHub workflow behavior had drifted into runtime orchestration even though hosted Airflow on the retained operator host is the orchestration surface of record
- this restores a clean reviewed delivery plane before the explicit GitHub-to-runtime trigger contract lands

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-203 && PYTHONPATH="$PWD/src" /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/pytest tests/test_cloud_operator_contract.py`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-203 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #203
