### PR TITLE
feature(runtime): define GitHub-to-runtime trigger contract

### DIFF
--- a/.github/workflows/promote-candidate.yml
+++ b/.github/workflows/promote-candidate.yml
@@ -90,14 +90,14 @@ jobs:
         run: |
           set -euo pipefail
           {
-            echo "## Candidate promotion moved out of GitHub"
+            echo "## Candidate promotion moved behind Trigger Runtime Release"
             echo
             echo "- Candidate tag: $CANDIDATE_REVISION_TAG"
             echo "- Candidate alias: $CANDIDATE_ALIAS"
             echo "- Target alias: $TARGET_ALIAS"
             echo
             echo "GitHub Actions no longer promotes live runtime state directly."
-            echo "Use the runtime-side operator path until the explicit GitHub-to-runtime trigger contract lands."
+            echo "Use Trigger Runtime Release with action promote_candidate so GitHub sends one reviewed request into hosted Airflow."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo 'Candidate promotion is no longer executed directly from GitHub Actions. Use the runtime-side operator path until the explicit GitHub-to-runtime trigger contract is implemented.' >&2
+          echo 'Candidate promotion is no longer executed directly from GitHub Actions. Use Trigger Runtime Release with action promote_candidate instead.' >&2
           exit 1

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -139,7 +139,7 @@ jobs:
             echo "- Immutable: ${{ steps.image.outputs.immutable_tag }}"
             echo "- Floating: ${{ steps.image.outputs.latest_tag }}"
             echo "- Runtime handoff: not executed from GitHub in this workflow"
-            echo "- Next step: use the runtime-side trigger contract or operator path to deploy this image"
+            echo "- Next step: run Trigger Runtime Release with action deploy_candidate and this immutable image URI"
           } >> "$GITHUB_STEP_SUMMARY"
 
   skipped:

--- a/.github/workflows/rollback-live-release.yml
+++ b/.github/workflows/rollback-live-release.yml
@@ -104,7 +104,7 @@ jobs:
         run: |
           set -euo pipefail
           {
-            echo "## Live rollback moved out of GitHub"
+            echo "## Live rollback moved behind Trigger Runtime Release"
             echo
             echo "- Rollback revision: $ROLLBACK_REVISION"
             echo "- Rollback model version: $ROLLBACK_MODEL_VERSION"
@@ -112,7 +112,7 @@ jobs:
             echo "- Target alias: $TARGET_ALIAS"
             echo
             echo "GitHub Actions no longer restores live runtime state directly."
-            echo "Use the runtime-side operator path until the explicit GitHub-to-runtime trigger contract lands."
+            echo "Use Trigger Runtime Release with action rollback_live so GitHub sends one reviewed request into hosted Airflow."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo 'Live rollback is no longer executed directly from GitHub Actions. Use the runtime-side operator path until the explicit GitHub-to-runtime trigger contract is implemented.' >&2
+          echo 'Live rollback is no longer executed directly from GitHub Actions. Use Trigger Runtime Release with action rollback_live instead.' >&2
           exit 1

--- a/.github/workflows/trigger-runtime-release.yml
+++ b/.github/workflows/trigger-runtime-release.yml
@@ -1,0 +1,288 @@
+name: Trigger Runtime Release
+
+on:
+    workflow_dispatch:
+        inputs:
+            action:
+                description: Runtime release action to hand off to hosted Airflow
+                required: true
+                default: deploy_candidate
+                type: choice
+                options:
+                    - deploy_candidate
+                    - promote_candidate
+                    - rollback_live
+            image_uri:
+                description: Immutable image URI for deploy_candidate requests
+                required: false
+                type: string
+            candidate_revision_tag:
+                description: Candidate Cloud Run revision tag for deploy or promote requests
+                required: false
+                default: candidate
+                type: string
+            candidate_alias:
+                description: Candidate MLflow alias expected for promote requests
+                required: false
+                default: candidate
+                type: string
+            target_alias:
+                description: Target MLflow alias expected after promote or rollback requests
+                required: false
+                default: champion
+                type: string
+            rollback_revision:
+                description: Exact Cloud Run revision to restore for rollback_live requests
+                required: false
+                type: string
+            rollback_model_version:
+                description: Exact MLflow model version to restore for rollback_live requests
+                required: false
+                type: string
+            rollback_revision_tag:
+                description: Temporary rollback revision tag for rollback_live requests
+                required: false
+                default: rollback
+                type: string
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    config:
+        runs-on: ubuntu-latest
+        outputs:
+            owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
+            project_id: ${{ steps.repo_config.outputs.project_id }}
+            workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
+            service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
+            online_compose_host_name: ${{ steps.repo_config.outputs.online_compose_host_name }}
+            online_compose_host_zone: ${{ steps.repo_config.outputs.online_compose_host_zone }}
+            action: ${{ steps.derived.outputs.action }}
+            image_uri: ${{ steps.derived.outputs.image_uri }}
+            candidate_revision_tag: ${{ steps.derived.outputs.candidate_revision_tag }}
+            candidate_alias: ${{ steps.derived.outputs.candidate_alias }}
+            target_alias: ${{ steps.derived.outputs.target_alias }}
+            rollback_revision: ${{ steps.derived.outputs.rollback_revision }}
+            rollback_model_version: ${{ steps.derived.outputs.rollback_model_version }}
+            rollback_revision_tag: ${{ steps.derived.outputs.rollback_revision_tag }}
+            trigger_ready: ${{ steps.derived.outputs.trigger_ready }}
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            - id: flags
+              env:
+                  ACTOR: ${{ github.actor }}
+                  TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+                  REPOSITORY_OWNER: ${{ github.repository_owner }}
+              run: |
+                  set -euo pipefail
+
+                  owner_allowed=false
+                  if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
+                    owner_allowed=true
+                  fi
+
+                  echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
+
+            - id: repo_config
+              uses: ./.github/actions/load-gcp-repo-config
+              with:
+                  repo-vars-json: ${{ toJson(vars) }}
+
+            - id: derived
+              env:
+                  ACTION_INPUT: ${{ github.event.inputs.action }}
+                  IMAGE_URI_INPUT: ${{ github.event.inputs.image_uri }}
+                  CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
+                  CANDIDATE_ALIAS_INPUT: ${{ github.event.inputs.candidate_alias }}
+                  TARGET_ALIAS_INPUT: ${{ github.event.inputs.target_alias }}
+                  ROLLBACK_REVISION_INPUT: ${{ github.event.inputs.rollback_revision }}
+                  ROLLBACK_MODEL_VERSION_INPUT: ${{ github.event.inputs.rollback_model_version }}
+                  ROLLBACK_REVISION_TAG_INPUT: ${{ github.event.inputs.rollback_revision_tag }}
+                  PROJECT_ID: ${{ steps.repo_config.outputs.project_id }}
+                  PROVISION_ONLINE_COMPOSE_HOST: ${{ steps.repo_config.outputs.provision_online_compose_host }}
+                  ONLINE_COMPOSE_HOST_NAME: ${{ steps.repo_config.outputs.online_compose_host_name }}
+                  ONLINE_COMPOSE_HOST_ZONE: ${{ steps.repo_config.outputs.online_compose_host_zone }}
+                  WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
+                  SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
+              run: |
+                  set -euo pipefail
+
+                  action="$(printf '%s' "${ACTION_INPUT:-deploy_candidate}" | tr '[:upper:]' '[:lower:]')"
+                  case "$action" in
+                    deploy_candidate|promote_candidate|rollback_live)
+                      ;;
+                    *)
+                      echo "Unsupported action '$action'." >&2
+                      exit 1
+                      ;;
+                  esac
+
+                  image_uri="$(printf '%s' "${IMAGE_URI_INPUT:-}" | tr -d '\r')"
+
+                  candidate_revision_tag="$(printf '%s' "${CANDIDATE_REVISION_TAG_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+                  candidate_revision_tag="${candidate_revision_tag#-}"
+                  candidate_revision_tag="${candidate_revision_tag%-}"
+                  if [[ -z "$candidate_revision_tag" ]]; then
+                    candidate_revision_tag='candidate'
+                  fi
+
+                  candidate_alias="$(printf '%s' "${CANDIDATE_ALIAS_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]')"
+                  if [[ -z "$candidate_alias" ]]; then
+                    candidate_alias='candidate'
+                  fi
+
+                  target_alias="$(printf '%s' "${TARGET_ALIAS_INPUT:-champion}" | tr '[:upper:]' '[:lower:]')"
+                  if [[ -z "$target_alias" ]]; then
+                    target_alias='champion'
+                  fi
+
+                  rollback_revision="$(printf '%s' "${ROLLBACK_REVISION_INPUT:-}" | tr -d '[:space:]')"
+                  rollback_model_version="$(printf '%s' "${ROLLBACK_MODEL_VERSION_INPUT:-}" | tr -d '[:space:]')"
+
+                  rollback_revision_tag="$(printf '%s' "${ROLLBACK_REVISION_TAG_INPUT:-rollback}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+                  rollback_revision_tag="${rollback_revision_tag#-}"
+                  rollback_revision_tag="${rollback_revision_tag%-}"
+                  if [[ -z "$rollback_revision_tag" ]]; then
+                    rollback_revision_tag='rollback'
+                  fi
+
+                  trigger_ready=false
+                  if [[ "$PROVISION_ONLINE_COMPOSE_HOST" == 'true' \
+                    && -n "$PROJECT_ID" \
+                    && -n "$ONLINE_COMPOSE_HOST_NAME" \
+                    && -n "$ONLINE_COMPOSE_HOST_ZONE" \
+                    && -n "$WORKLOAD_IDENTITY_PROVIDER" \
+                    && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
+                    trigger_ready=true
+                  fi
+
+                  case "$action" in
+                    deploy_candidate)
+                      if [[ -z "$image_uri" ]]; then
+                        trigger_ready=false
+                      fi
+                      ;;
+                    rollback_live)
+                      if [[ -z "$rollback_revision" || -z "$rollback_model_version" ]]; then
+                        trigger_ready=false
+                      fi
+                      ;;
+                  esac
+
+                  {
+                    echo "action=$action"
+                    echo "image_uri=$image_uri"
+                    echo "candidate_revision_tag=$candidate_revision_tag"
+                    echo "candidate_alias=$candidate_alias"
+                    echo "target_alias=$target_alias"
+                    echo "rollback_revision=$rollback_revision"
+                    echo "rollback_model_version=$rollback_model_version"
+                    echo "rollback_revision_tag=$rollback_revision_tag"
+                    echo "trigger_ready=$trigger_ready"
+                  } >> "$GITHUB_OUTPUT"
+
+    trigger:
+        needs: config
+        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready == 'true' }}
+        runs-on: ubuntu-latest
+        env:
+            PROJECT_ID: ${{ needs.config.outputs.project_id }}
+            HOST_NAME: ${{ needs.config.outputs.online_compose_host_name }}
+            HOST_ZONE: ${{ needs.config.outputs.online_compose_host_zone }}
+            ACTION: ${{ needs.config.outputs.action }}
+            IMAGE_URI: ${{ needs.config.outputs.image_uri }}
+            CANDIDATE_REVISION_TAG: ${{ needs.config.outputs.candidate_revision_tag }}
+            CANDIDATE_ALIAS: ${{ needs.config.outputs.candidate_alias }}
+            TARGET_ALIAS: ${{ needs.config.outputs.target_alias }}
+            ROLLBACK_REVISION: ${{ needs.config.outputs.rollback_revision }}
+            ROLLBACK_MODEL_VERSION: ${{ needs.config.outputs.rollback_model_version }}
+            ROLLBACK_REVISION_TAG: ${{ needs.config.outputs.rollback_revision_tag }}
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            - uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
+                  service_account: ${{ needs.config.outputs.service_account_email }}
+
+            - uses: google-github-actions/setup-gcloud@v2
+
+            - name: Build runtime release request
+              run: |
+                  set -euo pipefail
+                  python -c 'from datetime import UTC, datetime; import json, os, pathlib; run_url = "/".join([os.environ["GITHUB_SERVER_URL"], os.environ["GITHUB_REPOSITORY"], "actions", "runs", os.environ["GITHUB_RUN_ID"]]); payload = {"action": os.environ["ACTION"], "request_source": "github-actions", "requested_at": datetime.now(tz=UTC).isoformat(), "github_repository": os.environ["GITHUB_REPOSITORY"], "github_workflow": os.environ["GITHUB_WORKFLOW"], "github_run_id": os.environ["GITHUB_RUN_ID"], "github_run_url": run_url, "github_sha": os.environ["GITHUB_SHA"], "image_uri": os.environ.get("IMAGE_URI", ""), "candidate_revision_tag": os.environ.get("CANDIDATE_REVISION_TAG", "candidate"), "candidate_alias": os.environ.get("CANDIDATE_ALIAS", "candidate"), "target_alias": os.environ.get("TARGET_ALIAS", "champion"), "rollback_revision": os.environ.get("ROLLBACK_REVISION", ""), "rollback_model_version": os.environ.get("ROLLBACK_MODEL_VERSION", ""), "rollback_revision_tag": os.environ.get("ROLLBACK_REVISION_TAG", "rollback")}; pathlib.Path("runtime-release-request.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")'
+
+            - name: Refresh operator host checkout
+              run: |
+                  set -euo pipefail
+                  gcloud compute ssh "$HOST_NAME" \
+                    --project "$PROJECT_ID" \
+                    --zone "$HOST_ZONE" \
+                    --command "sudo systemctl start --wait foehncast-online-compose-sync.service"
+
+            - name: Copy runtime release request
+              run: |
+                  set -euo pipefail
+                  gcloud compute scp \
+                    --project "$PROJECT_ID" \
+                    --zone "$HOST_ZONE" \
+                    runtime-release-request.json \
+                    "$HOST_NAME:/tmp/runtime-release-request.json"
+
+            - id: handoff
+              name: Trigger runtime release handoff
+              run: |
+                  set -euo pipefail
+
+                  report="$(gcloud compute ssh "$HOST_NAME" \
+                    --project "$PROJECT_ID" \
+                    --zone "$HOST_ZONE" \
+                    --command "cd /opt/foehncast && ./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json")"
+
+                  printf '%s\n' "$report"
+
+                  dag_run_id="$(printf '%s\n' "$report" | python -c 'import json, sys; print(json.load(sys.stdin)["dag_run_id"])')"
+                  report_path="$(printf '%s\n' "$report" | python -c 'import json, sys; print(json.load(sys.stdin)["report_path"])')"
+
+                  {
+                    echo "dag_run_id=$dag_run_id"
+                    echo "report_path=$report_path"
+                  } >> "$GITHUB_OUTPUT"
+
+                  {
+                    echo "## Runtime release handoff"
+                    echo
+                    echo "- Action: $ACTION"
+                    echo "- Operator host: $HOST_NAME"
+                    echo "- Airflow DAG: runtime_release"
+                    echo "- DAG run: $dag_run_id"
+                    echo "- Summary path: $report_path"
+                    echo
+                    echo '```json'
+                    printf '%s\n' "$report"
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+    skipped:
+        needs: config
+        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready != 'true' }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Explain skipped runtime release handoff
+              run: |
+                  {
+                    echo "## Runtime release handoff skipped"
+                    echo
+                    echo "The explicit runtime trigger contract needs all of these inputs before it can run:"
+                    echo "- GCP_PROJECT_ID"
+                    echo "- GCP_WORKLOAD_IDENTITY_PROVIDER"
+                    echo "- GCP_SERVICE_ACCOUNT_EMAIL"
+                    echo "- GCP_PROVISION_ONLINE_COMPOSE_HOST=true"
+                    echo "- GCP_ONLINE_COMPOSE_HOST_NAME"
+                    echo "- GCP_ONLINE_COMPOSE_HOST_ZONE"
+                    echo
+                    echo "Action-specific coordinates must also be present for the chosen request."
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/dags/runtime_release_dag.py
+++ b/dags/runtime_release_dag.py
@@ -1,0 +1,35 @@
+"""Airflow DAG for recording reviewed runtime release handoff requests."""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator
+    from airflow.sdk import DAG
+except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
+    dag = None
+else:
+    from foehncast.runtime_release import record_runtime_release_request
+
+    with DAG(
+        dag_id="runtime_release",
+        description=(
+            "Accept one reviewed GitHub-to-runtime handoff request and persist "
+            "an observable acknowledgement for operators."
+        ),
+        start_date=datetime(2024, 1, 1),
+        schedule=None,
+        catchup=False,
+        is_paused_upon_creation=False,
+        tags=["foehncast", "runtime"],
+    ) as dag:
+        record_runtime_release = PythonOperator(
+            task_id="record_runtime_release_request",
+            python_callable=record_runtime_release_request,
+            op_kwargs={
+                "request_json": "{{ dag_run.conf | tojson if dag_run and dag_run.conf else '{}' }}",
+                "dag_run_id": "{{ run_id }}",
+                "dag_id": "runtime_release",
+            },
+        )

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -89,7 +89,7 @@ The shared environment currently follows one promoted hosted lane plus one retai
 
 This is why the shared environment docs now center Cloud Run as the first hosted API URL while still keeping the compose-host path visible as the retained control plane.
 
-Rollback for the shared API now means Cloud Run rollback, not reopening the VM app publicly. Candidate promotion captures rollback inputs, and `.github/workflows/rollback-live-release.yml` restores live traffic to a known Cloud Run revision and model version when the promoted path regresses. The remaining retirement gate is whether the operator lane can later shrink without blurring the Airflow and MLflow control-plane boundary.
+Rollback for the shared API now means retrying the reviewed runtime release handoff, not reopening the VM app publicly or mutating runtime state directly from GitHub. `.github/workflows/publish-app-image.yml` stops at image publication, `.github/workflows/trigger-runtime-release.yml` sends the reviewed deploy, promote, or rollback request into the hosted Airflow receiver, and the runtime side records the acknowledgement under `airflow/reports/runtime-release-latest.json`. The remaining retirement gate is whether the operator lane can later shrink without blurring the Airflow and MLflow control-plane boundary.
 
 ## Orchestration Surface Of Record
 

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -98,10 +98,13 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 | `.github/workflows/terraform.yml` | primary Terraform operator path | pushes to `main` automatically resolve to `apply` after bootstrap; manual dispatch stays available for `plan`, `destroy`, `cleanup`, and explicit overrides |
 | `scripts/configure-github-actions.sh` | repo-variable sync | Terraform outputs are copied into GitHub repository variables so the remote workflow reads one shared contract |
 | `terraform/terraform.tfvars` | bootstrap input | used during the interactive bootstrap path, not as the day-2 source of truth for remote applies |
-| runtime image workflows | app delivery follow-up | when Terraform has already provisioned `GCP_CLOUD_RUN_SERVICE`, publish automation updates the existing Cloud Run service with new images |
+| runtime image workflows | reviewed artifact publishing | publish automation builds and publishes runtime images, but it does not deploy Cloud Run, shift traffic, or mutate MLflow aliases directly |
+| `.github/workflows/trigger-runtime-release.yml` | reviewed runtime handoff | GitHub sends one explicit runtime release request into hosted Airflow after the retained operator host refreshes to the reviewed git ref |
 | `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up | run this after a remote apply succeeds and curated BigQuery rows exist |
 
 This contract is deliberate. The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as container port, CPU, and memory stay repo-variable-backed instead of becoming more manual workflow inputs.
+
+GitHub-hosted workflows now stop at reviewed infrastructure change, artifact publication, and one explicit runtime release request. GitHub does not mutate live runtime state directly; the request is handed to hosted Airflow on the retained operator host.
 
 The promoted hosted runtime story is now:
 
@@ -134,17 +137,35 @@ The reviewed delivery plane and the runtime execution plane have different respo
 |------|---------------|--------------|----------------------|
 | Reviewed delivery | GitHub Actions plus Terraform | lint, test, build, image publish, Terraform plan/apply/destroy, and reviewed deploy workflows | runtime scheduling, retries, backfills, and long-lived operator state |
 | Runtime execution | GCP-hosted runtime surfaces | Cloud Run serving, hosted Airflow scheduling, retries, backfills, runtime environment injection, and operator telemetry | source control, CI review, and infrastructure policy review |
-| Shared handoff | repository variables, published images, and Terraform outputs | reviewed contract from GitHub into GCP runtime surfaces | ad hoc operator-only divergence from the declared contract |
+| Shared handoff | repository variables, published images, Terraform outputs, and runtime release requests | reviewed contract from GitHub into GCP runtime surfaces | ad hoc operator-only divergence from the declared contract |
 
 For the next delivery horizon, hosted Airflow on the retained operator host remains the orchestration surface of record. GitHub Actions may trigger reviewed delivery workflows, but it is not the runtime orchestrator.
 
+## Runtime Release Trigger Contract
+
+GitHub now has exactly one reviewed handoff into runtime execution.
+
+- signal: `.github/workflows/trigger-runtime-release.yml` sends one JSON request with a single action and the associated release coordinates
+- receiver: `./scripts/trigger-runtime-release.sh` runs on the retained operator host and triggers the hosted Airflow `runtime_release` DAG locally
+- auth path: GitHub Actions uses OIDC into the deployer service account and Compute Engine SSH; GitHub does not store Airflow credentials or call a public Airflow endpoint
+- observable outcome: the workflow waits for the `runtime_release` DAG to succeed and captures `airflow/reports/runtime-release-latest.json`
+
+The current action set is deliberately small:
+
+- `deploy_candidate`
+- `promote_candidate`
+- `rollback_live`
+
+This keeps the handoff explicit before deeper runtime automation is added behind the Airflow side of the boundary.
+
 ## Rollback And Retirement Coordinates
 
-The shared API rollback path now lives entirely on Cloud Run.
+The reviewed rollback handoff now runs through the runtime trigger contract instead of direct GitHub runtime mutation.
 
-- `.github/workflows/publish-app-image.yml` can deploy a candidate tagged revision with zero traffic or a live revision directly
-- `.github/workflows/promote-candidate.yml` verifies the candidate runtime, captures the current live Cloud Run revision and model version as rollback inputs, and only then promotes the candidate image
-- `.github/workflows/rollback-live-release.yml` uses those explicit inputs to restore live traffic to an exact revision and model version
+- `.github/workflows/publish-app-image.yml` publishes the reviewed app image only
+- `.github/workflows/trigger-runtime-release.yml` is the single reviewed GitHub-to-runtime handoff for candidate deploy, promotion, and rollback requests
+- `.github/workflows/promote-candidate.yml` and `.github/workflows/rollback-live-release.yml` stay as blocked redirect workflows so the old entry points do not continue mutating runtime state directly
+- `airflow/reports/runtime-release-latest.json` and its history files record the acknowledged handoff on the runtime side
 - reopening the hosted VM app on port `8000` is not part of rollback; the shared environment treats that as misconfiguration
 
 The remaining VM-retirement gate is separate from serving rollback. The VM stays online while Airflow, MLflow, and monitoring still define the retained control plane. Later retirement should happen only after that operator-plane scope is reduced explicitly.
@@ -170,6 +191,7 @@ Several boundaries stay explicit across the scripts, Terraform reference, and te
 - the shared cloud environment stays operator-owned, even though the repository and images are public
 - `terraform/terraform.tfvars` belongs to bootstrap and local preview work, while day-2 remote runs read GitHub repository variables
 - runtime scheduling, retries, and backfills belong to hosted Airflow for this horizon rather than to GitHub Actions
+- runtime promotion, rollback, and live traffic control do not run inside GitHub workflows; GitHub only sends the reviewed runtime release request
 - Grafana, Airflow, MLflow, and Prometheus remain operator surfaces rather than rider-facing product surfaces
 - public docs should explain those surfaces with rendered evidence and checked-in configuration, not live control-plane embeds
 

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -149,8 +149,9 @@ The remaining gate is not whether the VM should keep a public serving fallback. 
 
 The current rollback contract is:
 
-- `.github/workflows/promote-candidate.yml` captures the current live Cloud Run revision and model version before promotion so operators have explicit rollback inputs
-- `.github/workflows/rollback-live-release.yml` restores live traffic to an exact Cloud Run revision and MLflow model version after the tagged rollback target passes `/health`
+- `.github/workflows/publish-app-image.yml` publishes the reviewed app image only
+- `.github/workflows/trigger-runtime-release.yml` is the reviewed GitHub-to-runtime handoff for candidate deploy, promotion, and rollback requests
+- `airflow/reports/runtime-release-latest.json` records the latest acknowledged serving rollout request on the runtime side
 - bootstrap and Terraform verification fail if the VM app becomes public again instead of treating that as rollback
 
 The remaining retirement decision is narrower:

--- a/scripts/trigger-runtime-release.sh
+++ b/scripts/trigger-runtime-release.sh
@@ -1,0 +1,121 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+REQUEST_FILE=""
+DAG_ID="runtime_release"
+
+usage() {
+  echo "Usage: $0 --request-file path" >&2
+}
+
+verify_airflow_api_health() {
+  local max_attempts="${1:-60}"
+  local sleep_seconds="${2:-2}"
+  local payload=""
+  local attempt
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if payload="$(curl --retry 1 --retry-all-errors --retry-delay 0 -fsS "http://127.0.0.1:8080/api/v2/monitor/health" 2>/dev/null)"; then
+      if printf '%s' "$payload" | python3 -c $'import json, sys\npayload = json.load(sys.stdin)\nrequired = ("metadatabase", "scheduler", "dag_processor", "triggerer")\nfor name in required:\n    status = (payload.get(name) or {}).get("status")\n    if status != "healthy":\n        raise SystemExit(1)\n'; then
+        return 0
+      fi
+    fi
+
+    sleep "$sleep_seconds"
+  done
+
+  echo "Timed out waiting for Airflow API health." >&2
+  if [[ -n "$payload" ]]; then
+    printf '%s\n' "$payload" >&2
+  fi
+  return 1
+}
+
+wait_for_airflow_dag_run_state() {
+  local dag_id="$1"
+  local dag_run_id="$2"
+  local expected_state="$3"
+  local max_attempts="${4:-120}"
+  local sleep_seconds="${5:-2}"
+  local payload=""
+  local status
+  local attempt
+
+  for ((attempt = 1; attempt <= max_attempts; attempt++)); do
+    if payload="$(curl --retry 1 --retry-all-errors --retry-delay 0 -fsS "http://127.0.0.1:8080/api/v2/dags/${dag_id}/dagRuns?limit=20&order_by=-start_date" 2>/dev/null)"; then
+      if printf '%s' "$payload" | EXPECTED_RUN_ID="$dag_run_id" EXPECTED_STATE="$expected_state" python3 -c $'import json, os, sys\npayload = json.load(sys.stdin)\nexpected_run_id = os.environ["EXPECTED_RUN_ID"]\nexpected_state = os.environ["EXPECTED_STATE"].lower()\nruns = payload.get("dag_runs") or []\nfor run in runs:\n    if (run.get("dag_run_id") or "") != expected_run_id:\n        continue\n    state = (run.get("state") or "").lower()\n    if state == expected_state:\n        raise SystemExit(0)\n    if state in {"failed", "error"}:\n        print(json.dumps(run), file=sys.stderr)\n        raise SystemExit(2)\n    raise SystemExit(1)\nraise SystemExit(1)\n'; then
+        return 0
+      else
+        status=$?
+        if [[ "$status" -eq 2 ]]; then
+          echo "Airflow DAG '${dag_id}' reached a terminal failure state." >&2
+          printf '%s\n' "$payload" >&2
+          return 1
+        fi
+      fi
+    fi
+
+    sleep "$sleep_seconds"
+  done
+
+  echo "Timed out waiting for Airflow DAG '${dag_id}' run '${dag_run_id}' to reach state '${expected_state}'." >&2
+  if [[ -n "$payload" ]]; then
+    printf '%s\n' "$payload" >&2
+  fi
+  return 1
+}
+
+normalize_request_payload() {
+  python3 -c $'import json, sys\nfrom datetime import UTC, datetime\n\npayload = json.load(open(sys.argv[1], encoding="utf-8"))\nif not isinstance(payload, dict):\n    raise SystemExit("Runtime release request must be a JSON object.")\n\ndef clean(name, default=""):\n    value = payload.get(name, default)\n    if value is None:\n        return default\n    value = str(value).strip()\n    return value or default\n\naction = clean("action").lower()\nif action not in {"deploy_candidate", "promote_candidate", "rollback_live"}:\n    raise SystemExit("action must be deploy_candidate, promote_candidate, or rollback_live.")\n\nnormalized = {\n    "action": action,\n    "request_source": clean("request_source", "github-actions"),\n    "requested_at": clean("requested_at", datetime.now(tz=UTC).isoformat()),\n    "github_repository": clean("github_repository"),\n    "github_workflow": clean("github_workflow"),\n    "github_run_id": clean("github_run_id"),\n    "github_run_url": clean("github_run_url"),\n    "github_sha": clean("github_sha"),\n    "image_uri": clean("image_uri"),\n    "candidate_revision_tag": clean("candidate_revision_tag", "candidate").lower(),\n    "candidate_alias": clean("candidate_alias", "candidate").lower(),\n    "target_alias": clean("target_alias", "champion").lower(),\n    "rollback_revision": clean("rollback_revision"),\n    "rollback_model_version": clean("rollback_model_version"),\n    "rollback_revision_tag": clean("rollback_revision_tag", "rollback").lower(),\n}\n\nif action == "deploy_candidate" and not normalized["image_uri"]:\n    raise SystemExit("deploy_candidate requests require image_uri.")\nif action == "rollback_live" and not normalized["rollback_revision"]:\n    raise SystemExit("rollback_live requests require rollback_revision.")\nif action == "rollback_live" and not normalized["rollback_model_version"]:\n    raise SystemExit("rollback_live requests require rollback_model_version.")\n\nprint(json.dumps(normalized, sort_keys=True))\n' "$REQUEST_FILE"
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --request-file)
+      REQUEST_FILE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$REQUEST_FILE" || ! -f "$REQUEST_FILE" ]]; then
+  usage
+  exit 1
+fi
+
+normalized_request="$(normalize_request_payload)"
+dag_run_id="runtime_release__$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
+logical_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+compose_args=(
+  -f "$ROOT_DIR/docker-compose.yml"
+  -f "$ROOT_DIR/docker-compose.cloud.yml"
+  --env-file "$ROOT_DIR/.env"
+)
+
+verify_airflow_api_health 90 2 >&2
+
+docker compose "${compose_args[@]}" exec -T airflow-webserver \
+  airflow dags trigger "$DAG_ID" \
+  --logical-date "$logical_date" \
+  --run-id "$dag_run_id" \
+  --conf "$normalized_request" >/dev/null
+
+wait_for_airflow_dag_run_state "$DAG_ID" "$dag_run_id" success 120 2 >&2
+
+report_path="$ROOT_DIR/airflow/reports/runtime-release-latest.json"
+if [[ ! -f "$report_path" ]]; then
+  echo "Runtime release report was not written to $report_path." >&2
+  exit 1
+fi
+
+python3 -c $'import json, sys\nreport_path = sys.argv[1]\nexpected_run_id = sys.argv[2]\nreport = json.load(open(report_path, encoding="utf-8"))\nif report.get("dag_run_id") != expected_run_id:\n    raise SystemExit(f"runtime release report does not match dag run {expected_run_id!r}")\nreport["report_path"] = report_path\nprint(json.dumps(report, indent=2, sort_keys=True))\n' "$report_path" "$dag_run_id"

--- a/src/foehncast/runtime_release.py
+++ b/src/foehncast/runtime_release.py
@@ -1,0 +1,195 @@
+"""Helpers for normalizing and persisting runtime release handoff requests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import UTC, datetime
+import json
+from pathlib import Path
+from typing import Any
+
+from foehncast.paths import project_root
+
+
+ALLOWED_RUNTIME_RELEASE_ACTIONS = {
+    "deploy_candidate",
+    "promote_candidate",
+    "rollback_live",
+}
+
+
+def runtime_release_report_dir() -> Path:
+    """Return the stable report directory for runtime release handoffs."""
+    return project_root() / "airflow" / "reports"
+
+
+def runtime_release_summary_path() -> Path:
+    """Return the stable JSON summary path for the latest runtime release handoff."""
+    return runtime_release_report_dir() / "runtime-release-latest.json"
+
+
+def runtime_release_summary_history_paths() -> list[Path]:
+    """Return persisted runtime release handoff history paths."""
+    return sorted(
+        (runtime_release_report_dir() / "history").glob("runtime-release-*.json")
+    )
+
+
+def _summary_history_timestamp(generated_at: str | None) -> str:
+    timestamp = datetime.now(tz=UTC)
+    if generated_at:
+        try:
+            timestamp = datetime.fromisoformat(generated_at.replace("Z", "+00:00"))
+        except ValueError:
+            timestamp = datetime.now(tz=UTC)
+
+    if timestamp.tzinfo is None:
+        timestamp = timestamp.replace(tzinfo=UTC)
+    else:
+        timestamp = timestamp.astimezone(UTC)
+
+    return timestamp.strftime("%Y%m%dT%H%M%S%fZ")
+
+
+def _write_runtime_release_history(summary: dict[str, Any]) -> Path:
+    history_path = (
+        runtime_release_report_dir()
+        / "history"
+        / f"runtime-release-{_summary_history_timestamp(summary.get('generated_at'))}.json"
+    )
+    history_path.parent.mkdir(parents=True, exist_ok=True)
+    history_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    return history_path
+
+
+def _request_mapping(request: Mapping[str, Any] | str | None) -> dict[str, Any]:
+    if request is None:
+        return {}
+
+    if isinstance(request, Mapping):
+        return dict(request)
+
+    request_json = str(request).strip()
+    if not request_json:
+        return {}
+
+    payload = json.loads(request_json)
+    if not isinstance(payload, dict):
+        raise ValueError("Runtime release request must decode to a JSON object.")
+    return payload
+
+
+def _normalized_string(value: Any, *, default: str = "") -> str:
+    if value is None:
+        return default
+    normalized = str(value).strip()
+    return normalized or default
+
+
+def build_runtime_release_summary(
+    request: Mapping[str, Any] | str | None,
+    *,
+    dag_run_id: str,
+    dag_id: str = "runtime_release",
+) -> dict[str, Any]:
+    """Normalize a runtime release request into a stable observable summary."""
+    payload = _request_mapping(request)
+
+    action = _normalized_string(payload.get("action")).lower()
+    if action not in ALLOWED_RUNTIME_RELEASE_ACTIONS:
+        raise ValueError(
+            "Runtime release action must be one of deploy_candidate, "
+            "promote_candidate, or rollback_live."
+        )
+
+    image_uri = _normalized_string(payload.get("image_uri"))
+    candidate_revision_tag = _normalized_string(
+        payload.get("candidate_revision_tag"),
+        default="candidate",
+    ).lower()
+    candidate_alias = _normalized_string(
+        payload.get("candidate_alias"),
+        default="candidate",
+    ).lower()
+    target_alias = _normalized_string(
+        payload.get("target_alias"),
+        default="champion",
+    ).lower()
+    rollback_revision = _normalized_string(payload.get("rollback_revision"))
+    rollback_model_version = _normalized_string(payload.get("rollback_model_version"))
+    rollback_revision_tag = _normalized_string(
+        payload.get("rollback_revision_tag"),
+        default="rollback",
+    ).lower()
+
+    if action == "deploy_candidate" and not image_uri:
+        raise ValueError("deploy_candidate requests require image_uri.")
+
+    if action == "rollback_live":
+        if not rollback_revision:
+            raise ValueError("rollback_live requests require rollback_revision.")
+        if not rollback_model_version:
+            raise ValueError("rollback_live requests require rollback_model_version.")
+
+    generated_at = _normalized_string(payload.get("requested_at"))
+    if not generated_at:
+        generated_at = datetime.now(tz=UTC).isoformat()
+
+    return {
+        "generated_at": generated_at,
+        "state": "accepted",
+        "runtime_receiver": "hosted_airflow",
+        "dag_id": dag_id,
+        "dag_run_id": _normalized_string(dag_run_id, default="manual"),
+        "action": action,
+        "request_source": _normalized_string(
+            payload.get("request_source"),
+            default="github-actions",
+        ),
+        "github_repository": _normalized_string(payload.get("github_repository")),
+        "github_workflow": _normalized_string(payload.get("github_workflow")),
+        "github_run_id": _normalized_string(payload.get("github_run_id")),
+        "github_run_url": _normalized_string(payload.get("github_run_url")),
+        "github_sha": _normalized_string(payload.get("github_sha")),
+        "image_uri": image_uri,
+        "candidate_revision_tag": candidate_revision_tag,
+        "candidate_alias": candidate_alias,
+        "target_alias": target_alias,
+        "rollback_revision": rollback_revision,
+        "rollback_model_version": rollback_model_version,
+        "rollback_revision_tag": rollback_revision_tag,
+    }
+
+
+def write_runtime_release_summary(summary: dict[str, Any]) -> Path:
+    """Persist the latest runtime release handoff summary and a history copy."""
+    summary_path = runtime_release_summary_path()
+    summary_path.parent.mkdir(parents=True, exist_ok=True)
+    summary_path.write_text(json.dumps(summary, indent=2, sort_keys=True) + "\n")
+    _write_runtime_release_history(summary)
+    return summary_path
+
+
+def record_runtime_release_request(
+    request_json: Mapping[str, Any] | str | None = None,
+    dag_run_id: str = "manual",
+    dag_id: str = "runtime_release",
+) -> str:
+    """Normalize and persist the runtime release handoff request."""
+    summary = build_runtime_release_summary(
+        request_json,
+        dag_run_id=dag_run_id,
+        dag_id=dag_id,
+    )
+    return str(write_runtime_release_summary(summary))
+
+
+__all__ = [
+    "ALLOWED_RUNTIME_RELEASE_ACTIONS",
+    "build_runtime_release_summary",
+    "record_runtime_release_request",
+    "runtime_release_report_dir",
+    "runtime_release_summary_history_paths",
+    "runtime_release_summary_path",
+    "write_runtime_release_summary",
+]

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -569,7 +569,7 @@ def test_publish_app_image_stops_at_image_publish_boundary() -> None:
         in summary_step["run"]
     )
     assert (
-        'echo "- Next step: use the runtime-side trigger contract or operator path to deploy this image"'
+        'echo "- Next step: run Trigger Runtime Release with action deploy_candidate and this immutable image URI"'
         in summary_step["run"]
     )
 
@@ -584,9 +584,96 @@ def test_publish_app_image_stops_at_image_publish_boundary() -> None:
     assert "GCP_CLOUD_RUN_SERVICE" not in skipped_step["run"]
 
 
-def test_promote_candidate_workflow_is_blocked_pending_runtime_trigger_contract() -> (
+def test_trigger_runtime_release_workflow_uses_hosted_airflow_handoff_contract() -> (
     None
 ):
+    workflow = _workflow_yaml(".github/workflows/trigger-runtime-release.yml")
+    config_job = workflow["jobs"]["config"]
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+
+    assert workflow["permissions"] == {"contents": "read", "id-token": "write"}
+    assert dispatch_inputs["action"]["default"] == "deploy_candidate"
+    assert dispatch_inputs["action"]["type"] == "choice"
+    assert dispatch_inputs["action"]["options"] == [
+        "deploy_candidate",
+        "promote_candidate",
+        "rollback_live",
+    ]
+    assert dispatch_inputs["candidate_revision_tag"]["default"] == "candidate"
+    assert dispatch_inputs["candidate_alias"]["default"] == "candidate"
+    assert dispatch_inputs["target_alias"]["default"] == "champion"
+    assert dispatch_inputs["rollback_revision_tag"]["default"] == "rollback"
+
+    assert set(config_job["outputs"]) == {
+        "owner_allowed",
+        "project_id",
+        "workload_identity_provider",
+        "service_account_email",
+        "online_compose_host_name",
+        "online_compose_host_zone",
+        "action",
+        "image_uri",
+        "candidate_revision_tag",
+        "candidate_alias",
+        "target_alias",
+        "rollback_revision",
+        "rollback_model_version",
+        "rollback_revision_tag",
+        "trigger_ready",
+    }
+
+    repo_config_step = _workflow_step(workflow, "config", "repo_config")
+    assert repo_config_step["uses"] == "./.github/actions/load-gcp-repo-config"
+
+    derived_step = _workflow_step(workflow, "config", "derived")
+    assert derived_step["env"]["ACTION_INPUT"] == "${{ github.event.inputs.action }}"
+    assert (
+        derived_step["env"]["PROVISION_ONLINE_COMPOSE_HOST"]
+        == "${{ steps.repo_config.outputs.provision_online_compose_host }}"
+    )
+    assert "deploy_candidate|promote_candidate|rollback_live" in derived_step["run"]
+    assert "trigger_ready=false" in derived_step["run"]
+    assert 'echo "trigger_ready=$trigger_ready"' in derived_step["run"]
+
+    trigger_job = workflow["jobs"]["trigger"]
+    assert (
+        trigger_job["if"]
+        == "${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready == 'true' }}"
+    )
+    assert (
+        trigger_job["env"]["HOST_NAME"]
+        == "${{ needs.config.outputs.online_compose_host_name }}"
+    )
+    assert (
+        trigger_job["env"]["HOST_ZONE"]
+        == "${{ needs.config.outputs.online_compose_host_zone }}"
+    )
+
+    payload_step = _workflow_step(workflow, "trigger", "Build runtime release request")
+    assert "runtime-release-request.json" in payload_step["run"]
+    assert "github_run_url" in payload_step["run"]
+
+    refresh_step = _workflow_step(workflow, "trigger", "Refresh operator host checkout")
+    assert "gcloud compute ssh" in refresh_step["run"]
+    assert "foehncast-online-compose-sync.service" in refresh_step["run"]
+    assert "--wait" in refresh_step["run"]
+
+    copy_step = _workflow_step(workflow, "trigger", "Copy runtime release request")
+    assert "gcloud compute scp" in copy_step["run"]
+    assert "/tmp/runtime-release-request.json" in copy_step["run"]
+
+    handoff_step = _workflow_step(
+        workflow, "trigger", "Trigger runtime release handoff"
+    )
+    assert (
+        "./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json"
+        in handoff_step["run"]
+    )
+    assert 'echo "- Airflow DAG: runtime_release"' in handoff_step["run"]
+    assert 'echo "## Runtime release handoff"' in handoff_step["run"]
+
+
+def test_promote_candidate_workflow_redirects_to_runtime_trigger_contract() -> None:
     workflow = _workflow_yaml(".github/workflows/promote-candidate.yml")
     config_job = workflow["jobs"]["config"]
     dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
@@ -645,20 +732,21 @@ def test_promote_candidate_workflow_is_blocked_pending_runtime_trigger_contract(
     blocked_step = _workflow_step(
         workflow, "blocked", "Explain blocked promotion workflow"
     )
-    assert "Candidate promotion moved out of GitHub" in blocked_step["run"]
+    assert (
+        "Candidate promotion moved behind Trigger Runtime Release"
+        in blocked_step["run"]
+    )
     assert (
         "Candidate promotion is no longer executed directly from GitHub Actions."
         in blocked_step["run"]
     )
     assert (
-        "explicit GitHub-to-runtime trigger contract is implemented"
+        "Use Trigger Runtime Release with action promote_candidate"
         in blocked_step["run"]
     )
 
 
-def test_rollback_live_release_workflow_is_blocked_pending_runtime_trigger_contract() -> (
-    None
-):
+def test_rollback_live_release_workflow_redirects_to_runtime_trigger_contract() -> None:
     workflow = _workflow_yaml(".github/workflows/rollback-live-release.yml")
     config_job = workflow["jobs"]["config"]
     dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
@@ -730,15 +818,28 @@ def test_rollback_live_release_workflow_is_blocked_pending_runtime_trigger_contr
     blocked_step = _workflow_step(
         workflow, "blocked", "Explain blocked rollback workflow"
     )
-    assert "Live rollback moved out of GitHub" in blocked_step["run"]
+    assert "Live rollback moved behind Trigger Runtime Release" in blocked_step["run"]
     assert (
         "Live rollback is no longer executed directly from GitHub Actions."
         in blocked_step["run"]
     )
     assert (
-        "explicit GitHub-to-runtime trigger contract is implemented"
-        in blocked_step["run"]
+        "Use Trigger Runtime Release with action rollback_live" in blocked_step["run"]
     )
+
+
+def test_trigger_runtime_release_script_uses_local_airflow_contract() -> None:
+    script = _read_text("scripts/trigger-runtime-release.sh")
+
+    assert "Usage: $0 --request-file path" in script
+    assert "http://127.0.0.1:8080/api/v2/monitor/health" in script
+    assert "deploy_candidate, promote_candidate, or rollback_live" in script
+    assert 'airflow dags trigger "$DAG_ID"' in script
+    assert (
+        'wait_for_airflow_dag_run_state "$DAG_ID" "$dag_run_id" success 120 2' in script
+    )
+    assert "runtime-release-latest.json" in script
+    assert 'report["report_path"] = report_path' in script
 
 
 def test_publish_runtime_images_excludes_local_only_development_env() -> None:

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -264,3 +264,22 @@ def test_training_dag_supports_dataset_override(
         "dataset": expected_dataset_template,
         "requested_stage": expected_stage_template,
     }
+
+
+def test_runtime_release_dag_accepts_manual_handoff_requests(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, operators = _load_dag_module(monkeypatch, "dags/runtime_release_dag.py")
+
+    assert module.dag.kwargs["schedule"] is None
+    assert module.dag.kwargs["catchup"] is False
+    assert module.dag.kwargs["is_paused_upon_creation"] is False
+    assert module.dag.kwargs["tags"] == ["foehncast", "runtime"]
+    assert [operator.kwargs["task_id"] for operator in operators] == [
+        "record_runtime_release_request",
+    ]
+    assert operators[0].kwargs["op_kwargs"] == {
+        "request_json": "{{ dag_run.conf | tojson if dag_run and dag_run.conf else '{}' }}",
+        "dag_run_id": "{{ run_id }}",
+        "dag_id": "runtime_release",
+    }

--- a/tests/test_runtime_release.py
+++ b/tests/test_runtime_release.py
@@ -1,0 +1,88 @@
+"""Tests for runtime release handoff normalization and persistence."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import foehncast.runtime_release as runtime_release
+
+
+def test_build_runtime_release_summary_normalizes_deploy_candidate_request() -> None:
+    summary = runtime_release.build_runtime_release_summary(
+        {
+            "action": "DEPLOY_CANDIDATE",
+            "image_uri": "europe-west6-docker.pkg.dev/demo/foehncast/foehncast-app:sha-123",
+            "candidate_revision_tag": "Candidate",
+            "candidate_alias": "Candidate",
+            "target_alias": "Champion",
+            "request_source": "github-actions",
+            "github_repository": "javihslu/foehncast",
+        },
+        dag_run_id="runtime_release__2026-05-14T10-00-00Z",
+    )
+
+    assert summary["action"] == "deploy_candidate"
+    assert (
+        summary["image_uri"]
+        == "europe-west6-docker.pkg.dev/demo/foehncast/foehncast-app:sha-123"
+    )
+    assert summary["candidate_revision_tag"] == "candidate"
+    assert summary["candidate_alias"] == "candidate"
+    assert summary["target_alias"] == "champion"
+    assert summary["dag_id"] == "runtime_release"
+    assert summary["dag_run_id"] == "runtime_release__2026-05-14T10-00-00Z"
+    assert summary["runtime_receiver"] == "hosted_airflow"
+
+
+def test_build_runtime_release_summary_requires_rollback_coordinates() -> None:
+    with pytest.raises(ValueError):
+        runtime_release.build_runtime_release_summary(
+            {"action": "rollback_live", "rollback_revision": "candidate"},
+            dag_run_id="runtime_release__rollback",
+        )
+
+
+def test_write_runtime_release_summary_persists_latest_and_history(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(runtime_release, "project_root", lambda: tmp_path)
+
+    summary = {
+        "generated_at": "2026-05-14T11:00:00+00:00",
+        "state": "accepted",
+        "runtime_receiver": "hosted_airflow",
+        "dag_id": "runtime_release",
+        "dag_run_id": "runtime_release__2026-05-14T11-00-00Z",
+        "action": "promote_candidate",
+        "request_source": "github-actions",
+        "github_repository": "javihslu/foehncast",
+        "github_workflow": "Trigger Runtime Release",
+        "github_run_id": "42",
+        "github_run_url": "https://github.com/javihslu/foehncast/actions/runs/42",
+        "github_sha": "abc123",
+        "image_uri": "",
+        "candidate_revision_tag": "candidate",
+        "candidate_alias": "candidate",
+        "target_alias": "champion",
+        "rollback_revision": "",
+        "rollback_model_version": "",
+        "rollback_revision_tag": "rollback",
+    }
+
+    latest_path = runtime_release.write_runtime_release_summary(summary)
+
+    assert (
+        latest_path == tmp_path / "airflow" / "reports" / "runtime-release-latest.json"
+    )
+    assert (
+        json.loads(latest_path.read_text())["dag_run_id"]
+        == "runtime_release__2026-05-14T11-00-00Z"
+    )
+    history_paths = runtime_release.runtime_release_summary_history_paths()
+    assert len(history_paths) == 1
+    assert history_paths[0].name == "runtime-release-20260514T110000000000Z.json"
+    assert json.loads(history_paths[0].read_text())["action"] == "promote_candidate"


### PR DESCRIPTION
## What changed
- add `.github/workflows/trigger-runtime-release.yml` as the single reviewed GitHub-to-runtime handoff for candidate deploy, promotion, and rollback requests
- add `scripts/trigger-runtime-release.sh` as the retained-host receiver that validates the request, triggers hosted Airflow locally, waits for success, and returns the runtime acknowledgement
- add `dags/runtime_release_dag.py` and `src/foehncast/runtime_release.py` to normalize and persist runtime release requests under `airflow/reports/`
- repoint the legacy publish, promote, and rollback workflow messaging at the new trigger contract
- extend public delivery docs and regression tests to cover the handoff contract, receiver DAG, and persisted acknowledgement

## Why
- the runtime boundary needed one explicit signal, one auth path, and one observable outcome instead of a mix of blocked workflows and operator-only tribal steps
- this makes GitHub a reviewed delivery trigger while keeping hosted Airflow as the runtime surface of record

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-204 && PYTHONPATH="$PWD/src" /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/pytest tests/test_cloud_operator_contract.py tests/test_dags.py tests/test_runtime_release.py`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-204 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #204
