### PR TITLE
docs(operations): publish retry and backfill runbooks

### DIFF
--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -113,6 +113,17 @@ The current delivery story is split intentionally:
 
 For this horizon, hosted Airflow on the retained operator host remains the orchestration surface of record. That means Cloud Run is the serving surface, not the scheduler, and GitHub Actions is the delivery plane, not the runtime orchestrator.
 
+## Operator Recovery Lane
+
+The active shared environment now has one reviewed recovery split:
+
+- delivery failures before runtime execution stay on the GitHub plus Terraform side
+- serving rollout retries use the explicit runtime trigger contract, not ad hoc SSH-only release changes
+- feature retries and backfills stay on hosted Airflow on the retained operator host
+- replaying one logical date starts with `feature_pipeline`; the downstream `training_pipeline` run should remain asset-triggered when the replay is meant to refresh production training state
+
+This keeps the recovery story aligned with the topology: GitHub advances reviewed delivery, Cloud Run serves the public API, and hosted Airflow on the retained host owns runtime replay work.
+
 ## Honest Mapping From Local To Cloud
 
 | Local component | Current hosted path |
@@ -193,6 +204,18 @@ In practice, GCS stores raw landing data and registry-style metadata for the clo
 | Auth | local `.env` plus developer credentials | runtime service accounts and GitHub OIDC |
 | Image source | local builds | GHCR runtime images or Artifact Registry app image |
 | Public exposure | local ports on the developer machine | Cloud Run is the shared hosted API surface; the retained hosted full-stack target stays private by default; operator dashboards stay private unless you deliberately publish them |
+
+## Recovery Evidence In Cloud
+
+Operators should be able to prove what changed after a retry, replay, or rollback request.
+
+The stable evidence surfaces are:
+
+- `airflow/reports/feature-pipeline-<dataset>-latest.json` and its history copy for feature retries or backfills
+- `airflow/reports/training-pipeline-<dataset>-latest.json` and its history copy for training follow-up
+- `airflow/reports/runtime-release-latest.json` and its history copy for reviewed deploy, promote, or rollback handoffs
+- `.state/online-compose-sync/last-success.json` for the retained host refresh state
+- `/metrics` and the checked-in Grafana panels for post-recovery operator verification
 
 ## What Is Already In Place
 

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -158,6 +158,38 @@ The current action set is deliberately small:
 
 This keeps the handoff explicit before deeper runtime automation is added behind the Airflow side of the boundary.
 
+## Retry And Backfill Runbooks
+
+The recovery lane is now explicit too. Operators should retry work on the same plane that owns it instead of jumping between GitHub and runtime surfaces.
+
+| Situation | Where to act | Normal procedure | Minimum evidence |
+|------|---------------|------------------|------------------|
+| Terraform or image publication fails before any runtime request is sent | GitHub Actions | fix the reviewed delivery input, then rerun the failed GitHub workflow | GitHub workflow URL plus the updated workflow summary |
+| candidate deploy, promotion, or rollback handoff needs another attempt | GitHub Actions through the runtime trigger contract | rerun `.github/workflows/trigger-runtime-release.yml` with the same reviewed release coordinates so the retained operator host refreshes and the hosted Airflow `runtime_release` DAG records a new acknowledgement | GitHub workflow URL plus `airflow/reports/runtime-release-latest.json` |
+| a feature slice failed or needs replay for one logical date | hosted Airflow on the retained operator host | SSH to the host, verify Airflow health, trigger `feature_pipeline` with an explicit logical date, and wait for the DAG to succeed | logical date, feature DAG run id, and `airflow/reports/feature-pipeline-<dataset>-latest.json` |
+| a replayed feature slice should refresh training state too | hosted Airflow on the retained operator host | let the feature replay publish the training-request asset and wait for the asset-triggered `training_pipeline` run instead of treating training as a separate first step | training DAG run id plus `airflow/reports/training-pipeline-<dataset>-latest.json` |
+| training must be rerun without replaying feature ingestion | hosted Airflow on the retained operator host | use a manual `training_pipeline` run only when the curated feature slice already exists and the operator is intentionally choosing the requested stage in DAG config | training DAG run id, requested stage, model version, and training summary JSON |
+
+The retained operator host stays private by default, so the documented recovery path assumes SSH to the host rather than a public Airflow endpoint.
+
+Example feature replay on the retained host:
+
+```bash
+cd /opt/foehncast
+docker compose -f docker-compose.yml -f docker-compose.cloud.yml --env-file .env exec -T airflow-webserver \
+    airflow dags trigger feature_pipeline \
+    --logical-date "2026-05-14T00:00:00Z" \
+    --run-id "manual_backfill__2026-05-14T00-00-00Z"
+```
+
+The same host-side wait contract used by the sync path still applies after the trigger:
+
+- `feature_pipeline` should reach `success` for the chosen logical date
+- the downstream `training_pipeline` should reach `success` as an `asset_triggered` run when the replay is meant to refresh production model state
+- operators should check the latest summary JSON files under `airflow/reports/` before treating the replay as complete
+
+When the problem is serving rollout rather than data replay, do not use the backfill path. Use the runtime trigger contract instead so GitHub sends the reviewed deploy, promote, or rollback request and the runtime side records one explicit acknowledgement.
+
 ## Rollback And Retirement Coordinates
 
 The reviewed rollback handoff now runs through the runtime trigger contract instead of direct GitHub runtime mutation.
@@ -169,6 +201,12 @@ The reviewed rollback handoff now runs through the runtime trigger contract inst
 - reopening the hosted VM app on port `8000` is not part of rollback; the shared environment treats that as misconfiguration
 
 The remaining VM-retirement gate is separate from serving rollback. The VM stays online while Airflow, MLflow, and monitoring still define the retained control plane. Later retirement should happen only after that operator-plane scope is reduced explicitly.
+
+For recovery work, the practical split is:
+
+- use GitHub workflow reruns when reviewed delivery failed before runtime execution
+- use hosted Airflow retries and backfills when runtime data or orchestration work failed after delivery
+- use the runtime trigger contract when the serving release handoff itself must be retried
 
 ## What The Cloud-Operator Tests Enforce
 

--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -132,6 +132,21 @@ The checked-in alert rules cover the main operator failure modes.
 
 The contact point and policy tree stay checked in too, so the alert routing contract is reviewable without depending on a live Grafana instance.
 
+## Recovery Evidence And Runbook Checks
+
+Retry and backfill work should leave durable evidence that operators can compare before and after the intervention.
+
+| Recovery task | Durable evidence to capture | Operator check |
+|------|-----------------------------|----------------|
+| feature retry or backfill | `airflow/reports/feature-pipeline-<dataset>-latest.json` plus the matching history file | the latest summary timestamp advances and the feature-stage failure alert clears |
+| training follow-up after a replay | `airflow/reports/training-pipeline-<dataset>-latest.json` plus the matching history file | the summary records the requested stage, registered model version, and no training-stage failure alert remains |
+| reviewed deploy, promote, or rollback handoff retry | `airflow/reports/runtime-release-latest.json` plus the matching history file | the GitHub workflow summary and the runtime-side acknowledgement describe the same action and coordinates |
+| retained operator host refresh verification | `.state/online-compose-sync/last-success.json` | the hosted-sync stale signal clears and the app republishes the updated sync state on `/metrics` |
+
+When the recovery started from reviewed delivery, capture the GitHub workflow URL too. When the recovery started from hosted Airflow, capture the logical date and DAG run id with the summary artifacts.
+
+These checks are intentionally small. They give operators one repeatable evidence pack without turning the monitoring stack into the system that performs the retry itself.
+
 ## Reading Evidence Safely
 
 The docs site should explain monitoring with rendered evidence, not live control-plane embeds.


### PR DESCRIPTION
## What changed
- add the reviewed retry and backfill runbooks to `docs/site/system/delivery-and-operator-workflow.md`
- document the operator recovery lane and recovery evidence surfaces in `docs/site/system/cloud-mapping.md`
- add the durable evidence and runbook checks section to `docs/site/system/monitoring.md`
- keep the recovery guidance scoped to hosted Airflow on the retained operator host and the reviewed runtime trigger contract

## Why
- retry and backfill work should be reviewable operator guidance, not tribal knowledge spread across delivery and runtime surfaces
- this lands last so the runbooks describe the chosen runtime trigger contract instead of a transitional state

## Verification
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-205 && PYTHONPATH="$PWD/src" /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/pytest tests/test_cloud_operator_contract.py tests/test_dags.py tests/test_runtime_release.py`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-205 && /Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin/mkdocs build --strict -f docs/mkdocs.yml`

Closes #205
