### PR TITLE
docs(architecture): clarify cloud secret ownership boundary

### DIFF
--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -113,6 +113,8 @@ The current delivery story is split intentionally:
 
 For this horizon, hosted Airflow on the retained operator host remains the orchestration surface of record. That means Cloud Run is the serving surface, not the scheduler, and GitHub Actions is the delivery plane, not the runtime orchestrator.
 
+That same split is also the current ownership boundary for cloud-facing values. Terraform inputs and GitHub repository variables carry the structural delivery contract, while secret-bearing runtime values stay on the runtime side through hosted environment injection or a managed secret path. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
+
 ## Operator Recovery Lane
 
 The active shared environment now has one reviewed recovery split:

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -104,6 +104,8 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 
 This contract is deliberate. The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as container port, CPU, and memory stay repo-variable-backed instead of becoming more manual workflow inputs.
 
+That same split is also the current ownership boundary for cloud-facing values. Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables remain structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
+
 GitHub-hosted workflows now stop at reviewed infrastructure change, artifact publication, and one explicit runtime release request. GitHub does not mutate live runtime state directly; the request is handed to hosted Airflow on the retained operator host.
 
 The promoted hosted runtime story is now:

--- a/scripts/configure-github-actions.sh
+++ b/scripts/configure-github-actions.sh
@@ -97,6 +97,8 @@ fi
 
 REPOSITORY_PATH="$(resolve_repo)"
 
+echo "GitHub repository variables carry the structural delivery contract only; keep runtime secrets in the runtime environment or a managed secret path."
+
 if [[ "$CLEAR" == "true" ]]; then
   while IFS= read -r variable_name; do
     delete_variable "$REPOSITORY_PATH" "$variable_name"

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -186,6 +186,8 @@ These repository variables are the structural hosted-delivery contract. They are
 
 If the shared cloud runtime later needs secret-bearing values beyond local-safe placeholders, inject them into the hosted runtime environment or a managed secret path instead of adding them to GitHub repository variables. Endpoints such as `GCP_MLFLOW_TRACKING_URI` should stay credential-free; if auth is required later, inject that secret separately at runtime.
 
+See [../docs/site/system/configuration-and-contracts.md](../docs/site/system/configuration-and-contracts.md) for the reviewed inventory of checked-in examples, bootstrap outputs, GitHub repository variables, runtime environment injection, and identity-backed auth.
+
 `GCP_CLOUD_RUN_SERVICE` stays unset until Terraform has actually provisioned the Cloud Run service. After that, publish automation can update the service with newly built images.
 
 When `GCP_CLOUD_RUN_SERVICE` is set and the service already exists, the workflow publishes an immutable `sha-<commit>` image tag, updates the existing Cloud Run service to that image, and then smoke-checks `/health` plus `/spots`. If the service blocks unauthenticated access, the workflow requests an identity token before calling those routes. Terraform remains the source of truth for the service baseline such as service account, scaling, ingress, and environment variables.


### PR DESCRIPTION
What changed: clarified that GitHub repository variables are only for structural delivery values, not runtime secrets, and linked the public ownership inventory from the main operator docs and Terraform reference.

Why: makes the cloud boundary easier to read and keeps secret handling consistent across docs and helper output.

Verification: ran uv run pytest tests/test_cloud_operator_contract.py -q and uv run mkdocs build -f docs/mkdocs.yml.

Closes: #217