### PR TITLE
docs(terraform): inventory retained-host delivery coupling

### DIFF
--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -96,6 +96,18 @@ The remote workflow reads repository-backed values for project, state, storage, 
 
 Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables stay structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. Both hosted lanes still read the same Terraform-managed storage, Feast, and MLflow contract. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
 
+## Current Retained-Host Dependencies
+
+The shared environment still depends on the retained operator host in a few specific places. This table is the current inventory for the active migration wave.
+
+| Surface | Current dependency | Classification | Next migration issue |
+|------|--------------------|----------------|----------------------|
+| runtime release handoff | `.github/workflows/trigger-runtime-release.yml` still refreshes the VM checkout over SSH and runs `scripts/trigger-runtime-release.sh` to trigger the host-local `runtime_release` DAG | transitional | #224 |
+| hosted DAG execution and recovery | runtime retries, backfills, and manual replay still assume SSH access to the retained host and host-local Airflow | transitional | #224 |
+| bootstrap and repo-variable plumbing | `scripts/bootstrap-gcp.sh`, `.github/workflows/terraform.yml`, and `scripts/terraform-platform-state.sh` still resolve and sync `GCP_ONLINE_COMPOSE_*` inputs | transitional | #224 |
+| sync evidence and operator checks | the retained host still writes `.state/online-compose-sync/last-success.json`, and hosted verification still checks that sync evidence through `/metrics` | keep for now | later host-shrink issue |
+| cloud-operator regression tests | `tests/test_cloud_operator_contract.py` and the online-compose sync tests still enforce the retained-host contract directly | keep while migrating | same issue as the production surface being changed |
+
 ## Hosted Orchestration Surface Decision
 
 Hosted Airflow on the retained operator host remains the orchestration surface of record for this horizon.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -111,6 +111,18 @@ By default, `online_compose_public_ports = []`, so the retained operator host st
 
 The compose-host path is the simplest way to keep the whole stack online without forcing Airflow into Cloud Run.
 
+## Transitional VM-Specific Surface
+
+The retained host is still part of the shared environment, but several VM-specific surfaces are transitional rather than long-term design targets.
+
+| Surface | Why it still exists | Classification | Next migration issue |
+|--------|----------------------|----------------|----------------------|
+| `online_compose_*` Terraform inputs, outputs, and repo variables | the current VM target still needs host name, zone, sizing, and exposure controls | transitional | #224 |
+| default GHCR image sources for the VM path | the retained-host images still fall back to GHCR when explicit image URIs are not provided | stale build-plane assumption | #223 |
+| VM runtime service account and IAM | the current host still combines Airflow, MLflow, training, Feast preparation, and private app checks on one machine | current but transitional | later host-shrink issue |
+| startup template and sync timer | the VM still refreshes the repo, pulls the stack, and records retained-host sync evidence for operators | current but transitional | later host-shrink issue |
+| public-port outputs and verification rules | the current hosted contract still needs to prove that Cloud Run is the only public API surface while the VM stays private | keep for now | keep until the VM role changes |
+
 ## What The Hosted Paths Expose
 
 | Path | Public surface by default | Notes |


### PR DESCRIPTION
# Issue 222 PR Draft

Repo: `javihslu/foehncast`
Issue: #222 `chore: inventory retained-host coupling in hosted delivery`
Branch: `chore/222-inventory-retained-host-coupling`
Worktree: `/Users/jvr/github/HSLU/MLOPS/workdocs/git-worktrees/foehncast-222`
Status: validated diff exists, not committed

## Suggested PR Title

`docs(terraform): inventory retained-host delivery coupling`

## Suggested PR Body

Closes #222.

## Summary

This change adds a minimal checked-in inventory of the retained operator host dependencies that still shape the hosted delivery path today.

It does not change runtime behavior or Terraform semantics. It only makes the remaining host-coupled surfaces explicit so later migration issues can remove them deliberately.

## What Changed

- added a `Current Retained-Host Dependencies` table to `docs/site/system/delivery-and-operator-workflow.md`
- added a `Transitional VM-Specific Surface` table to `terraform/README.md`
- kept the issue deliberately small and inventory-only

## Scope Boundaries

This PR intentionally does not:

- change runtime behavior
- change Terraform resources or defaults
- change tests
- start the Cloud Build or Composer cutover work

## Validation

- `PATH=/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin:$PATH PYTHONPATH=$PWD/src mkdocs build -f docs/mkdocs.yml --strict`
- strict MkDocs build passed against the clean worktree

## Diff Snapshot

Tracked diff summary at the current branch state:

- `docs/site/system/delivery-and-operator-workflow.md`
- `terraform/README.md`

Tracked diff stat at the current branch state:

- 2 files changed, 24 insertions

## Reviewer Notes

This PR is the inventory slice only. It documents the still-retained host surfaces so the follow-on branches can remove them in a controlled order instead of mixing discovery and implementation in the same diff.
