### PR TITLE
feat(ci): define hosted Cloud Build image contract

### DIFF
--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - .github/workflows/publish-app-image.yml
+      - .github/actions/load-gcp-repo-config/action.yml
+      - cloudbuild/**
       - containers/app/**
       - src/**
       - pyproject.toml
@@ -21,6 +23,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
+      project_id: ${{ steps.repo_config.outputs.project_id }}
       workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
       service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
       registry_host: ${{ steps.derived.outputs.registry_host }}
@@ -90,46 +93,54 @@ jobs:
     outputs:
       image_uri: ${{ steps.image.outputs.immutable_tag }}
     env:
-      REGISTRY_HOST: ${{ needs.config.outputs.registry_host }}
+      PROJECT_ID: ${{ needs.config.outputs.project_id }}
       IMAGE_NAME: foehncast-app
       IMAGE_REPOSITORY: ${{ needs.config.outputs.image_repository }}
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: docker/setup-buildx-action@v4
-
       - id: image
         run: |
-          echo "immutable_tag=${IMAGE_REPOSITORY}:sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
-          echo "latest_tag=${IMAGE_REPOSITORY}:latest" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
 
-      - uses: google-github-actions/auth@v2
+          echo "immutable_tag=${IMAGE_REPOSITORY}:sha-${GITHUB_SHA}" >> "$GITHUB_OUTPUT"
+          latest_tag=""
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            latest_tag="${IMAGE_REPOSITORY}:latest"
+          fi
+          echo "latest_tag=${latest_tag}" >> "$GITHUB_OUTPUT"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
           workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
           service_account: ${{ needs.config.outputs.service_account_email }}
 
-      - uses: google-github-actions/setup-gcloud@v2
-
-      - run: gcloud auth configure-docker "${REGISTRY_HOST}" --quiet
-
-      - id: metadata
-        uses: docker/metadata-action@v6
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
         with:
-          images: ${{ env.IMAGE_REPOSITORY }}
-          tags: |
-            type=raw,value=sha-${{ github.sha }}
-            type=raw,value=latest,enable={{is_default_branch}}
+          project_id: ${{ needs.config.outputs.project_id }}
 
-      - uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: containers/app/Dockerfile
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - id: submit
+        name: Submit Cloud Build
+        env:
+          BUILD_CONTEXT: .
+          DOCKERFILE: containers/app/Dockerfile
+          LATEST_TAG: ${{ steps.image.outputs.latest_tag }}
+        run: |
+          set -euo pipefail
+
+          substitutions=(
+            "_BUILD_CONTEXT=${BUILD_CONTEXT}"
+            "_DOCKERFILE=${DOCKERFILE}"
+            "_IMAGE_REPOSITORY=${IMAGE_REPOSITORY}"
+            "_COMMIT_SHA=${GITHUB_SHA}"
+            "_FLOATING_TAG=${LATEST_TAG}"
+          )
+          IFS=,
+          build_id="$(gcloud builds submit . --project "${PROJECT_ID}" --config cloudbuild/runtime-image.yaml --substitutions "${substitutions[*]}" --format='value(id)')"
+          unset IFS
+          echo "build_id=${build_id}" >> "$GITHUB_OUTPUT"
 
       - name: Summarize published image
         run: |
@@ -137,7 +148,13 @@ jobs:
             echo "## Published app image"
             echo
             echo "- Immutable: ${{ steps.image.outputs.immutable_tag }}"
-            echo "- Floating: ${{ steps.image.outputs.latest_tag }}"
+            if [[ -n "${{ steps.image.outputs.latest_tag }}" ]]; then
+              echo "- Floating: ${{ steps.image.outputs.latest_tag }}"
+            else
+              echo "- Floating: not published for non-main ref"
+            fi
+            echo "- Builder: Cloud Build"
+            echo "- Build id: ${{ steps.submit.outputs.build_id }}"
             echo "- Runtime handoff: not executed from GitHub in this workflow"
             echo "- Next step: run Trigger Runtime Release with action deploy_candidate and this immutable image URI"
           } >> "$GITHUB_STEP_SUMMARY"
@@ -152,7 +169,7 @@ jobs:
           {
             echo "## App image publish skipped"
             echo
-            echo "Set these repository variables to enable Artifact Registry publishing:"
+            echo "Set these repository variables to enable Artifact Registry publication through Cloud Build:"
             echo "- GCP_PROJECT_ID"
             echo "- GCP_LOCATION"
             echo "- GCP_ARTIFACT_REPOSITORY"

--- a/.github/workflows/publish-runtime-images.yml
+++ b/.github/workflows/publish-runtime-images.yml
@@ -5,30 +5,86 @@ on:
     branches: [main]
     paths:
       - .github/workflows/publish-runtime-images.yml
-      - containers/app/**
+      - .github/actions/load-gcp-repo-config/action.yml
+      - cloudbuild/**
       - containers/airflow/**
       - containers/mlflow/**
       - src/**
       - pyproject.toml
       - uv.lock
       - config.yaml
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: read
-  packages: write
+  id-token: write
 
 jobs:
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
+      project_id: ${{ steps.repo_config.outputs.project_id }}
+      workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
+      service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
+      image_repository_base: ${{ steps.derived.outputs.image_repository_base }}
+      publish_ready: ${{ steps.derived.outputs.publish_ready }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - id: flags
+        env:
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
+
+          owner_allowed=false
+          if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
+            owner_allowed=true
+          fi
+
+          echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
+
+      - id: repo_config
+        uses: ./.github/actions/load-gcp-repo-config
+        with:
+          repo-vars-json: ${{ toJson(vars) }}
+
+      - id: derived
+        env:
+          PROJECT_ID: ${{ steps.repo_config.outputs.project_id }}
+          LOCATION: ${{ steps.repo_config.outputs.location }}
+          ARTIFACT_REPOSITORY: ${{ steps.repo_config.outputs.artifact_repository }}
+          WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
+          SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
+        run: |
+          set -euo pipefail
+
+          image_repository_base=""
+          if [[ -n "$LOCATION" && -n "$PROJECT_ID" && -n "$ARTIFACT_REPOSITORY" ]]; then
+            image_repository_base="${LOCATION}-docker.pkg.dev/${PROJECT_ID}/${ARTIFACT_REPOSITORY}"
+          fi
+
+          publish_ready=false
+          if [[ -n "$image_repository_base" && -n "$WORKLOAD_IDENTITY_PROVIDER" && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
+            publish_ready=true
+          fi
+
+          {
+            echo "image_repository_base=$image_repository_base"
+            echo "publish_ready=$publish_ready"
+          } >> "$GITHUB_OUTPUT"
+
   publish:
-    if: ${{ github.actor == github.repository_owner && github.triggering_actor == github.repository_owner }}
+    needs: config
+    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.publish_ready == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         include:
-          - image_name: foehncast-app
-            context: .
-            dockerfile: containers/app/Dockerfile
           - image_name: foehncast-airflow
             context: .
             dockerfile: containers/airflow/Dockerfile
@@ -38,38 +94,90 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
 
-      - uses: docker/setup-buildx-action@v4
+      - id: image
+        env:
+          IMAGE_REPOSITORY_BASE: ${{ needs.config.outputs.image_repository_base }}
+          IMAGE_NAME: ${{ matrix.image_name }}
+        run: |
+          set -euo pipefail
 
-      - uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ github.token }}
+          image_repository="${IMAGE_REPOSITORY_BASE}/${IMAGE_NAME}"
+          immutable_tag="${image_repository}:sha-${GITHUB_SHA}"
+          latest_tag=""
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            latest_tag="${image_repository}:latest"
+          fi
 
-      - id: metadata
-        uses: docker/metadata-action@v6
-        with:
-          images: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}
-          tags: |
-            type=raw,value=main,enable={{is_default_branch}}
-            type=sha,prefix=sha-
+          {
+            echo "image_repository=${image_repository}"
+            echo "immutable_tag=${immutable_tag}"
+            echo "latest_tag=${latest_tag}"
+          } >> "$GITHUB_OUTPUT"
 
-      - uses: docker/build-push-action@v6
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
         with:
-          context: ${{ matrix.context }}
-          file: ${{ matrix.dockerfile }}
-          platforms: linux/amd64
-          push: true
-          tags: ${{ steps.metadata.outputs.tags }}
-          labels: ${{ steps.metadata.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
+          service_account: ${{ needs.config.outputs.service_account_email }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ needs.config.outputs.project_id }}
+
+      - id: submit
+        name: Submit Cloud Build
+        env:
+          PROJECT_ID: ${{ needs.config.outputs.project_id }}
+          BUILD_CONTEXT: ${{ matrix.context }}
+          DOCKERFILE: ${{ matrix.dockerfile }}
+          IMAGE_REPOSITORY: ${{ steps.image.outputs.image_repository }}
+          LATEST_TAG: ${{ steps.image.outputs.latest_tag }}
+        run: |
+          set -euo pipefail
+
+          substitutions=(
+            "_BUILD_CONTEXT=${BUILD_CONTEXT}"
+            "_DOCKERFILE=${DOCKERFILE}"
+            "_IMAGE_REPOSITORY=${IMAGE_REPOSITORY}"
+            "_COMMIT_SHA=${GITHUB_SHA}"
+            "_FLOATING_TAG=${LATEST_TAG}"
+          )
+          IFS=,
+          build_id="$(gcloud builds submit . --project "${PROJECT_ID}" --config cloudbuild/runtime-image.yaml --substitutions "${substitutions[*]}" --format='value(id)')"
+          unset IFS
+          echo "build_id=${build_id}" >> "$GITHUB_OUTPUT"
 
       - name: Summarize image
         run: |
           {
             echo "## Published runtime image"
             echo
-            echo "- Image: ghcr.io/${{ github.repository_owner }}/${{ matrix.image_name }}"
-            echo "- Tags: ${{ steps.metadata.outputs.tags }}"
+            echo "- Image: ${{ steps.image.outputs.image_repository }}"
+            echo "- Immutable: ${{ steps.image.outputs.immutable_tag }}"
+            if [[ -n "${{ steps.image.outputs.latest_tag }}" ]]; then
+              echo "- Floating: ${{ steps.image.outputs.latest_tag }}"
+            else
+              echo "- Floating: not published for non-main ref"
+            fi
+            echo "- Builder: Cloud Build"
+            echo "- Build id: ${{ steps.submit.outputs.build_id }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  skipped:
+    needs: config
+    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.publish_ready != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain skipped publish
+        run: |
+          {
+            echo "## Runtime image publish skipped"
+            echo
+            echo "Set these repository variables to enable Artifact Registry publication through Cloud Build:"
+            echo "- GCP_PROJECT_ID"
+            echo "- GCP_LOCATION"
+            echo "- GCP_ARTIFACT_REPOSITORY"
+            echo "- GCP_WORKLOAD_IDENTITY_PROVIDER"
+            echo "- GCP_SERVICE_ACCOUNT_EMAIL"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/cloudbuild/runtime-image.yaml
+++ b/cloudbuild/runtime-image.yaml
@@ -1,0 +1,28 @@
+steps:
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -ceu
+      - |
+        tags=(-t "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}")
+        if [[ -n "${_FLOATING_TAG}" ]]; then
+          tags+=(-t "${_FLOATING_TAG}")
+        fi
+
+        docker build -f "${_DOCKERFILE}" "${tags[@]}" "${_BUILD_CONTEXT}"
+        docker push "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}"
+
+        if [[ -n "${_FLOATING_TAG}" ]]; then
+          docker push "${_FLOATING_TAG}"
+        fi
+
+options:
+  dynamicSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY
+
+substitutions:
+  _BUILD_CONTEXT: .
+  _DOCKERFILE: containers/app/Dockerfile
+  _IMAGE_REPOSITORY: europe-west6-docker.pkg.dev/example-project/foehncast-docker/foehncast-app
+  _COMMIT_SHA: dev
+  _FLOATING_TAG: ""

--- a/containers/README.md
+++ b/containers/README.md
@@ -105,7 +105,7 @@ Run these checks before deployment work:
 
 ## Hosted Reuse
 
-The hosted full-stack target is maintainer-owned and reuses the same service layout, but changes the runtime context: the host writes `.env` from Terraform-managed values, `development_env`, MinIO, and the Feast emulator do not deploy there, public exposure stays narrow and private by default, and MLflow artifacts point at the shared GCS bucket instead of the local artifact volume. Runtime images can be pulled from GHCR or built locally on the host if needed.
+The hosted full-stack target is maintainer-owned and reuses the same service layout, but changes the runtime context: the host writes `.env` from Terraform-managed values, `development_env`, MinIO, and the Feast emulator do not deploy there, public exposure stays narrow and private by default, and MLflow artifacts point at the shared GCS bucket instead of the local artifact volume. In the reviewed hosted path, runtime images are published to Artifact Registry through Cloud Build and pulled onto the host with the VM runtime identity instead of being built locally on the VM.
 
 See [../docs/site/system/hosted-full-stack.md](../docs/site/system/hosted-full-stack.md) for the hosted target contract and [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/system/delivery-and-operator-workflow.md) for the bootstrap and day-2 delivery flow.
 
@@ -114,4 +114,4 @@ See [../docs/site/system/hosted-full-stack.md](../docs/site/system/hosted-full-s
 - Local development uses the base `docker-compose.yml`, so images build natively on the current machine.
 - GCP-targeted local runs add `docker-compose.gcp.yml`, which mounts host ADC and pins the deployable app service to `linux/amd64`.
 - Example: `docker compose -f docker-compose.yml -f docker-compose.gcp.yml build app`
-- For release publishing, keep the same target architecture in CI with `docker buildx build --platform linux/amd64 ...`.
+- For reviewed hosted release publishing, GitHub submits Cloud Build builds that publish the deployable images to Artifact Registry.

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -78,12 +78,12 @@ This Cloud Run runtime identity is intentionally narrower than the other hosted 
 
 When `provision_online_compose_host = true`, provide:
 
-- optional image overrides if you do not want the default GHCR `:main` tags
+- optional image overrides if you do not want the default Artifact Registry `:latest` tags
 - any extra stack environment in `online_compose_env_vars`
 
 If the hosted Grafana tenant should deliver the provisioned monitoring alerts by email, set `FOEHNCAST_GRAFANA_ALERT_EMAIL` in `online_compose_env_vars`. The local Docker path intentionally leaves that override out of `.env.example` and relies on the placeholder route instead.
 
-Terraform creates a network, a static public IP, and a Compute Engine VM. The VM clones the repo, writes a runtime `.env` file with the GCP and BigQuery settings, and pulls the GHCR images. If the images are not available, the sync fails fast instead of building on the VM.
+Terraform creates a network, a static public IP, and a Compute Engine VM. The VM clones the repo, writes a runtime `.env` file with the GCP and BigQuery settings, configures Artifact Registry auth with its runtime identity, and pulls the reviewed runtime images from Artifact Registry. If the images are not available, the sync fails fast instead of building on the VM.
 That `.env` file uses the same Feast runtime settings as the Cloud Run path, so both hosted targets use the same Feast config.
 It also points MLflow artifacts to `gs://<artifact-bucket>/mlflow/artifacts`, so artifacts go to the shared bucket instead of a VM-local volume.
 The VM installs a `foehncast-online-compose-sync` systemd timer. Every run fetches the configured Git ref and refreshes the hosted compose stack, so DAG and runtime changes land on the host without a manual SSH pull.
@@ -92,7 +92,7 @@ The app exposes that status through Prometheus `/metrics`, and Grafana shows it 
 
 Terraform also creates a Firestore Datastore-mode database for Feast online serving. Using a named database keeps this setup separate from any default Firestore state in the project.
 
-The VM uses a dedicated service account with access to BigQuery jobs, BigQuery Storage API read sessions, BigQuery dataset edits, bucket objects for MLflow and Feast, and Datastore. This lets the Airflow, training, Feast, app, and MLflow containers use Application Default Credentials instead of key files.
+The VM uses a dedicated service account with access to Artifact Registry pulls, BigQuery jobs, BigQuery Storage API read sessions, BigQuery dataset edits, bucket objects for MLflow and Feast, and Datastore. This lets the Airflow, training, Feast, app, and MLflow containers use Application Default Credentials instead of key files.
 
 That broader VM identity is transitional by design. GitHub delivery uses the separate `github-actions-deployer` identity, and Cloud Run uses the separate `foehncast-cloud-run` runtime identity. The online compose host keeps the broader `foehncast-online-compose` identity only because the current VM still combines operator, training, and serving responsibilities on one machine.
 
@@ -150,10 +150,12 @@ Remote destroy intentionally stops at Terraform-managed resources tracked in the
 
 ## GitHub Delivery Inputs
 
-The repository uses two delivery workflows:
+The repository uses two image-publication workflows that share one hosted build contract:
 
-- `.github/workflows/publish-runtime-images.yml` publishes the runtime images to GHCR
-- `.github/workflows/publish-app-image.yml` supports the Artifact Registry plus Cloud Run path for the inference service
+- `.github/workflows/publish-app-image.yml` submits the app image build to Cloud Build and publishes the reviewed image to Artifact Registry for the Cloud Run path
+- `.github/workflows/publish-runtime-images.yml` submits the Airflow and MLflow image builds to Cloud Build and publishes the reviewed images to Artifact Registry for the retained operator host
+
+Artifact Registry is the canonical hosted image registry in this contract. GHCR convenience artifacts, if published separately, are not the default hosted deployment path.
 
 Set these GitHub repository variables:
 
@@ -191,6 +193,8 @@ The normal shared-environment path is:
 1. one-time maintainer bootstrap from Google Cloud Shell
 2. GitHub Actions remote apply
 3. best-effort repository-variable resync after each successful apply
+
+GitHub remains the review gate for hosted image publication, but Cloud Build now executes the reviewed hosted image builds on GCP.
 
 In normal operation you should not edit these variables by hand. The bootstrap path seeds the shared contract automatically. Remote applies also attempt to resync it, but GitHub's default workflow token may not be allowed to edit repository variables in every repository configuration.
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,13 +1,14 @@
 locals {
-  github_repository_path       = "${var.github_owner}/${var.github_repository}"
-  cloud_run_image              = var.cloud_run_image != "" ? var.cloud_run_image : "${var.region}-docker.pkg.dev/${var.project_id}/${var.artifact_registry_repository_id}/foehncast-app:latest"
-  ghcr_registry_owner          = lower(var.github_owner)
-  online_compose_app_image     = var.online_compose_app_image != "" ? var.online_compose_app_image : "ghcr.io/${local.ghcr_registry_owner}/foehncast-app:main"
-  online_compose_airflow_image = var.online_compose_airflow_image != "" ? var.online_compose_airflow_image : "ghcr.io/${local.ghcr_registry_owner}/foehncast-airflow:main"
-  online_compose_mlflow_image  = var.online_compose_mlflow_image != "" ? var.online_compose_mlflow_image : "ghcr.io/${local.ghcr_registry_owner}/foehncast-mlflow:main"
-  feast_registry_uri           = "gs://${var.artifact_bucket_name}/feast/registry.db"
-  feast_staging_uri            = "gs://${var.artifact_bucket_name}/feast/staging"
-  feast_bigquery_table         = "${var.project_id}.${var.bigquery_dataset_id}.${var.bigquery_feature_table_id}"
+  github_repository_path         = "${var.github_owner}/${var.github_repository}"
+  artifact_registry_host         = "${var.region}-docker.pkg.dev"
+  artifact_registry_repository_path = "${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
+  cloud_run_image                = var.cloud_run_image != "" ? var.cloud_run_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"
+  online_compose_app_image       = var.online_compose_app_image != "" ? var.online_compose_app_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"
+  online_compose_airflow_image   = var.online_compose_airflow_image != "" ? var.online_compose_airflow_image : "${local.artifact_registry_repository_path}/foehncast-airflow:latest"
+  online_compose_mlflow_image    = var.online_compose_mlflow_image != "" ? var.online_compose_mlflow_image : "${local.artifact_registry_repository_path}/foehncast-mlflow:latest"
+  feast_registry_uri             = "gs://${var.artifact_bucket_name}/feast/registry.db"
+  feast_staging_uri              = "gs://${var.artifact_bucket_name}/feast/staging"
+  feast_bigquery_table           = "${var.project_id}.${var.bigquery_dataset_id}.${var.bigquery_feature_table_id}"
   cloud_run_env_vars = merge(
     {
       GCP_PROJECT_ID                       = var.project_id
@@ -234,6 +235,7 @@ locals {
   required_services = toset([
     "artifactregistry.googleapis.com",
     "bigquery.googleapis.com",
+    "cloudbuild.googleapis.com",
     "compute.googleapis.com",
     "firestore.googleapis.com",
     "iam.googleapis.com",
@@ -241,6 +243,10 @@ locals {
     "run.googleapis.com",
     "sts.googleapis.com",
   ])
+}
+
+data "google_project" "current" {
+  project_id = var.project_id
 }
 
 resource "random_password" "airflow_api_auth_jwt_secret" {
@@ -332,6 +338,7 @@ resource "google_project_iam_member" "github_project_admin" {
   for_each = toset([
     "roles/artifactregistry.admin",
     "roles/bigquery.admin",
+    "roles/cloudbuild.builds.editor",
     "roles/compute.admin",
     "roles/datastore.owner",
     "roles/iam.serviceAccountAdmin",
@@ -380,6 +387,13 @@ resource "google_storage_bucket_iam_member" "github_bucket_admin" {
   bucket = google_storage_bucket.artifacts.name
   role   = "roles/storage.objectAdmin"
   member = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "cloud_build_writer" {
+  location   = google_artifact_registry_repository.containers.location
+  repository = google_artifact_registry_repository.containers.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${data.google_project.current.number}@cloudbuild.gserviceaccount.com"
 }
 
 resource "google_artifact_registry_repository_iam_member" "cloud_run_reader" {
@@ -447,6 +461,15 @@ resource "google_project_iam_member" "online_compose_datastore_user" {
   project = var.project_id
   role    = "roles/datastore.user"
   member  = "serviceAccount:${google_service_account.online_compose_runtime[0].email}"
+}
+
+resource "google_artifact_registry_repository_iam_member" "online_compose_reader" {
+  count = var.provision_online_compose_host ? 1 : 0
+
+  location   = google_artifact_registry_repository.containers.location
+  repository = google_artifact_registry_repository.containers.name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.online_compose_runtime[0].email}"
 }
 
 resource "google_storage_bucket_iam_member" "online_compose_bucket_admin" {
@@ -607,6 +630,7 @@ resource "google_compute_instance" "online_compose" {
   metadata_startup_script = templatefile("${path.module}/templates/online-compose-host.sh.tftpl", {
     github_repository_path = local.github_repository_path
     git_ref                = var.online_compose_git_ref
+    artifact_registry_host = local.artifact_registry_host
     stack_env              = local.online_compose_env_vars
   })
 
@@ -617,6 +641,7 @@ resource "google_compute_instance" "online_compose" {
     google_project_iam_member.online_compose_bigquery_job_user,
     google_project_iam_member.online_compose_bigquery_read_session_user,
     google_project_iam_member.online_compose_datastore_user,
+    google_artifact_registry_repository_iam_member.online_compose_reader,
     google_storage_bucket_iam_member.online_compose_bucket_admin,
     google_storage_bucket_iam_member.online_compose_bucket_metadata_reader,
     google_bigquery_dataset_iam_member.online_compose_bigquery_editor,

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,14 +1,14 @@
 locals {
-  github_repository_path         = "${var.github_owner}/${var.github_repository}"
-  artifact_registry_host         = "${var.region}-docker.pkg.dev"
+  github_repository_path            = "${var.github_owner}/${var.github_repository}"
+  artifact_registry_host            = "${var.region}-docker.pkg.dev"
   artifact_registry_repository_path = "${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"
-  cloud_run_image                = var.cloud_run_image != "" ? var.cloud_run_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"
-  online_compose_app_image       = var.online_compose_app_image != "" ? var.online_compose_app_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"
-  online_compose_airflow_image   = var.online_compose_airflow_image != "" ? var.online_compose_airflow_image : "${local.artifact_registry_repository_path}/foehncast-airflow:latest"
-  online_compose_mlflow_image    = var.online_compose_mlflow_image != "" ? var.online_compose_mlflow_image : "${local.artifact_registry_repository_path}/foehncast-mlflow:latest"
-  feast_registry_uri             = "gs://${var.artifact_bucket_name}/feast/registry.db"
-  feast_staging_uri              = "gs://${var.artifact_bucket_name}/feast/staging"
-  feast_bigquery_table           = "${var.project_id}.${var.bigquery_dataset_id}.${var.bigquery_feature_table_id}"
+  cloud_run_image                   = var.cloud_run_image != "" ? var.cloud_run_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"
+  online_compose_app_image          = var.online_compose_app_image != "" ? var.online_compose_app_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"
+  online_compose_airflow_image      = var.online_compose_airflow_image != "" ? var.online_compose_airflow_image : "${local.artifact_registry_repository_path}/foehncast-airflow:latest"
+  online_compose_mlflow_image       = var.online_compose_mlflow_image != "" ? var.online_compose_mlflow_image : "${local.artifact_registry_repository_path}/foehncast-mlflow:latest"
+  feast_registry_uri                = "gs://${var.artifact_bucket_name}/feast/registry.db"
+  feast_staging_uri                 = "gs://${var.artifact_bucket_name}/feast/staging"
+  feast_bigquery_table              = "${var.project_id}.${var.bigquery_dataset_id}.${var.bigquery_feature_table_id}"
   cloud_run_env_vars = merge(
     {
       GCP_PROJECT_ID                       = var.project_id

--- a/terraform/templates/online-compose-host.sh.tftpl
+++ b/terraform/templates/online-compose-host.sh.tftpl
@@ -28,8 +28,16 @@ echo \
   "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.gpg] https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" \
   > /etc/apt/sources.list.d/docker.list
 
+if [[ ! -f /etc/apt/keyrings/cloud.google.gpg ]]; then
+  curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | gpg --dearmor -o /etc/apt/keyrings/cloud.google.gpg
+  chmod a+r /etc/apt/keyrings/cloud.google.gpg
+fi
+
+echo "deb [signed-by=/etc/apt/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+  > /etc/apt/sources.list.d/google-cloud-sdk.list
+
 apt-get update
-apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin google-cloud-cli
 install -d -m 0755 /etc/docker
 cat > /etc/docker/daemon.json <<'EOF'
 {
@@ -210,6 +218,7 @@ verify_serving_surface() {
 
 git -C /opt/foehncast fetch --depth 1 origin "${git_ref}"
 git -C /opt/foehncast checkout --force FETCH_HEAD
+gcloud auth configure-docker "${artifact_registry_host}" --quiet >/dev/null 2>&1
 
 vacuum_host_logs
 docker compose "$${compose_args[@]}" pull model-registry app airflow-init airflow-webserver airflow-dag-processor airflow-scheduler airflow-triggerer

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -178,19 +178,19 @@ variable "online_compose_airflow_admin_username" {
 }
 
 variable "online_compose_app_image" {
-  description = "Optional app image URI for the online Docker host. Leave empty to use the default GHCR image."
+  description = "Optional app image URI for the online Docker host. Leave empty to use the default Artifact Registry image."
   type        = string
   default     = ""
 }
 
 variable "online_compose_airflow_image" {
-  description = "Optional Airflow image URI for the online Docker host. Leave empty to use the default GHCR image."
+  description = "Optional Airflow image URI for the online Docker host. Leave empty to use the default Artifact Registry image."
   type        = string
   default     = ""
 }
 
 variable "online_compose_mlflow_image" {
-  description = "Optional MLflow image URI for the online Docker host. Leave empty to use the default GHCR image."
+  description = "Optional MLflow image URI for the online Docker host. Leave empty to use the default Artifact Registry image."
   type        = string
   default     = ""
 }

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -1040,25 +1040,27 @@ def test_terraform_defines_cloud_build_and_artifact_registry_hosted_image_contra
 ):
     terraform = _read_text("terraform/main.tf")
     variables = _read_text("terraform/variables.tf")
+    terraform_single_spaced = re.sub(r"[ \t]+", " ", terraform)
 
     assert (
-        'artifact_registry_host         = "${var.region}-docker.pkg.dev"' in terraform
+        'artifact_registry_host = "${var.region}-docker.pkg.dev"'
+        in terraform_single_spaced
     )
     assert (
         'artifact_registry_repository_path = "${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"'
-        in terraform
+        in terraform_single_spaced
     )
     assert (
-        'online_compose_app_image       = var.online_compose_app_image != "" ? var.online_compose_app_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"'
-        in terraform
+        'online_compose_app_image = var.online_compose_app_image != "" ? var.online_compose_app_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"'
+        in terraform_single_spaced
     )
     assert (
-        'online_compose_airflow_image   = var.online_compose_airflow_image != "" ? var.online_compose_airflow_image : "${local.artifact_registry_repository_path}/foehncast-airflow:latest"'
-        in terraform
+        'online_compose_airflow_image = var.online_compose_airflow_image != "" ? var.online_compose_airflow_image : "${local.artifact_registry_repository_path}/foehncast-airflow:latest"'
+        in terraform_single_spaced
     )
     assert (
-        'online_compose_mlflow_image    = var.online_compose_mlflow_image != "" ? var.online_compose_mlflow_image : "${local.artifact_registry_repository_path}/foehncast-mlflow:latest"'
-        in terraform
+        'online_compose_mlflow_image = var.online_compose_mlflow_image != "" ? var.online_compose_mlflow_image : "${local.artifact_registry_repository_path}/foehncast-mlflow:latest"'
+        in terraform_single_spaced
     )
     assert '"cloudbuild.googleapis.com",' in terraform
     assert '"roles/cloudbuild.builds.editor",' in terraform

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -506,6 +506,10 @@ def test_publish_app_image_stops_at_image_publish_boundary() -> None:
 
     assert workflow["on"]["workflow_dispatch"] == {}
     assert (
+        config_job["outputs"]["project_id"]
+        == "${{ steps.repo_config.outputs.project_id }}"
+    )
+    assert (
         config_job["outputs"]["workload_identity_provider"]
         == "${{ steps.repo_config.outputs.workload_identity_provider }}"
     )
@@ -567,6 +571,39 @@ def test_publish_app_image_stops_at_image_publish_boundary() -> None:
         in skipped_step["run"]
     )
     assert "GCP_CLOUD_RUN_SERVICE" not in skipped_step["run"]
+
+
+def test_publish_app_image_uses_cloud_build_artifact_registry_contract() -> None:
+    workflow = _workflow_yaml(".github/workflows/publish-app-image.yml")
+    workflow_text = _read_text(".github/workflows/publish-app-image.yml")
+    push_paths = workflow["on"]["push"]["paths"]
+
+    assert workflow["permissions"] == {"contents": "read", "id-token": "write"}
+    assert ".github/actions/load-gcp-repo-config/action.yml" in push_paths
+    assert "cloudbuild/**" in push_paths
+
+    repo_config_step = _workflow_step(workflow, "config", "repo_config")
+    assert repo_config_step["uses"] == "./.github/actions/load-gcp-repo-config"
+
+    auth_step = _workflow_step(workflow, "publish", "Authenticate to Google Cloud")
+    assert auth_step["uses"] == "google-github-actions/auth@v2"
+
+    setup_step = _workflow_step(workflow, "publish", "Set up gcloud")
+    assert setup_step["uses"] == "google-github-actions/setup-gcloud@v2"
+    assert setup_step["with"]["project_id"] == "${{ needs.config.outputs.project_id }}"
+
+    submit_step = _workflow_step(workflow, "publish", "Submit Cloud Build")
+    assert "gcloud builds submit ." in submit_step["run"]
+    assert "--config cloudbuild/runtime-image.yaml" in submit_step["run"]
+    assert '"_BUILD_CONTEXT=${BUILD_CONTEXT}"' in submit_step["run"]
+    assert '"_DOCKERFILE=${DOCKERFILE}"' in submit_step["run"]
+    assert '"_IMAGE_REPOSITORY=${IMAGE_REPOSITORY}"' in submit_step["run"]
+    assert '"_FLOATING_TAG=${LATEST_TAG}"' in submit_step["run"]
+    assert "BUILD_CONTEXT: ." in workflow_text
+    assert "DOCKERFILE: containers/app/Dockerfile" in workflow_text
+    assert "docker/setup-buildx-action" not in workflow_text
+    assert "docker/build-push-action" not in workflow_text
+    assert "docker/metadata-action" not in workflow_text
 
 
 def test_trigger_runtime_release_workflow_uses_hosted_airflow_handoff_contract() -> (
@@ -854,11 +891,72 @@ def test_publish_runtime_images_excludes_local_only_development_env() -> None:
     image_targets = workflow["jobs"]["publish"]["strategy"]["matrix"]["include"]
 
     assert "containers/development_env/**" not in push_paths
+    assert "containers/app/**" not in push_paths
+    assert ".github/actions/load-gcp-repo-config/action.yml" in push_paths
+    assert "cloudbuild/**" in push_paths
     assert {target["image_name"] for target in image_targets} == {
-        "foehncast-app",
         "foehncast-airflow",
         "foehncast-mlflow",
     }
+
+
+def test_publish_runtime_images_uses_cloud_build_artifact_registry_contract() -> None:
+    workflow = _workflow_yaml(".github/workflows/publish-runtime-images.yml")
+    workflow_text = _read_text(".github/workflows/publish-runtime-images.yml")
+    config_job = workflow["jobs"]["config"]
+
+    assert workflow["permissions"] == {"contents": "read", "id-token": "write"}
+    assert (
+        config_job["outputs"]["project_id"]
+        == "${{ steps.repo_config.outputs.project_id }}"
+    )
+    assert (
+        config_job["outputs"]["image_repository_base"]
+        == "${{ steps.derived.outputs.image_repository_base }}"
+    )
+
+    repo_config_step = _workflow_step(workflow, "config", "repo_config")
+    assert repo_config_step["uses"] == "./.github/actions/load-gcp-repo-config"
+
+    auth_step = _workflow_step(workflow, "publish", "Authenticate to Google Cloud")
+    assert auth_step["uses"] == "google-github-actions/auth@v2"
+
+    setup_step = _workflow_step(workflow, "publish", "Set up gcloud")
+    assert setup_step["uses"] == "google-github-actions/setup-gcloud@v2"
+    assert setup_step["with"]["project_id"] == "${{ needs.config.outputs.project_id }}"
+
+    submit_step = _workflow_step(workflow, "publish", "Submit Cloud Build")
+    assert "gcloud builds submit ." in submit_step["run"]
+    assert "--config cloudbuild/runtime-image.yaml" in submit_step["run"]
+    assert '"_BUILD_CONTEXT=${BUILD_CONTEXT}"' in submit_step["run"]
+    assert '"_DOCKERFILE=${DOCKERFILE}"' in submit_step["run"]
+    assert '"_IMAGE_REPOSITORY=${IMAGE_REPOSITORY}"' in submit_step["run"]
+    assert '"_FLOATING_TAG=${LATEST_TAG}"' in submit_step["run"]
+    assert "ghcr.io" not in workflow_text
+    assert "docker/login-action" not in workflow_text
+    assert "docker/build-push-action" not in workflow_text
+    assert "docker/metadata-action" not in workflow_text
+
+
+def test_runtime_image_cloud_build_config_defines_shared_hosted_build_contract() -> (
+    None
+):
+    cloudbuild = _read_text("cloudbuild/runtime-image.yaml")
+
+    assert "gcr.io/cloud-builders/docker" in cloudbuild
+    assert (
+        'docker build -f "${_DOCKERFILE}" "${tags[@]}" "${_BUILD_CONTEXT}"'
+        in cloudbuild
+    )
+    assert 'docker push "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}"' in cloudbuild
+    assert 'if [[ -n "${_FLOATING_TAG}" ]]; then' in cloudbuild
+    assert 'docker push "${_FLOATING_TAG}"' in cloudbuild
+    assert "CLOUD_LOGGING_ONLY" in cloudbuild
+    assert (
+        "_IMAGE_REPOSITORY: europe-west6-docker.pkg.dev/example-project/foehncast-docker/foehncast-app"
+        in cloudbuild
+    )
+    assert '_FLOATING_TAG: ""' in cloudbuild
 
 
 def test_cloud_env_pairs_include_feast_runtime_contract() -> None:
@@ -935,6 +1033,54 @@ def test_terraform_grants_hosted_runtime_identities_bigquery_storage_and_bucket_
         "google_storage_bucket_iam_member.online_compose_bucket_metadata_reader,"
         in terraform
     )
+
+
+def test_terraform_defines_cloud_build_and_artifact_registry_hosted_image_contract() -> (
+    None
+):
+    terraform = _read_text("terraform/main.tf")
+    variables = _read_text("terraform/variables.tf")
+
+    assert (
+        'artifact_registry_host         = "${var.region}-docker.pkg.dev"' in terraform
+    )
+    assert (
+        'artifact_registry_repository_path = "${local.artifact_registry_host}/${var.project_id}/${var.artifact_registry_repository_id}"'
+        in terraform
+    )
+    assert (
+        'online_compose_app_image       = var.online_compose_app_image != "" ? var.online_compose_app_image : "${local.artifact_registry_repository_path}/foehncast-app:latest"'
+        in terraform
+    )
+    assert (
+        'online_compose_airflow_image   = var.online_compose_airflow_image != "" ? var.online_compose_airflow_image : "${local.artifact_registry_repository_path}/foehncast-airflow:latest"'
+        in terraform
+    )
+    assert (
+        'online_compose_mlflow_image    = var.online_compose_mlflow_image != "" ? var.online_compose_mlflow_image : "${local.artifact_registry_repository_path}/foehncast-mlflow:latest"'
+        in terraform
+    )
+    assert '"cloudbuild.googleapis.com",' in terraform
+    assert '"roles/cloudbuild.builds.editor",' in terraform
+    assert 'data "google_project" "current"' in terraform
+    assert (
+        'resource "google_artifact_registry_repository_iam_member" "cloud_build_writer"'
+        in terraform
+    )
+    assert (
+        "serviceAccount:${data.google_project.current.number}@cloudbuild.gserviceaccount.com"
+        in terraform
+    )
+    assert (
+        'resource "google_artifact_registry_repository_iam_member" "online_compose_reader"'
+        in terraform
+    )
+    assert (
+        "google_artifact_registry_repository_iam_member.online_compose_reader,"
+        in terraform
+    )
+    assert "default Artifact Registry image" in variables
+    assert "default GHCR image" not in variables
 
 
 def test_terraform_forecast_feature_schema_tracks_direction_encoding_columns() -> None:
@@ -1072,6 +1218,17 @@ def test_online_compose_startup_template_installs_periodic_repo_sync_timer() -> 
         in template
     )
     assert "--build" not in template
+
+
+def test_online_compose_startup_template_configures_artifact_registry_auth() -> None:
+    template = _read_text("terraform/templates/online-compose-host.sh.tftpl")
+
+    assert "packages.cloud.google.com/apt/doc/apt-key.gpg" in template
+    assert "google-cloud-cli" in template
+    assert (
+        'gcloud auth configure-docker "${artifact_registry_host}" --quiet >/dev/null 2>&1'
+        in template
+    )
 
 
 def test_online_compose_startup_template_configures_docker_log_rotation() -> None:


### PR DESCRIPTION
Closes #223.

## Summary

This change defines the hosted image publication contract around Cloud Build plus Artifact Registry without changing the runtime-release handoff or Composer orchestration boundary.

It keeps GitHub Actions as the reviewed trigger and OIDC gate, but moves hosted image builds onto Cloud Build and aligns the retained-host image defaults with Artifact Registry.

## What Changed

- added `cloudbuild/runtime-image.yaml` as the shared hosted image build contract
- updated `.github/workflows/publish-app-image.yml` to submit the app image build to Cloud Build
- updated `.github/workflows/publish-runtime-images.yml` to submit Airflow and MLflow image builds to Cloud Build
- updated `terraform/main.tf` so hosted runtime image defaults target Artifact Registry and so Cloud Build/API/IAM surfaces exist in the shared baseline
- updated `terraform/templates/online-compose-host.sh.tftpl` so the retained host installs `google-cloud-cli` and configures Docker auth for Artifact Registry pulls
- updated `terraform/variables.tf`, `terraform/README.md`, and `containers/README.md` to describe Artifact Registry and Cloud Build as the canonical hosted path
- extended `tests/test_cloud_operator_contract.py` to lock in the Cloud Build plus Artifact Registry contract

## Scope Boundaries

This PR intentionally does not:

- change runtime release handoff
- provision or cut over to Cloud Composer
- retire the retained operator host

## Validation

- `PATH=/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin:$PATH pytest tests/test_cloud_operator_contract.py`
- result: `61 passed`
- strict MkDocs build passed in the clean worktree using the original repo `.venv`
- workflow, Terraform, Markdown, and YAML diagnostics were clean after the final fix