### PR TITLE
docs(orchestration): define Composer readiness contract

### DIFF
--- a/.github/workflows/trigger-runtime-release.yml
+++ b/.github/workflows/trigger-runtime-release.yml
@@ -1,288 +1,291 @@
 name: Trigger Runtime Release
 
 on:
-    workflow_dispatch:
-        inputs:
-            action:
-                description: Runtime release action to hand off to hosted Airflow
-                required: true
-                default: deploy_candidate
-                type: choice
-                options:
-                    - deploy_candidate
-                    - promote_candidate
-                    - rollback_live
-            image_uri:
-                description: Immutable image URI for deploy_candidate requests
-                required: false
-                type: string
-            candidate_revision_tag:
-                description: Candidate Cloud Run revision tag for deploy or promote requests
-                required: false
-                default: candidate
-                type: string
-            candidate_alias:
-                description: Candidate MLflow alias expected for promote requests
-                required: false
-                default: candidate
-                type: string
-            target_alias:
-                description: Target MLflow alias expected after promote or rollback requests
-                required: false
-                default: champion
-                type: string
-            rollback_revision:
-                description: Exact Cloud Run revision to restore for rollback_live requests
-                required: false
-                type: string
-            rollback_model_version:
-                description: Exact MLflow model version to restore for rollback_live requests
-                required: false
-                type: string
-            rollback_revision_tag:
-                description: Temporary rollback revision tag for rollback_live requests
-                required: false
-                default: rollback
-                type: string
+  workflow_dispatch:
+    inputs:
+      action:
+        description: Runtime release action to hand off to hosted Airflow
+        required: true
+        default: deploy_candidate
+        type: choice
+        options:
+          - deploy_candidate
+          - promote_candidate
+          - rollback_live
+      image_uri:
+        description: Immutable image URI for deploy_candidate requests
+        required: false
+        type: string
+      candidate_revision_tag:
+        description: Candidate Cloud Run revision tag for deploy or promote requests
+        required: false
+        default: candidate
+        type: string
+      candidate_alias:
+        description: Candidate MLflow alias expected for promote requests
+        required: false
+        default: candidate
+        type: string
+      target_alias:
+        description: Target MLflow alias expected after promote or rollback requests
+        required: false
+        default: champion
+        type: string
+      rollback_revision:
+        description: Exact Cloud Run revision to restore for rollback_live requests
+        required: false
+        type: string
+      rollback_model_version:
+        description: Exact MLflow model version to restore for rollback_live requests
+        required: false
+        type: string
+      rollback_revision_tag:
+        description: Temporary rollback revision tag for rollback_live requests
+        required: false
+        default: rollback
+        type: string
 
 permissions:
-    contents: read
-    id-token: write
+  contents: read
+  id-token: write
 
 jobs:
-    config:
-        runs-on: ubuntu-latest
-        outputs:
-            owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
-            project_id: ${{ steps.repo_config.outputs.project_id }}
-            workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
-            service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
-            online_compose_host_name: ${{ steps.repo_config.outputs.online_compose_host_name }}
-            online_compose_host_zone: ${{ steps.repo_config.outputs.online_compose_host_zone }}
-            action: ${{ steps.derived.outputs.action }}
-            image_uri: ${{ steps.derived.outputs.image_uri }}
-            candidate_revision_tag: ${{ steps.derived.outputs.candidate_revision_tag }}
-            candidate_alias: ${{ steps.derived.outputs.candidate_alias }}
-            target_alias: ${{ steps.derived.outputs.target_alias }}
-            rollback_revision: ${{ steps.derived.outputs.rollback_revision }}
-            rollback_model_version: ${{ steps.derived.outputs.rollback_model_version }}
-            rollback_revision_tag: ${{ steps.derived.outputs.rollback_revision_tag }}
-            trigger_ready: ${{ steps.derived.outputs.trigger_ready }}
-        steps:
-            - uses: actions/checkout@v6.0.2
+  config:
+    runs-on: ubuntu-latest
+    outputs:
+      owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
+      project_id: ${{ steps.repo_config.outputs.project_id }}
+      workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
+      service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
+      online_compose_host_name: ${{ steps.repo_config.outputs.online_compose_host_name }}
+      online_compose_host_zone: ${{ steps.repo_config.outputs.online_compose_host_zone }}
+      action: ${{ steps.derived.outputs.action }}
+      image_uri: ${{ steps.derived.outputs.image_uri }}
+      candidate_revision_tag: ${{ steps.derived.outputs.candidate_revision_tag }}
+      candidate_alias: ${{ steps.derived.outputs.candidate_alias }}
+      target_alias: ${{ steps.derived.outputs.target_alias }}
+      rollback_revision: ${{ steps.derived.outputs.rollback_revision }}
+      rollback_model_version: ${{ steps.derived.outputs.rollback_model_version }}
+      rollback_revision_tag: ${{ steps.derived.outputs.rollback_revision_tag }}
+      trigger_ready: ${{ steps.derived.outputs.trigger_ready }}
+    steps:
+      - uses: actions/checkout@v6.0.2
 
-            - id: flags
-              env:
-                  ACTOR: ${{ github.actor }}
-                  TRIGGERING_ACTOR: ${{ github.triggering_actor }}
-                  REPOSITORY_OWNER: ${{ github.repository_owner }}
-              run: |
-                  set -euo pipefail
-
-                  owner_allowed=false
-                  if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
-                    owner_allowed=true
-                  fi
-
-                  echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
-
-            - id: repo_config
-              uses: ./.github/actions/load-gcp-repo-config
-              with:
-                  repo-vars-json: ${{ toJson(vars) }}
-
-            - id: derived
-              env:
-                  ACTION_INPUT: ${{ github.event.inputs.action }}
-                  IMAGE_URI_INPUT: ${{ github.event.inputs.image_uri }}
-                  CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
-                  CANDIDATE_ALIAS_INPUT: ${{ github.event.inputs.candidate_alias }}
-                  TARGET_ALIAS_INPUT: ${{ github.event.inputs.target_alias }}
-                  ROLLBACK_REVISION_INPUT: ${{ github.event.inputs.rollback_revision }}
-                  ROLLBACK_MODEL_VERSION_INPUT: ${{ github.event.inputs.rollback_model_version }}
-                  ROLLBACK_REVISION_TAG_INPUT: ${{ github.event.inputs.rollback_revision_tag }}
-                  PROJECT_ID: ${{ steps.repo_config.outputs.project_id }}
-                  PROVISION_ONLINE_COMPOSE_HOST: ${{ steps.repo_config.outputs.provision_online_compose_host }}
-                  ONLINE_COMPOSE_HOST_NAME: ${{ steps.repo_config.outputs.online_compose_host_name }}
-                  ONLINE_COMPOSE_HOST_ZONE: ${{ steps.repo_config.outputs.online_compose_host_zone }}
-                  WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
-                  SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
-              run: |
-                  set -euo pipefail
-
-                  action="$(printf '%s' "${ACTION_INPUT:-deploy_candidate}" | tr '[:upper:]' '[:lower:]')"
-                  case "$action" in
-                    deploy_candidate|promote_candidate|rollback_live)
-                      ;;
-                    *)
-                      echo "Unsupported action '$action'." >&2
-                      exit 1
-                      ;;
-                  esac
-
-                  image_uri="$(printf '%s' "${IMAGE_URI_INPUT:-}" | tr -d '\r')"
-
-                  candidate_revision_tag="$(printf '%s' "${CANDIDATE_REVISION_TAG_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
-                  candidate_revision_tag="${candidate_revision_tag#-}"
-                  candidate_revision_tag="${candidate_revision_tag%-}"
-                  if [[ -z "$candidate_revision_tag" ]]; then
-                    candidate_revision_tag='candidate'
-                  fi
-
-                  candidate_alias="$(printf '%s' "${CANDIDATE_ALIAS_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]')"
-                  if [[ -z "$candidate_alias" ]]; then
-                    candidate_alias='candidate'
-                  fi
-
-                  target_alias="$(printf '%s' "${TARGET_ALIAS_INPUT:-champion}" | tr '[:upper:]' '[:lower:]')"
-                  if [[ -z "$target_alias" ]]; then
-                    target_alias='champion'
-                  fi
-
-                  rollback_revision="$(printf '%s' "${ROLLBACK_REVISION_INPUT:-}" | tr -d '[:space:]')"
-                  rollback_model_version="$(printf '%s' "${ROLLBACK_MODEL_VERSION_INPUT:-}" | tr -d '[:space:]')"
-
-                  rollback_revision_tag="$(printf '%s' "${ROLLBACK_REVISION_TAG_INPUT:-rollback}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
-                  rollback_revision_tag="${rollback_revision_tag#-}"
-                  rollback_revision_tag="${rollback_revision_tag%-}"
-                  if [[ -z "$rollback_revision_tag" ]]; then
-                    rollback_revision_tag='rollback'
-                  fi
-
-                  trigger_ready=false
-                  if [[ "$PROVISION_ONLINE_COMPOSE_HOST" == 'true' \
-                    && -n "$PROJECT_ID" \
-                    && -n "$ONLINE_COMPOSE_HOST_NAME" \
-                    && -n "$ONLINE_COMPOSE_HOST_ZONE" \
-                    && -n "$WORKLOAD_IDENTITY_PROVIDER" \
-                    && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
-                    trigger_ready=true
-                  fi
-
-                  case "$action" in
-                    deploy_candidate)
-                      if [[ -z "$image_uri" ]]; then
-                        trigger_ready=false
-                      fi
-                      ;;
-                    rollback_live)
-                      if [[ -z "$rollback_revision" || -z "$rollback_model_version" ]]; then
-                        trigger_ready=false
-                      fi
-                      ;;
-                  esac
-
-                  {
-                    echo "action=$action"
-                    echo "image_uri=$image_uri"
-                    echo "candidate_revision_tag=$candidate_revision_tag"
-                    echo "candidate_alias=$candidate_alias"
-                    echo "target_alias=$target_alias"
-                    echo "rollback_revision=$rollback_revision"
-                    echo "rollback_model_version=$rollback_model_version"
-                    echo "rollback_revision_tag=$rollback_revision_tag"
-                    echo "trigger_ready=$trigger_ready"
-                  } >> "$GITHUB_OUTPUT"
-
-    trigger:
-        needs: config
-        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready == 'true' }}
-        runs-on: ubuntu-latest
+      - id: flags
         env:
-            PROJECT_ID: ${{ needs.config.outputs.project_id }}
-            HOST_NAME: ${{ needs.config.outputs.online_compose_host_name }}
-            HOST_ZONE: ${{ needs.config.outputs.online_compose_host_zone }}
-            ACTION: ${{ needs.config.outputs.action }}
-            IMAGE_URI: ${{ needs.config.outputs.image_uri }}
-            CANDIDATE_REVISION_TAG: ${{ needs.config.outputs.candidate_revision_tag }}
-            CANDIDATE_ALIAS: ${{ needs.config.outputs.candidate_alias }}
-            TARGET_ALIAS: ${{ needs.config.outputs.target_alias }}
-            ROLLBACK_REVISION: ${{ needs.config.outputs.rollback_revision }}
-            ROLLBACK_MODEL_VERSION: ${{ needs.config.outputs.rollback_model_version }}
-            ROLLBACK_REVISION_TAG: ${{ needs.config.outputs.rollback_revision_tag }}
-        steps:
-            - uses: actions/checkout@v6.0.2
+          ACTOR: ${{ github.actor }}
+          TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+          REPOSITORY_OWNER: ${{ github.repository_owner }}
+        run: |
+          set -euo pipefail
 
-            - uses: google-github-actions/auth@v2
-              with:
-                  workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
-                  service_account: ${{ needs.config.outputs.service_account_email }}
+          owner_allowed=false
+          if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
+            owner_allowed=true
+          fi
 
-            - uses: google-github-actions/setup-gcloud@v2
+          echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
 
-            - name: Build runtime release request
-              run: |
-                  set -euo pipefail
-                  python -c 'from datetime import UTC, datetime; import json, os, pathlib; run_url = "/".join([os.environ["GITHUB_SERVER_URL"], os.environ["GITHUB_REPOSITORY"], "actions", "runs", os.environ["GITHUB_RUN_ID"]]); payload = {"action": os.environ["ACTION"], "request_source": "github-actions", "requested_at": datetime.now(tz=UTC).isoformat(), "github_repository": os.environ["GITHUB_REPOSITORY"], "github_workflow": os.environ["GITHUB_WORKFLOW"], "github_run_id": os.environ["GITHUB_RUN_ID"], "github_run_url": run_url, "github_sha": os.environ["GITHUB_SHA"], "image_uri": os.environ.get("IMAGE_URI", ""), "candidate_revision_tag": os.environ.get("CANDIDATE_REVISION_TAG", "candidate"), "candidate_alias": os.environ.get("CANDIDATE_ALIAS", "candidate"), "target_alias": os.environ.get("TARGET_ALIAS", "champion"), "rollback_revision": os.environ.get("ROLLBACK_REVISION", ""), "rollback_model_version": os.environ.get("ROLLBACK_MODEL_VERSION", ""), "rollback_revision_tag": os.environ.get("ROLLBACK_REVISION_TAG", "rollback")}; pathlib.Path("runtime-release-request.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")'
+      - id: repo_config
+        uses: ./.github/actions/load-gcp-repo-config
+        with:
+          repo-vars-json: ${{ toJson(vars) }}
 
-            - name: Refresh operator host checkout
-              run: |
-                  set -euo pipefail
-                  gcloud compute ssh "$HOST_NAME" \
-                    --project "$PROJECT_ID" \
-                    --zone "$HOST_ZONE" \
-                    --command "sudo systemctl start --wait foehncast-online-compose-sync.service"
+      - id: derived
+        env:
+          ACTION_INPUT: ${{ github.event.inputs.action }}
+          IMAGE_URI_INPUT: ${{ github.event.inputs.image_uri }}
+          CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
+          CANDIDATE_ALIAS_INPUT: ${{ github.event.inputs.candidate_alias }}
+          TARGET_ALIAS_INPUT: ${{ github.event.inputs.target_alias }}
+          ROLLBACK_REVISION_INPUT: ${{ github.event.inputs.rollback_revision }}
+          ROLLBACK_MODEL_VERSION_INPUT: ${{ github.event.inputs.rollback_model_version }}
+          ROLLBACK_REVISION_TAG_INPUT: ${{ github.event.inputs.rollback_revision_tag }}
+          PROJECT_ID: ${{ steps.repo_config.outputs.project_id }}
+          PROVISION_ONLINE_COMPOSE_HOST: ${{ steps.repo_config.outputs.provision_online_compose_host }}
+          ONLINE_COMPOSE_HOST_NAME: ${{ steps.repo_config.outputs.online_compose_host_name }}
+          ONLINE_COMPOSE_HOST_ZONE: ${{ steps.repo_config.outputs.online_compose_host_zone }}
+          WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
+          SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
+        run: |
+          set -euo pipefail
 
-            - name: Copy runtime release request
-              run: |
-                  set -euo pipefail
-                  gcloud compute scp \
-                    --project "$PROJECT_ID" \
-                    --zone "$HOST_ZONE" \
-                    runtime-release-request.json \
-                    "$HOST_NAME:/tmp/runtime-release-request.json"
+          action="$(printf '%s' "${ACTION_INPUT:-deploy_candidate}" | tr '[:upper:]' '[:lower:]')"
+          case "$action" in
+            deploy_candidate|promote_candidate|rollback_live)
+              ;;
+            *)
+              echo "Unsupported action '$action'." >&2
+              exit 1
+              ;;
+          esac
 
-            - id: handoff
-              name: Trigger runtime release handoff
-              run: |
-                  set -euo pipefail
+          image_uri="$(printf '%s' "${IMAGE_URI_INPUT:-}" | tr -d '\r')"
 
-                  report="$(gcloud compute ssh "$HOST_NAME" \
-                    --project "$PROJECT_ID" \
-                    --zone "$HOST_ZONE" \
-                    --command "cd /opt/foehncast && ./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json")"
+          candidate_revision_tag="$(printf '%s' "${CANDIDATE_REVISION_TAG_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+          candidate_revision_tag="${candidate_revision_tag#-}"
+          candidate_revision_tag="${candidate_revision_tag%-}"
+          if [[ -z "$candidate_revision_tag" ]]; then
+            candidate_revision_tag='candidate'
+          fi
 
-                  printf '%s\n' "$report"
+          candidate_alias="$(printf '%s' "${CANDIDATE_ALIAS_INPUT:-candidate}" | tr '[:upper:]' '[:lower:]')"
+          if [[ -z "$candidate_alias" ]]; then
+            candidate_alias='candidate'
+          fi
 
-                  dag_run_id="$(printf '%s\n' "$report" | python -c 'import json, sys; print(json.load(sys.stdin)["dag_run_id"])')"
-                  report_path="$(printf '%s\n' "$report" | python -c 'import json, sys; print(json.load(sys.stdin)["report_path"])')"
+          target_alias="$(printf '%s' "${TARGET_ALIAS_INPUT:-champion}" | tr '[:upper:]' '[:lower:]')"
+          if [[ -z "$target_alias" ]]; then
+            target_alias='champion'
+          fi
 
-                  {
-                    echo "dag_run_id=$dag_run_id"
-                    echo "report_path=$report_path"
-                  } >> "$GITHUB_OUTPUT"
+          rollback_revision="$(printf '%s' "${ROLLBACK_REVISION_INPUT:-}" | tr -d '[:space:]')"
+          rollback_model_version="$(printf '%s' "${ROLLBACK_MODEL_VERSION_INPUT:-}" | tr -d '[:space:]')"
 
-                  {
-                    echo "## Runtime release handoff"
-                    echo
-                    echo "- Action: $ACTION"
-                    echo "- Operator host: $HOST_NAME"
-                    echo "- Airflow DAG: runtime_release"
-                    echo "- DAG run: $dag_run_id"
-                    echo "- Summary path: $report_path"
-                    echo
-                    echo '```json'
-                    printf '%s\n' "$report"
-                    echo '```'
-                  } >> "$GITHUB_STEP_SUMMARY"
+          rollback_revision_tag="$(printf '%s' "${ROLLBACK_REVISION_TAG_INPUT:-rollback}" | tr '[:upper:]' '[:lower:]' | tr -cs 'a-z0-9-' '-')"
+          rollback_revision_tag="${rollback_revision_tag#-}"
+          rollback_revision_tag="${rollback_revision_tag%-}"
+          if [[ -z "$rollback_revision_tag" ]]; then
+            rollback_revision_tag='rollback'
+          fi
 
-    skipped:
-        needs: config
-        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready != 'true' }}
-        runs-on: ubuntu-latest
-        steps:
-            - name: Explain skipped runtime release handoff
-              run: |
-                  {
-                    echo "## Runtime release handoff skipped"
-                    echo
-                    echo "The explicit runtime trigger contract needs all of these inputs before it can run:"
-                    echo "- GCP_PROJECT_ID"
-                    echo "- GCP_WORKLOAD_IDENTITY_PROVIDER"
-                    echo "- GCP_SERVICE_ACCOUNT_EMAIL"
-                    echo "- GCP_PROVISION_ONLINE_COMPOSE_HOST=true"
-                    echo "- GCP_ONLINE_COMPOSE_HOST_NAME"
-                    echo "- GCP_ONLINE_COMPOSE_HOST_ZONE"
-                    echo
-                    echo "Action-specific coordinates must also be present for the chosen request."
-                  } >> "$GITHUB_STEP_SUMMARY"
+          trigger_ready=false
+          if [[ "$PROVISION_ONLINE_COMPOSE_HOST" == 'true' \
+            && -n "$PROJECT_ID" \
+            && -n "$ONLINE_COMPOSE_HOST_NAME" \
+            && -n "$ONLINE_COMPOSE_HOST_ZONE" \
+            && -n "$WORKLOAD_IDENTITY_PROVIDER" \
+            && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
+            trigger_ready=true
+          fi
+
+          case "$action" in
+            deploy_candidate)
+              if [[ -z "$image_uri" ]]; then
+                trigger_ready=false
+              fi
+              ;;
+            rollback_live)
+              if [[ -z "$rollback_revision" || -z "$rollback_model_version" ]]; then
+                trigger_ready=false
+              fi
+              ;;
+          esac
+
+          {
+            echo "action=$action"
+            echo "image_uri=$image_uri"
+            echo "candidate_revision_tag=$candidate_revision_tag"
+            echo "candidate_alias=$candidate_alias"
+            echo "target_alias=$target_alias"
+            echo "rollback_revision=$rollback_revision"
+            echo "rollback_model_version=$rollback_model_version"
+            echo "rollback_revision_tag=$rollback_revision_tag"
+            echo "trigger_ready=$trigger_ready"
+          } >> "$GITHUB_OUTPUT"
+
+  trigger:
+    needs: config
+    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready == 'true' }}
+    runs-on: ubuntu-latest
+    env:
+      PROJECT_ID: ${{ needs.config.outputs.project_id }}
+      HOST_NAME: ${{ needs.config.outputs.online_compose_host_name }}
+      HOST_ZONE: ${{ needs.config.outputs.online_compose_host_zone }}
+      ACTION: ${{ needs.config.outputs.action }}
+      IMAGE_URI: ${{ needs.config.outputs.image_uri }}
+      CANDIDATE_REVISION_TAG: ${{ needs.config.outputs.candidate_revision_tag }}
+      CANDIDATE_ALIAS: ${{ needs.config.outputs.candidate_alias }}
+      TARGET_ALIAS: ${{ needs.config.outputs.target_alias }}
+      ROLLBACK_REVISION: ${{ needs.config.outputs.rollback_revision }}
+      ROLLBACK_MODEL_VERSION: ${{ needs.config.outputs.rollback_model_version }}
+      ROLLBACK_REVISION_TAG: ${{ needs.config.outputs.rollback_revision_tag }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
+          service_account: ${{ needs.config.outputs.service_account_email }}
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build runtime release request
+        run: |
+          set -euo pipefail
+          python -c 'from datetime import UTC, datetime; import json, os, pathlib; run_url = "/".join([os.environ["GITHUB_SERVER_URL"], os.environ["GITHUB_REPOSITORY"], "actions", "runs", os.environ["GITHUB_RUN_ID"]]); payload = {"action": os.environ["ACTION"], "request_source": "github-actions", "requested_at": datetime.now(tz=UTC).isoformat(), "github_repository": os.environ["GITHUB_REPOSITORY"], "github_workflow": os.environ["GITHUB_WORKFLOW"], "github_run_id": os.environ["GITHUB_RUN_ID"], "github_run_url": run_url, "github_sha": os.environ["GITHUB_SHA"], "image_uri": os.environ.get("IMAGE_URI", ""), "candidate_revision_tag": os.environ.get("CANDIDATE_REVISION_TAG", "candidate"), "candidate_alias": os.environ.get("CANDIDATE_ALIAS", "candidate"), "target_alias": os.environ.get("TARGET_ALIAS", "champion"), "rollback_revision": os.environ.get("ROLLBACK_REVISION", ""), "rollback_model_version": os.environ.get("ROLLBACK_MODEL_VERSION", ""), "rollback_revision_tag": os.environ.get("ROLLBACK_REVISION_TAG", "rollback")}; pathlib.Path("runtime-release-request.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")'
+
+      - name: Refresh operator host checkout
+        run: |
+          set -euo pipefail
+          gcloud compute ssh "$HOST_NAME" \
+            --project "$PROJECT_ID" \
+            --zone "$HOST_ZONE" \
+            --command "sudo systemctl start --wait foehncast-online-compose-sync.service"
+
+      - name: Copy runtime release request
+        run: |
+          set -euo pipefail
+          gcloud compute scp \
+            --project "$PROJECT_ID" \
+            --zone "$HOST_ZONE" \
+            runtime-release-request.json \
+            "$HOST_NAME:/tmp/runtime-release-request.json"
+
+      - id: handoff
+        name: Trigger runtime release handoff
+        run: |
+          set -euo pipefail
+
+          report="$(gcloud compute ssh "$HOST_NAME" \
+            --project "$PROJECT_ID" \
+            --zone "$HOST_ZONE" \
+            --command "cd /opt/foehncast && ./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json")"
+
+          printf '%s\n' "$report"
+
+          dag_run_id="$(printf '%s\n' "$report" | python -c 'import json, sys; print(json.load(sys.stdin)["dag_run_id"])')"
+          report_path="$(printf '%s\n' "$report" | python -c 'import json, sys; print(json.load(sys.stdin)["report_path"])')"
+
+          {
+            echo "dag_run_id=$dag_run_id"
+            echo "report_path=$report_path"
+          } >> "$GITHUB_OUTPUT"
+
+          {
+            echo "## Runtime release handoff"
+            echo
+            echo "- Action: $ACTION"
+            echo "- Operator host: $HOST_NAME"
+            echo "- Airflow DAG: runtime_release"
+            echo "- Current receiver: retained-host Airflow adapter"
+            echo "- Target receiver: Cloud Composer without VM SSH"
+            echo "- DAG run: $dag_run_id"
+            echo "- Summary path: $report_path"
+            echo
+            echo '```json'
+            printf '%s\n' "$report"
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  skipped:
+    needs: config
+    if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready != 'true' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Explain skipped runtime release handoff
+        run: |
+          {
+            echo "## Runtime release handoff skipped"
+            echo
+            echo "The explicit runtime trigger contract needs all of these inputs before it can run:"
+            echo "This is the current retained-host entry contract. The target managed receiver is Cloud Composer without VM SSH."
+            echo "- GCP_PROJECT_ID"
+            echo "- GCP_WORKLOAD_IDENTITY_PROVIDER"
+            echo "- GCP_SERVICE_ACCOUNT_EMAIL"
+            echo "- GCP_PROVISION_ONLINE_COMPOSE_HOST=true"
+            echo "- GCP_ONLINE_COMPOSE_HOST_NAME"
+            echo "- GCP_ONLINE_COMPOSE_HOST_ZONE"
+            echo
+            echo "Action-specific coordinates must also be present for the chosen request."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -1,12 +1,13 @@
 # Cloud Mapping
 
-FoehnCast keeps one public hosted lane and one private operator lane. Cloud Run carries the shared API, while the hosted full-stack target stays online on one Compute Engine host for Airflow, MLflow, and monitoring. This page maps the validated local stack onto those GCP lanes without changing the core Feature-Training-Inference boundaries.
+FoehnCast keeps one public hosted lane and one private operator lane. Cloud Run carries the shared API, while the hosted full-stack target stays online on one Compute Engine host for Airflow, MLflow, and monitoring. That retained host is current, not the intended long-term orchestration authority. This page maps the validated local stack onto those GCP lanes without changing the core Feature-Training-Inference boundaries.
 
 !!! note "What this page covers"
 
     The shared GCP baseline and both hosted lanes already exist.
     Cloud Run is the shared public API lane.
     The hosted full-stack target stays online as the private operator lane.
+    Cloud Composer is the target managed orchestration direction.
 
 ## Cloud Paths In One View
 
@@ -37,6 +38,7 @@ FoehnCast keeps one public hosted lane and one private operator lane. Cloud Run 
 |------|-----------------|------------------|----------|
 | Shared API lane | hosted inference target on Cloud Run | public | serve the FastAPI product and service routes |
 | Operator lane | hosted full-stack target on Compute Engine | private by default | run Airflow, MLflow, monitoring, and private app checks |
+| Managed orchestration direction | Cloud Composer | private or platform-only | run hosted Airflow workloads without VM-owned orchestration |
 | Delivery lane | GitHub Actions plus Terraform plus OIDC | not a runtime surface | publish reviewed artifacts and apply reviewed infrastructure changes |
 
 ## Mapping Principle
@@ -89,7 +91,19 @@ The hosted targets deploy runtime services only. Development assets stay local o
 
 Today the shared environment keeps a stable split: Cloud Run carries the shared public API URL, one Compute Engine host stays online as the private operator lane for Airflow, MLflow, monitoring, and private app checks, and GitHub Actions plus remote Terraform advance reviewed day-2 changes after maintainer bootstrap.
 
-Hosted Airflow on the retained operator host remains the runtime orchestration surface for this horizon. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed delivery and recovery runbooks and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
+Today the retained operator host still owns hosted orchestration. The target managed orchestration direction is Cloud Composer once DAG packaging, Python dependency delivery, secret and runtime-config injection, network and API reachability, and runtime release entry no longer depend on the retained host. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed current-versus-target boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
+
+## Managed Orchestration Direction
+
+Cloud Composer is the target managed orchestration direction.
+
+Before a later cutover, the repo needs:
+
+- a DAG packaging path that does not depend on a VM checkout
+- a Python dependency bundle for hosted Airflow
+- secret and runtime-config delivery for the managed orchestrator
+- network and API reachability that does not depend on VM SSH
+- a reviewed runtime release entry that reaches the managed Airflow surface directly
 
 ## Honest Mapping From Local To Cloud
 

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -89,7 +89,7 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 | `scripts/configure-github-actions.sh` | repo-variable sync | Terraform outputs are copied into GitHub repository variables so the remote workflow reads one shared contract |
 | `terraform/terraform.tfvars` | bootstrap input | used during the interactive bootstrap path, not as the day-2 source of truth for remote applies |
 | runtime image workflows | reviewed artifact publishing | publish automation builds and publishes runtime images, but it does not deploy Cloud Run, shift traffic, or mutate MLflow aliases directly |
-| `.github/workflows/trigger-runtime-release.yml` | reviewed runtime handoff | GitHub sends one explicit runtime release request into hosted Airflow after the retained operator host refreshes to the reviewed git ref |
+| `.github/workflows/trigger-runtime-release.yml` | reviewed runtime handoff | today GitHub sends one explicit runtime release request into hosted Airflow after the retained operator host refreshes to the reviewed git ref; this handoff is transitional until Composer owns it |
 | `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up | run this after a remote apply succeeds and curated BigQuery rows exist |
 
 The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as container port, CPU, and memory stay repo-variable-backed instead of becoming manual workflow inputs.
@@ -108,17 +108,18 @@ The shared environment still depends on the retained operator host in a few spec
 | sync evidence and operator checks | the retained host still writes `.state/online-compose-sync/last-success.json`, and hosted verification still checks that sync evidence through `/metrics` | keep for now | later host-shrink issue |
 | cloud-operator regression tests | `tests/test_cloud_operator_contract.py` and the online-compose sync tests still enforce the retained-host contract directly | keep while migrating | same issue as the production surface being changed |
 
-## Hosted Orchestration Surface Decision
+## Hosted Orchestration Boundary
 
-Hosted Airflow on the retained operator host remains the orchestration surface of record for this horizon.
+The current hosted orchestration path and the target managed direction are different on purpose.
 
-| Option | Fit against current constraints | Decision |
-|------|----------------------------------|----------|
-| Current hosted Airflow control plane | Matches the validated local Airflow DAG and asset model, already exists on the retained operator host, and supports runtime scheduling, retries, backfills, and operator inspection without another platform migration | chosen now |
-| Composer / Managed Airflow | Stronger managed-service story, but adds cost, IAM surface area, and migration churn before the GitHub-versus-runtime boundary cleanup is complete | deferred |
-| Lighter managed trigger model | Could reduce infrastructure, but the current feature and training paths already depend on Airflow-owned scheduling, asset hand-offs, retries, and backfills | not chosen for this horizon |
+| Concern | Current operational path | Target managed direction |
+|------|---------------------------|--------------------------|
+| Hosted Airflow surface | retained operator host | Cloud Composer |
+| Reviewed runtime release entry | GitHub OIDC plus SSH to the retained host, then local `runtime_release` DAG trigger | reviewed request should reach Composer without VM SSH |
+| Scheduling, retries, and backfills | retained-host Airflow | Composer |
+| Operator host role | Airflow, MLflow, monitoring, and private app checks on one VM | shrink after Composer absorbs orchestration; keep only the services that still need a VM |
 
-So the boundary stays simple: GitHub Actions handles review, build, publish, and Terraform-driven delivery; hosted Airflow handles DAG execution, scheduling, retries, and backfills; Cloud Run serves the public API. Managed alternatives can be revisited later only if the operator lane gets smaller first.
+Today the retained host path remains the operational recovery surface. It is not the intended long-term hosted orchestration authority.
 
 ## GitHub Versus GCP Boundary
 
@@ -130,7 +131,7 @@ The reviewed delivery plane and the runtime execution plane still have different
 | Runtime execution | GCP-hosted runtime surfaces | Cloud Run serving, hosted Airflow scheduling, retries, backfills, runtime environment injection, and operator telemetry | source control, CI review, and infrastructure policy review |
 | Shared handoff | repository variables, published images, Terraform outputs, and runtime release requests | reviewed contract from GitHub into GCP runtime surfaces | ad hoc operator-only divergence from the declared contract |
 
-GitHub Actions may trigger reviewed delivery workflows, but hosted Airflow on the retained operator host remains the runtime orchestrator.
+GitHub Actions may trigger reviewed delivery workflows, but runtime scheduling does not belong to GitHub. Today that runtime orchestration still lives on the retained operator host. The target managed surface is Cloud Composer.
 
 ## Runtime Release Trigger Contract
 
@@ -159,11 +160,25 @@ Supported actions:
 - `promote_candidate`
 - `rollback_live`
 
-This keeps the handoff explicit while deeper runtime automation still lives behind the Airflow side of the boundary.
+This keeps the handoff explicit while deeper runtime automation still lives behind the Airflow side of the boundary. It is the current operational contract, not the intended long-term hosted entry path. The target managed direction is the same reviewed request reaching Composer without a retained-host refresh step.
+
+## Composer Readiness Requirements
+
+Cloud Composer is still a target, not a provisioned surface in this repo. Before it can become the hosted orchestration authority, the repo needs an explicit contract for:
+
+| Requirement | Current repo shape | What later Composer work must replace or define |
+|------|--------------------|-----------------------------------------------|
+| DAG packaging | DAGs currently arrive through the retained host checkout and compose-mounted repo path | a reviewed DAG delivery path that does not depend on a VM checkout |
+| Python dependencies | Airflow dependencies currently live in the retained-host container image path | a hosted Airflow dependency bundle compatible with Composer |
+| Secrets and runtime config | the retained host reads runtime configuration from the VM-local environment and service identity | a managed secret and runtime-config path for hosted orchestration |
+| Network and API reachability | the current trigger contract reaches Airflow through VM SSH and host-local API access | a reviewed runtime-release entry path that reaches Composer without VM SSH |
+| Operator access model | retries, backfills, and recovery currently assume SSH to the retained host | a clear managed operator access model for Composer-owned orchestration |
 
 ## Retry And Backfill Runbooks
 
 The recovery lane is now explicit too. Operators should retry work on the same plane that owns it instead of jumping between GitHub and runtime surfaces.
+
+These are the current runbooks while hosted orchestration still lives on the retained host.
 
 | Situation | Where to act | Normal procedure | Minimum evidence |
 |------|---------------|------------------|------------------|

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -123,6 +123,21 @@ The retained host is still part of the shared environment, but several VM-specif
 | startup template and sync timer | the VM still refreshes the repo, pulls the stack, and records retained-host sync evidence for operators | current but transitional | later host-shrink issue |
 | public-port outputs and verification rules | the current hosted contract still needs to prove that Cloud Run is the only public API surface while the VM stays private | keep for now | keep until the VM role changes |
 
+## Composer Readiness Boundary
+
+Terraform does not provision Cloud Composer today. The current online compose host remains the operational orchestration surface.
+
+Before a later Composer cutover, this repo needs explicit contract surfaces for:
+
+- DAG packaging outside a VM checkout
+- a Python dependency bundle for hosted Airflow
+- secrets and runtime-config delivery for managed orchestration
+- network and API reachability for managed Airflow
+- reviewed runtime release entry without VM SSH
+- operator access rules for retries, backfills, and recovery
+
+These are readiness requirements, not resources this directory manages yet.
+
 ## What The Hosted Paths Expose
 
 | Path | Public surface by default | Notes |

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -359,6 +359,7 @@ def test_remote_terraform_workflow_apply_summary_reports_hosted_feast_follow_up(
     summary_script = summary_step["run"]
 
     assert "always()" in summary_step["if"]
+    assert (
         'echo "- Primary hosted API target: $(render_output primary_hosted_api_target not-provisioned)"'
         in summary_script
     )

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -359,7 +359,6 @@ def test_remote_terraform_workflow_apply_summary_reports_hosted_feast_follow_up(
     summary_script = summary_step["run"]
 
     assert "always()" in summary_step["if"]
-    assert (
         'echo "- Primary hosted API target: $(render_output primary_hosted_api_target not-provisioned)"'
         in summary_script
     )
@@ -606,7 +605,7 @@ def test_publish_app_image_uses_cloud_build_artifact_registry_contract() -> None
     assert "docker/metadata-action" not in workflow_text
 
 
-def test_trigger_runtime_release_workflow_uses_hosted_airflow_handoff_contract() -> (
+def test_trigger_runtime_release_workflow_uses_current_retained_host_handoff_contract() -> (
     None
 ):
     workflow = _workflow_yaml(".github/workflows/trigger-runtime-release.yml")
@@ -692,7 +691,61 @@ def test_trigger_runtime_release_workflow_uses_hosted_airflow_handoff_contract()
         in handoff_step["run"]
     )
     assert 'echo "- Airflow DAG: runtime_release"' in handoff_step["run"]
+    assert (
+        'echo "- Current receiver: retained-host Airflow adapter"'
+        in handoff_step["run"]
+    )
+    assert (
+        'echo "- Target receiver: Cloud Composer without VM SSH"' in handoff_step["run"]
+    )
     assert 'echo "## Runtime release handoff"' in handoff_step["run"]
+
+    skipped_step = _workflow_step(
+        workflow, "skipped", "Explain skipped runtime release handoff"
+    )
+    assert "This is the current retained-host entry contract." in skipped_step["run"]
+    assert "Cloud Composer without VM SSH" in skipped_step["run"]
+
+
+def test_orchestration_docs_describe_current_host_path_and_target_composer_readiness() -> (
+    None
+):
+    workflow_doc = _read_text("docs/site/system/delivery-and-operator-workflow.md")
+    cloud_mapping = _read_text("docs/site/system/cloud-mapping.md")
+    terraform_readme = _read_text("terraform/README.md")
+
+    assert (
+        "The current hosted orchestration path and the target managed direction are different on purpose."
+        in workflow_doc
+    )
+    assert (
+        "| Hosted Airflow surface | retained operator host | Cloud Composer |"
+        in workflow_doc
+    )
+    assert "reviewed request should reach Composer without VM SSH" in workflow_doc
+    assert (
+        "a reviewed DAG delivery path that does not depend on a VM checkout"
+        in workflow_doc
+    )
+    assert (
+        "a managed secret and runtime-config path for hosted orchestration"
+        in workflow_doc
+    )
+    assert (
+        "The target managed direction is the same reviewed request reaching Composer without a retained-host refresh step."
+        in workflow_doc
+    )
+
+    assert (
+        "Cloud Composer is the target managed orchestration direction." in cloud_mapping
+    )
+    assert (
+        "a reviewed runtime release entry that reaches the managed Airflow surface directly"
+        in cloud_mapping
+    )
+
+    assert "Terraform does not provision Cloud Composer today." in terraform_readme
+    assert "reviewed runtime release entry without VM SSH" in terraform_readme
 
 
 def test_promote_candidate_workflow_redirects_to_runtime_trigger_contract() -> None:


### PR DESCRIPTION
Closes #224.

## Summary

This change defines the current-versus-target orchestration boundary for a later Cloud Composer cutover.

It keeps the retained-host Airflow path as the current operational contract, but it stops presenting that path as the intended long-term orchestration authority. Instead, the repo now documents Cloud Composer as the target managed direction and names the explicit readiness prerequisites before a cutover can happen.

## What Changed

- updated `docs/site/system/delivery-and-operator-workflow.md` to distinguish the current retained-host orchestration path from the target Cloud Composer direction
- updated `docs/site/system/cloud-mapping.md` to name Cloud Composer as the managed orchestration target and list the repo prerequisites before a cutover
- updated `terraform/README.md` to state that Composer is not provisioned yet and to define the readiness boundary for a later infrastructure issue
- updated `.github/workflows/trigger-runtime-release.yml` summary text so the reviewed runtime trigger names the current retained-host receiver and the target managed receiver explicitly
- updated `tests/test_cloud_operator_contract.py` to enforce the revised docs and workflow contract wording

Note: after the initial branch edit, `.github/workflows/trigger-runtime-release.yml` was reformatted externally. The branch was revalidated in that current state, and the larger workflow diff is formatting-heavy rather than a broader contract change.

## Scope Boundaries

This PR intentionally does not:

- provision Cloud Composer
- route runtime release requests to Composer yet
- remove the retained operator host
- change runtime release execution behavior
- change MLflow placement

## Validation

- `PATH=/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin:$PATH PYTHONPATH=$PWD/src pytest tests/test_cloud_operator_contract.py tests/test_runtime_release.py tests/test_dags.py`
- result: `74 passed`
- `PATH=/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin:$PATH PYTHONPATH=$PWD/src mkdocs build -f docs/mkdocs.yml --strict`
- strict docs build passed
- diagnostics were clean on the edited workflow, docs, and test files
- current branch state was revalidated after the external workflow reformat