### PR TITLE
docs(system): simplify hosted GCP architecture and delivery pages

### DIFF
--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -1,11 +1,12 @@
 # Architecture
 
-FoehnCast keeps the same Feature-Training-Inference split in every runtime mode. What changes is the surrounding lane: the local evaluator, the public API lane on Cloud Run, or the private operator lane on the retained host.
+FoehnCast keeps the same Feature-Training-Inference split in every runtime mode. What changes is the supporting delivery and operator lane around that split. Today the shared cloud path has a public API lane on Cloud Run and a private operator lane on a retained host. That operator lane is transitional while hosted image builds move toward Cloud Build and hosted orchestration moves toward Cloud Composer.
 
 !!! note "How to read this page"
 
     The validated baseline is the local Compose stack.
-    The shared cloud path splits into a public API lane on Cloud Run and a private operator lane on the retained host.
+    The shared cloud path today splits into a public API lane on Cloud Run and a private retained operator lane.
+    The intended hosted direction keeps Cloud Run as the public API, moves hosted image builds to Cloud Build, and moves hosted orchestration to Cloud Composer.
     The hosted paths use the same feature, training, and inference modules, but move storage, auth, and runtime services onto GCP in different ways.
     The rider-facing demo and prediction outputs are not the same thing as operator dashboards, and Grafana is not treated as the main product UI.
 
@@ -58,11 +59,11 @@ Grafana stays on the operator side of that boundary. The rider-facing experience
 
 ## Runtime Lanes
 
-| Lane | Current target | Main role | Exposure |
-|------|----------------|-----------|----------|
-| Local evaluator lane | local Compose stack | validate the full system on one machine | local-only |
-| Shared API lane | hosted inference target on Cloud Run | serve the shared FastAPI product and service routes | public |
-| Operator lane | hosted full-stack target on one GCP host | keep Airflow, MLflow, monitoring, and private app checks online | private by default |
+| Lane | Current target | State | Main role | Exposure |
+|------|----------------|-------|-----------|----------|
+| Local evaluator lane | local Compose stack | stable baseline | validate the full system on one machine | local-only |
+| Shared API lane | hosted inference target on Cloud Run | active hosted target | serve the shared FastAPI product and service routes | public |
+| Operator lane | hosted full-stack target on one GCP host | active but transitional | keep Airflow, MLflow, monitoring, and private app checks online while the hosted control plane is simplified | private by default |
 
 ## Stable Pipeline Boundaries
 
@@ -71,7 +72,7 @@ Grafana stays on the operator side of that boundary. The rider-facing experience
 | Feature pipeline | Collect data, engineer curated rows, validate them, and store the result | local Airflow DAG plus the configured storage backend |
 | Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
 | Inference pipeline | Serve health, predict, rank, and spot-list responses | FastAPI app container |
-| Orchestration | Schedule runtime DAGs, retries, backfills, and operator inspection | local Airflow plus the retained hosted Airflow control plane |
+| Orchestration | Schedule runtime DAGs, retries, backfills, and operator inspection | local Airflow today; retained-host Airflow today; Cloud Composer is the target hosted orchestrator |
 | Online features | Surface curated fields through an online lookup route | Feast-backed service path plus demo page |
 | Monitoring | Scrape runtime metrics, collect pushed gauges, and visualize starter alerts | Prometheus, StatsD exporter, and Grafana operator stack |
 
@@ -90,17 +91,20 @@ flowchart LR
 | Target | Deploys | Leaves out | Primary use |
 |------|---------|------------|-------------|
 | Local evaluator target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, Grafana, MinIO, the Feast Datastore emulator, and optional `development_env` tooling | shared GCP baseline | default development and evaluation |
-| Hosted full-stack target (operator lane) | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, and Grafana on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | retained operator control plane and orchestration surface of record |
+| Hosted full-stack target (transitional operator lane) | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, and Grafana on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | keep current operator duties online while the hosted build and orchestration contracts are cleaned up |
 | Hosted inference target (API lane) | FastAPI only, backed by shared GCP services | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | primary hosted API surface |
-| GitHub automation | image publishing and Terraform workflows | runtime services | shared cloud day-2 delivery, not a runtime target |
+| Managed hosted direction | Cloud Build for hosted runtime images and Cloud Composer for hosted Airflow workloads | VM-owned orchestration and host-built image responsibility | intended steady hosted build and orchestration path |
+| GitHub automation | review, workflow dispatch, and Terraform workflows | runtime services | shared cloud delivery control plane, not a runtime target |
 
-The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. Cloud Run owns the public API lane. The hosted full-stack target stays private by default and keeps the operator stack online when Airflow, MLflow, and monitoring need to stay together.
+The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. Cloud Run already owns the public API lane. The retained host stays private by default and is treated as a transitional operator surface, not as the desired long-term hosted control plane.
 
-See [Cloud Mapping](cloud-mapping.md) and [Hosted Full-Stack](hosted-full-stack.md) for the active hosted topology and exposure contract.
+See [Cloud Mapping](cloud-mapping.md) and [Hosted Full-Stack](hosted-full-stack.md) for the current hosted topology, the transitional retained-host contract, and the intended managed direction.
 
-## Orchestration Surface Of Record
+## Hosted Orchestration Direction
 
-Hosted Airflow on the private operator lane remains the runtime orchestration surface for this horizon. The detailed GitHub-versus-runtime boundary, runtime handoff, and recovery ownership stay in [Delivery and Operator Workflow](delivery-and-operator-workflow.md).
+Today the private operator lane still runs the hosted Airflow surface used for scheduling, retries, backfills, and runtime release handoff. That is the current operational contract.
+
+The target hosted control plane is Cloud Composer. The managed cutover should replace host-owned Airflow responsibilities without changing the core feature, training, and inference split. The detailed current-versus-target boundary stays in [Delivery and Operator Workflow](delivery-and-operator-workflow.md).
 
 ## Current Local Architecture
 
@@ -123,7 +127,7 @@ flowchart TD
 
 The Airflow control plane reflects those hand-offs directly. The feature pipeline owns the curated-row and Feast-sync publication steps, then emits a training-request asset. The training pipeline is scheduled from that asset rather than a direct DAG-to-DAG trigger, so the Assets view shows the real dependency graph between feature persistence, Feast serving preparation, model training, evaluation, and registration.
 
-## Hosted Runtime Detail
+## Hosted Runtime Detail Today
 
 <div class="mermaid">
 flowchart LR
@@ -152,7 +156,7 @@ flowchart LR
     OSRM2[OSRM] --> RAPI
 </div>
 
-The hosted lanes reuse the same application boundaries, but they deploy different runtime surfaces. The first diagram shows the private operator lane. The second shows the public API lane.
+The hosted lanes reuse the same application boundaries, but they deploy different runtime surfaces. The first diagram shows the retained private operator lane that exists today. The second shows the public API lane on Cloud Run. The managed hosted direction changes the build and orchestration plane around those diagrams; it does not change the core pipeline split.
 
 ## Representative Validation
 
@@ -169,6 +173,7 @@ The hosted lanes reuse the same application boundaries, but they deploy differen
 - The personalized ranking logic stays in the inference layer.
 - Feature engineering and training remain reusable across local and hosted paths.
 - Hosted changes mostly affect storage, auth, orchestration, and image delivery.
+- The retained operator lane is a support structure for the current hosted path, not the desired long-term hosted design.
 - Feast layers on top of the same curated features instead of splitting the design.
 
 ## Storage Contract

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -113,7 +113,7 @@ The intended hosted direction keeps Cloud Run as the public API, moves hosted im
 
 Cloud Composer is the target managed orchestration direction.
 
-Before a later cutover, DAG packaging, Python dependency delivery, secret and runtime-config injection, network and API reachability, and runtime release entry still need to stop depending on the retained operator host. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed current-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
+Before a later cutover, DAG packaging, Python dependency delivery, secret and runtime-config injection, network and API reachability, and a reviewed runtime release entry that reaches the managed Airflow surface directly still need to stop depending on the retained operator host. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed current-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
 
 ## Current And Target Hosted Mapping
 

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -1,13 +1,13 @@
 # Cloud Mapping
 
-FoehnCast keeps one public hosted lane and one private operator lane. Cloud Run carries the shared API, while the hosted full-stack target stays online on one Compute Engine host for Airflow, MLflow, and monitoring. That retained host is current, not the intended long-term orchestration authority. This page maps the validated local stack onto those GCP lanes without changing the core Feature-Training-Inference boundaries.
+FoehnCast keeps one public hosted lane and one private operator lane today. Cloud Run carries the shared API, while the hosted full-stack target still runs on one Compute Engine host for Airflow, MLflow, monitoring, and private app checks. That retained host is current but transitional while hosted image builds move toward Cloud Build and hosted orchestration moves toward Cloud Composer. This page maps the validated local stack onto the current and target GCP lanes without changing the core Feature-Training-Inference boundaries.
 
 !!! note "What this page covers"
 
     The shared GCP baseline and both hosted lanes already exist.
     Cloud Run is the shared public API lane.
-    The hosted full-stack target stays online as the private operator lane.
-    Cloud Composer is the target managed orchestration direction.
+    The hosted full-stack target is the current private operator lane.
+    Cloud Build and Cloud Composer are the intended managed hosted direction.
 
 ## Cloud Paths In One View
 
@@ -18,28 +18,28 @@ FoehnCast keeps one public hosted lane and one private operator lane. Cloud Run 
 <p>Terraform provisions APIs, Artifact Registry, GCS, BigQuery, and GitHub OIDC.</p>
 </li>
 <li>
-<p><strong>Hosted full-stack target</strong></p>
-<p>One Compute Engine host runs Airflow, MLflow, monitoring, and private app checks.</p>
+<p><strong>Current operator lane</strong></p>
+<p>One Compute Engine host still runs Airflow, MLflow, monitoring, and private app checks.</p>
+</li>
+<li>
+<p><strong>Managed hosted direction</strong></p>
+<p>Cloud Build and Cloud Composer are the intended hosted build and orchestration targets.</p>
 </li>
 <li>
 <p><strong>Hosted inference target</strong></p>
-<p>Cloud Run serves the promoted FastAPI API.</p>
-</li>
-<li>
-<p><strong>Operator delivery</strong></p>
-<p>Maintainers bootstrap once, then GitHub Actions advances reviewed changes.</p>
+<p>Cloud Run serves the promoted FastAPI API and remains the public surface.</p>
 </li>
 </ul>
 </div>
 
 ## Hosted Lanes At A Glance
 
-| Lane | Concrete target | Default exposure | Main job |
-|------|-----------------|------------------|----------|
-| Shared API lane | hosted inference target on Cloud Run | public | serve the FastAPI product and service routes |
-| Operator lane | hosted full-stack target on Compute Engine | private by default | run Airflow, MLflow, monitoring, and private app checks |
-| Managed orchestration direction | Cloud Composer | private or platform-only | run hosted Airflow workloads without VM-owned orchestration |
-| Delivery lane | GitHub Actions plus Terraform plus OIDC | not a runtime surface | publish reviewed artifacts and apply reviewed infrastructure changes |
+| Lane | Concrete target | State | Default exposure | Main job |
+|------|-----------------|-------|------------------|----------|
+| Shared API lane | hosted inference target on Cloud Run | active | public | serve the FastAPI product and service routes |
+| Operator lane | hosted full-stack target on Compute Engine | active but transitional | private by default | run Airflow, MLflow, monitoring, and private app checks |
+| Managed hosted control plane | Cloud Build and Cloud Composer | target direction | private or platform-only | build hosted images and run hosted Airflow workloads without VM-owned orchestration |
+| Delivery lane | GitHub Actions plus Terraform plus OIDC | active review gate | not a runtime surface | publish reviewed artifacts and apply reviewed infrastructure changes |
 
 ## Mapping Principle
 
@@ -75,6 +75,21 @@ flowchart LR
     GH -. app image publish .-> RUN
 </div>
 
+## Managed Direction
+
+<div class="mermaid">
+flowchart LR
+    GH[GitHub review gate] --> CB[Cloud Build]
+    CB --> AR[Artifact Registry]
+    AR --> RUN[Cloud Run API lane]
+    TF[Terraform baseline] --> GCP[Shared GCP resources]
+    GCP --> CMP[Cloud Composer]
+    CMP --> BQ[(BigQuery curated features)]
+    CMP --> GCS[(GCS artifacts)]
+</div>
+
+The managed direction keeps the same shared storage and API surfaces, but it changes two supporting planes: hosted image builds move into Cloud Build, and hosted orchestration moves into Cloud Composer. The retained host should then shrink to only the services that still need it.
+
 ## What Exists Today
 
 | Surface | Deploys | Leaves out | Current state |
@@ -83,39 +98,34 @@ flowchart LR
 | Hosted full-stack target (operator lane) | Airflow, MLflow, and the API on one Compute Engine host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented and retained for operator control-plane duties |
 | Hosted inference target (API lane) | the FastAPI inference API on Cloud Run | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented and promoted as the primary hosted API path |
 | GitHub delivery | image publishing and remote Terraform runs | runtime services | implemented and bootstrapped for the shared environment |
+| Hosted runtime image publishing | app image in Artifact Registry, other runtime images still mixed | n/a | transitional; not yet one managed build contract |
 | BigQuery backend support | support for a BigQuery storage backend in the app | none | available in both local and hosted runtimes |
 
-The hosted targets deploy runtime services only. Development assets stay local or CI-only. Cloud Run is the only promoted public API path. The hosted full-stack target stays private by default and keeps Airflow, MLflow, Prometheus, and Grafana together on the operator side.
+The hosted targets deploy runtime services only. Development assets stay local or CI-only. Cloud Run is the only promoted public API path. The hosted full-stack target stays private by default and keeps Airflow, MLflow, Prometheus, and Grafana together on the operator side for now.
 
 ## Active Shared Deployment Path
 
-Today the shared environment keeps a stable split: Cloud Run carries the shared public API URL, one Compute Engine host stays online as the private operator lane for Airflow, MLflow, monitoring, and private app checks, and GitHub Actions plus remote Terraform advance reviewed day-2 changes after maintainer bootstrap.
+Today the shared environment keeps a stable split: Cloud Run carries the shared public API URL, one Compute Engine host stays online as the private operator lane for Airflow, MLflow, monitoring, and private app checks, and GitHub Actions plus remote Terraform advance reviewed day-2 changes after maintainer bootstrap. This is the current operational contract, not the desired end state.
 
-Today the retained operator host still owns hosted orchestration. The target managed orchestration direction is Cloud Composer once DAG packaging, Python dependency delivery, secret and runtime-config injection, network and API reachability, and runtime release entry no longer depend on the retained host. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed current-versus-target boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
+The intended hosted direction keeps Cloud Run as the public API, moves hosted image builds to Cloud Build, and moves hosted orchestration to Cloud Composer. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed current-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
 
 ## Managed Orchestration Direction
 
 Cloud Composer is the target managed orchestration direction.
 
-Before a later cutover, the repo needs:
+Before a later cutover, DAG packaging, Python dependency delivery, secret and runtime-config injection, network and API reachability, and runtime release entry still need to stop depending on the retained operator host. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed current-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
 
-- a DAG packaging path that does not depend on a VM checkout
-- a Python dependency bundle for hosted Airflow
-- secret and runtime-config delivery for the managed orchestrator
-- network and API reachability that does not depend on VM SSH
-- a reviewed runtime release entry that reaches the managed Airflow surface directly
+## Current And Target Hosted Mapping
 
-## Honest Mapping From Local To Cloud
-
-| Local component | Current hosted path |
-|----------------|---------------------|
-| `app` container | Cloud Run API lane for shared traffic, plus the private operator lane for host-local checks |
-| Airflow containers | operator lane today |
-| MLflow local service | operator lane today with GCS-backed artifacts |
-| Local feature storage | BigQuery backend already available |
-| Local MLflow artifact volume | GCS artifact destination on the hosted compose path |
-| `development_env` container | local and CI only |
-| Feast serving path | sits on top of the same curated data |
+| Concern | Current hosted path | Target hosted direction |
+|---------|---------------------|-------------------------|
+| FastAPI app | Cloud Run API lane for shared traffic, plus the private operator lane for host-local checks | Cloud Run remains the only shared public API lane |
+| Hosted image builds | GitHub-hosted workflows publish an app image to Artifact Registry and other runtime images through a mixed path | Cloud Build publishes all hosted runtime images to Artifact Registry |
+| Airflow orchestration | retained operator lane today | Cloud Composer |
+| MLflow tracking | operator lane today with GCS-backed artifacts | stays on a separate operator surface until a later decision changes it |
+| Monitoring | operator lane today | stays private on an operator surface, whether retained-host or later replacement |
+| Curated storage | BigQuery backend already available | stays on BigQuery |
+| Feast serving path | sits on top of the same curated data | keeps the same logical feature view against cloud storage |
 
 ## Cloud Pipeline Shape
 
@@ -183,7 +193,7 @@ In practice, GCS stores raw landing data and registry-style metadata for the clo
 | Storage | MinIO-backed curated objects plus local Feast parquet and a Datastore-mode emulator | GCS holds raw landing and artifacts; BigQuery becomes the shared curated cloud data surface |
 | Artifacts | MinIO-backed MLflow artifact path | GCS bucket |
 | Auth | local `.env` plus developer credentials | runtime service accounts and GitHub OIDC |
-| Image source | local builds | GHCR runtime images or Artifact Registry app image |
+| Image source | local builds | mixed GitHub-hosted image publication today; target is Cloud Build plus Artifact Registry for all hosted runtime images |
 | Public exposure | local ports on the developer machine | Cloud Run is the shared hosted API surface; the operator lane stays private by default; dashboards stay private unless you deliberately publish them |
 
 ## Recovery Evidence In Cloud
@@ -205,15 +215,16 @@ The stable evidence surfaces are:
 - The application already supports a `bigquery` storage backend through the shared feature-store abstraction.
 - Local container runs can already mount ADC for BigQuery-based checks.
 
-## Current Tradeoffs
+## Current Transitional Points
 
-- MLflow stays on the compose host in the active shared environment.
-- Airflow stays on the compose host, while the sync timer, retained sync state, and monitoring stack make that host observable.
-- Cloud Run stays on the public API lane, and the hosted full-stack target keeps the broader private operator stack online.
+- MLflow stays on the retained host in the active shared environment.
+- Airflow still stays on the retained host today, so runtime release, retries, and backfills still depend on VM-backed orchestration.
+- Cloud Run already owns the public API lane and should keep that role.
+- Hosted image delivery is still split between GitHub-hosted execution and mixed registries; the target is Cloud Build plus Artifact Registry.
 - The monitoring stack stays intentionally small and reviewable through checked-in dashboards, alert rules, and scrape config.
 
 ## Why This Fits The Project Brief
 
-The goal is cloud-ready pipelines and cloud orchestration. This mapping keeps the validated backend design, but replaces the local support stack with cloud services that can run after deployment.
+The goal is cloud-ready pipelines and cloud orchestration. This mapping keeps the validated backend design, makes the current retained-host dependency explicit, and points the hosted path toward Google-managed build and orchestration services without discarding the working local baseline.
 
 See [Architecture](architecture.md) for the current runtime view and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the maintainer path that bootstraps and advances these hosted targets. The repository root also includes a Terraform README with the deployment details.

--- a/docs/site/system/configuration-and-contracts.md
+++ b/docs/site/system/configuration-and-contracts.md
@@ -93,6 +93,8 @@ The checked-in `.env.example` shows the kind of values that belong in runtime wi
 
 These values describe one concrete runtime instance. They should stay overridable because the local evaluator, hosted full-stack target, and hosted inference target do not all bind to the same services.
 
+In the shared hosted path today, the full-stack target still represents the current operator lane. That lane is transitional, so the runtime wiring should stay explicit instead of being treated as a permanent deployment shape.
+
 ## Cloud Runtime Inventory
 
 The shared cloud path uses four value surfaces plus identity-backed auth. The simple split is this: delivery surfaces carry reviewed hosted identifiers and toggles, runtime surfaces carry concrete per-environment wiring, and identities carry cloud access.
@@ -102,14 +104,14 @@ The shared cloud path uses four value surfaces plus identity-backed auth. The si
 | checked-in examples and repo defaults | `.env.example` placeholders, `terraform/terraform.tfvars.example`, checked-in operator docs | repository | bootstrap prompts, local operators, reviewers | structural examples only; never live credentials |
 | bootstrap outputs in the working tree | `.env`, `terraform/terraform.tfvars`, Terraform outputs echoed by `./scripts/bootstrap-gcp.sh` | maintainer running bootstrap for one environment | local preview applies, bootstrap verification, `scripts/configure-github-actions.sh` | hosted identifiers and toggles only; not a long-term secret store |
 | GitHub repository variables | `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_ARTIFACT_REPOSITORY`, `GCP_BIGQUERY_*`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT_EMAIL`, Cloud Run sizing and enablement flags | GitHub delivery control plane, normally synced from Terraform outputs | `.github/workflows/terraform.yml`, image-publish workflows, repo-config action | structural delivery contract only; do not store runtime passwords, API tokens, or key files here |
-| runtime `.env` and hosted runtime env vars | `MLFLOW_TRACKING_URI`, `AIRFLOW__API_AUTH__JWT_SECRET`, `FOEHNCAST_GRAFANA_ADMIN_*`, `GRAFANA_API_*`, `cloud_run_env_vars`, `online_compose_env_vars` | runtime operator or platform for one running surface | local evaluator, operator lane, shared API lane, Grafana and Airflow auth checks | concrete runtime wiring; secret-bearing values should stay local-only or move to Secret Manager or another managed secret path |
+| runtime `.env` and hosted runtime env vars | `MLFLOW_TRACKING_URI`, `AIRFLOW__API_AUTH__JWT_SECRET`, `FOEHNCAST_GRAFANA_ADMIN_*`, `GRAFANA_API_*`, `cloud_run_env_vars`, `online_compose_env_vars` | runtime operator or platform for one running surface | local evaluator, current operator lane, shared API lane, Grafana and Airflow auth checks | concrete runtime wiring; secret-bearing values should stay local-only or move to Secret Manager or another managed secret path |
 | identity-backed auth surfaces | GitHub OIDC, Cloud Run service account, compose-host VM service account | repository admin plus GCP IAM | GitHub workflows and hosted runtimes | prefer identities over stored cloud credentials; not a secret distribution path |
 
 This inventory keeps the current boundary explicit:
 
 - `config.yaml` keeps workload semantics.
 - `terraform/terraform.tfvars` and GitHub repository variables keep structural hosted rollout inputs.
-- runtime `.env` and hosted env injections carry concrete per-environment wiring for the local evaluator, operator lane, or shared API lane.
+- runtime `.env` and hosted env injections carry concrete per-environment wiring for the local evaluator, the current operator lane, or the shared API lane.
 - secret-bearing runtime values should not move into committed examples or repository variables just because they are cloud-facing.
 
 This page inventories where those values live. [Delivery and Operator Workflow](delivery-and-operator-workflow.md) owns the maintainer bootstrap, repository-variable sync, and remote-apply runbook that moves between those surfaces.

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -1,12 +1,12 @@
 # Delivery and Operator Workflow
 
-FoehnCast keeps contributor onboarding and shared-cloud delivery separate on purpose. Contributors use `./scripts/bootstrap-local.sh` to run the validated local evaluator. Maintainers use `./scripts/bootstrap-gcp.sh`, GitHub Actions, and Terraform to bootstrap and advance the shared hosted environment. This page records the current workflow contract validated by the bootstrap scripts, the Terraform reference, and the cloud-operator tests.
+FoehnCast keeps contributor onboarding and shared-cloud delivery separate on purpose. Contributors use `./scripts/bootstrap-local.sh` to run the validated local evaluator. Maintainers use `./scripts/bootstrap-gcp.sh`, GitHub Actions, and Terraform to bootstrap and advance the shared hosted environment. The current hosted runtime still uses a retained operator host for Airflow handoff and operator surfaces, but the intended hosted direction is Cloud Build plus Cloud Composer. This page records the current workflow contract and the boundary that future hosted changes should move toward.
 
 !!! note "Scope"
 
     This page describes the current validated delivery and operator workflow.
-    It is not a roadmap.
-    Future deployment changes should be documented after they are chosen and implemented.
+    It also names the intended managed hosted direction so the current host-backed path is not mistaken for the final design.
+    It is not a cutover runbook for Composer or Cloud Build.
 
 ## Workflow In One View
 
@@ -46,14 +46,16 @@ flowchart LR
 
 The split matters because the local path is the supported public onboarding path, while the cloud path assumes GCP ownership, GitHub repository administration, and access to private operator surfaces.
 
+Today the remote workflow still lands on two hosted runtime surfaces: Cloud Run for the public API lane and the retained operator host for Airflow, MLflow, monitoring, and private recovery work. The target managed direction keeps the same onboarding split but replaces host-owned build and orchestration duties with Cloud Build and Cloud Composer.
+
 ## Current Lanes
 
-| Lane | Current target | Main job |
-|------|----------------|----------|
-| Local evaluator lane | `./scripts/bootstrap-local.sh` plus local Compose | run the default contributor path |
-| Delivery lane | GitHub Actions plus Terraform plus OIDC | publish reviewed artifacts and apply reviewed infrastructure changes |
-| Shared API lane | hosted inference target on Cloud Run | serve the shared public API |
-| Operator lane | hosted full-stack target on one GCP host | keep Airflow, MLflow, monitoring, and private recovery work online |
+| Lane | Current target | State | Main job |
+|------|----------------|-------|----------|
+| Local evaluator lane | `./scripts/bootstrap-local.sh` plus local Compose | stable baseline | run the default contributor path |
+| Delivery lane | GitHub Actions plus Terraform plus OIDC | active review gate | publish reviewed artifacts and apply reviewed infrastructure changes |
+| Shared API lane | hosted inference target on Cloud Run | active hosted target | serve the shared public API |
+| Operator lane | hosted full-stack target on one GCP host | active but transitional | keep Airflow, MLflow, monitoring, and private recovery work online until the managed hosted control plane is ready |
 
 ## Default Contributor Path
 
@@ -88,7 +90,7 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 | `.github/workflows/terraform.yml` | primary Terraform operator path | pushes to `main` automatically resolve to `apply` after bootstrap; manual dispatch stays available for `plan`, `destroy`, `cleanup`, and explicit overrides |
 | `scripts/configure-github-actions.sh` | repo-variable sync | Terraform outputs are copied into GitHub repository variables so the remote workflow reads one shared contract |
 | `terraform/terraform.tfvars` | bootstrap input | used during the interactive bootstrap path, not as the day-2 source of truth for remote applies |
-| runtime image workflows | reviewed artifact publishing | publish automation builds and publishes runtime images, but it does not deploy Cloud Run, shift traffic, or mutate MLflow aliases directly |
+| runtime image workflows | reviewed artifact publishing | GitHub-reviewed workflows now submit hosted image builds to Cloud Build and publish the reviewed images to Artifact Registry, but they still do not deploy Cloud Run, shift traffic, or mutate MLflow aliases directly |
 | `.github/workflows/trigger-runtime-release.yml` | reviewed runtime handoff | today GitHub sends one explicit runtime release request into hosted Airflow after the retained operator host refreshes to the reviewed git ref; this handoff is transitional until Composer owns it |
 | `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up | run this after a remote apply succeeds and curated BigQuery rows exist |
 
@@ -118,7 +120,6 @@ The current hosted orchestration path and the target managed direction are diffe
 | Reviewed runtime release entry | GitHub OIDC plus SSH to the retained host, then local `runtime_release` DAG trigger | reviewed request should reach Composer without VM SSH |
 | Scheduling, retries, and backfills | retained-host Airflow | Composer |
 | Operator host role | Airflow, MLflow, monitoring, and private app checks on one VM | shrink after Composer absorbs orchestration; keep only the services that still need a VM |
-
 Today the retained host path remains the operational recovery surface. It is not the intended long-term hosted orchestration authority.
 
 ## GitHub Versus GCP Boundary
@@ -128,12 +129,12 @@ The reviewed delivery plane and the runtime execution plane still have different
 | Plane | Current owner | What it owns | What it must not own |
 |------|---------------|--------------|----------------------|
 | Reviewed delivery | GitHub Actions plus Terraform | lint, test, build, image publish, Terraform plan/apply/destroy, and reviewed deploy workflows | runtime scheduling, retries, backfills, and long-lived operator state |
-| Runtime execution | GCP-hosted runtime surfaces | Cloud Run serving, hosted Airflow scheduling, retries, backfills, runtime environment injection, and operator telemetry | source control, CI review, and infrastructure policy review |
-| Shared handoff | repository variables, published images, Terraform outputs, and runtime release requests | reviewed contract from GitHub into GCP runtime surfaces | ad hoc operator-only divergence from the declared contract |
+| Runtime execution | GCP-hosted runtime surfaces | Cloud Run serving, current hosted Airflow scheduling, retries, backfills, runtime environment injection, and operator telemetry | source control, CI review, and infrastructure policy review |
+| Shared handoff | repository variables, published images, Terraform outputs, and runtime release requests | reviewed contract from GitHub into GCP runtime surfaces; today it reaches runtime through the retained-host handoff and later should reach managed Airflow directly | ad hoc operator-only divergence from the declared contract |
 
 GitHub Actions may trigger reviewed delivery workflows, but runtime scheduling does not belong to GitHub. Today that runtime orchestration still lives on the retained operator host. The target managed surface is Cloud Composer.
 
-## Runtime Release Trigger Contract
+## Current Runtime Release Trigger Contract
 
 GitHub now has exactly one reviewed handoff into runtime execution.
 
@@ -218,7 +219,7 @@ Rollback uses the runtime trigger contract instead of direct GitHub runtime muta
 - `airflow/reports/runtime-release-latest.json` and its history files record the acknowledged handoff on the runtime side
 - reopening the hosted VM app on port `8000` is not part of rollback; the shared environment treats that as misconfiguration
 
-VM retirement is a separate question. The VM stays online while Airflow, MLflow, and monitoring still define the retained control plane. Later retirement should happen only after that operator lane gets smaller explicitly.
+VM retirement is a separate question. The VM stays online only while Airflow, MLflow, and monitoring still define the retained control plane. Airflow should leave the VM before that host is treated as steady state.
 
 Practical recovery split:
 
@@ -246,7 +247,7 @@ These boundaries stay explicit across the scripts, Terraform reference, and test
 - the local Docker evaluator remains the only default contributor path
 - the shared cloud environment stays operator-owned, even though the repository and images are public
 - `terraform/terraform.tfvars` belongs to bootstrap and local preview work, while day-2 remote runs read GitHub repository variables
-- runtime scheduling, retries, and backfills belong to hosted Airflow for this horizon rather than to GitHub Actions
+- runtime scheduling, retries, and backfills belong to hosted Airflow today and to Composer after the managed cutover, not to GitHub Actions
 - runtime promotion, rollback, and live traffic control do not run inside GitHub workflows; GitHub only sends the reviewed runtime release request
 - Grafana, Airflow, MLflow, and Prometheus remain operator surfaces rather than rider-facing product surfaces
 - public docs should explain those surfaces with rendered evidence and checked-in configuration, not live control-plane embeds
@@ -259,5 +260,6 @@ The same split also keeps cloud retirement reviewable. Destroy and cleanup stay 
 - it keeps the one-time cloud bootstrap explicit and interactive, which is safer for project, billing, and hosted-target choices
 - it moves normal day-2 infrastructure changes into GitHub Actions so operators do not need local Terraform for routine work
 - it keeps shared-cloud configuration reviewable because Terraform outputs, repository variables, and workflow behavior are tied together by regression tests
+- it records the current retained-host workflow without pretending that VM-backed orchestration is the desired hosted end state
 
 See [Interfaces and Surfaces](interfaces-and-surfaces.md), [Hosted Full-Stack](hosted-full-stack.md), [Cloud Mapping](cloud-mapping.md), and [Monitoring](monitoring.md) for the surrounding runtime and exposure boundaries.

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -1,14 +1,14 @@
-# Hosted Full-Stack
+# Hosted Full-Stack (Transitional Operator Host)
 
-FoehnCast keeps the hosted full-stack target as the private operator lane. It runs Airflow, MLflow, the FastAPI app, and the monitoring stack on one Compute Engine host while Cloud Run carries the public API lane.
+FoehnCast keeps the hosted full-stack target as the current private operator lane. It runs Airflow, MLflow, the FastAPI app, and the monitoring stack on one Compute Engine host while Cloud Run carries the public API lane. This host is transitional: it keeps the current operator stack online while hosted image builds move toward Cloud Build and hosted orchestration moves toward Cloud Composer.
 
 This page records the current hosted full-stack contract that is described by the cloud bootstrap, Terraform reference, and cloud-operator tests. It focuses on the active shared runtime target, not on future migrations.
 
 !!! note "Scope"
 
-    This page describes the current validated hosted full-stack target.
-    It is not a roadmap.
-    Future changes should be documented after they are chosen and implemented.
+    This page describes the current retained operator host contract.
+    It explains why that host is transitional rather than the intended long-term hosted control plane.
+    It is not the Composer cutover plan.
 
 ## Target Shape
 
@@ -36,16 +36,16 @@ flowchart LR
 | Lane | Current target | Main role |
 |------|----------------|-----------|
 | Shared API lane | Cloud Run hosted inference target | serve the public FastAPI routes |
-| Operator lane | hosted full-stack target on one VM | keep Airflow, MLflow, monitoring, and private app checks online |
+| Operator lane | hosted full-stack target on one VM | keep Airflow, MLflow, monitoring, and private app checks online while the managed hosted control plane is not ready yet |
 
-The important boundary is that the hosted full-stack target stays a runtime target, not a contributor environment. It depends on shared GCP storage and identity surfaces instead of local emulators, updates through the maintainer bootstrap plus remote Terraform and host sync path, and stays on the private operator side while Cloud Run owns public serving.
+The important boundary is that the hosted full-stack target stays a runtime target, not a contributor environment. It depends on shared GCP storage and identity surfaces instead of local emulators, updates through the maintainer bootstrap plus remote Terraform and host sync path, and stays on the private operator side while Cloud Run owns public serving. It is a retained support lane, not the target hosted architecture.
 
 ## Surface Responsibilities
 
 | Surface | Main responsibility | Must not become |
 |------|----------------------|-----------------|
 | Shared GCP baseline | provide Artifact Registry, GCS, BigQuery, Datastore, and identity foundations | the application runtime itself |
-| Online compose host | keep the full runtime stack online from one VM | a contributor setup path or notebook host |
+| Online compose host | keep the current operator stack online from one VM | a contributor setup path, notebook host, or long-term orchestration authority |
 | FastAPI app | serve the product and service routes | a hidden deployment control plane |
 | Airflow, MLflow, Prometheus, StatsD exporter, and Grafana | operator orchestration, tracking, monitoring, and review | the rider-facing interface |
 | GitHub OIDC delivery | run remote Terraform and image-driven deploy updates | a substitute for the runtime host |
@@ -70,11 +70,11 @@ The identity split around this target is deliberate:
 - Cloud Run uses its own narrower runtime identity for the inference-only service.
 - the online compose host uses a separate runtime identity because it still bundles Airflow, training, MLflow, Feast preparation, and the app on one VM.
 
-That online compose runtime identity is the current transition contract. It remains broader than the Cloud Run identity only because the host still owns more responsibilities today.
+That online compose runtime identity is the current transition contract. It remains broader than the Cloud Run identity only because the host still owns more responsibilities today. The intended hosted direction is to remove Airflow from this VM rather than to keep widening what the VM owns.
 
 ## Bootstrap And Day-2 Delivery
 
-The hosted full-stack target is not part of the default contributor path. Its lifecycle still splits into one-time maintainer bootstrap and GitHub-managed day-2 delivery after bootstrap. For this target, the hosted-specific contract is simple: Terraform provisions the VM and shared cloud data surfaces, the host sync refreshes the repository and runtime `.env`, and the VM app must stay private while Cloud Run remains the public API lane.
+The hosted full-stack target is not part of the default contributor path. Its lifecycle still splits into one-time maintainer bootstrap and GitHub-managed day-2 delivery after bootstrap. For this current target, the hosted-specific contract is simple: Terraform provisions the VM and shared cloud data surfaces, the host sync refreshes the repository and runtime `.env`, and the VM app must stay private while Cloud Run remains the public API lane.
 
 See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed bootstrap, remote Terraform, and runtime-release handoff steps.
 
@@ -91,6 +91,8 @@ The current sync contract is:
 - Grafana can show the last successful hosted refresh from the same retained sync state
 
 This makes the hosted target observable without turning SSH into the only source of truth for what the VM last deployed.
+
+This sync path matters only while the retained host still owns operator duties. It should shrink or disappear once managed build and orchestration paths take over.
 
 ## Exposure And Verification
 
@@ -120,15 +122,16 @@ These surfaces stay local or CI-only:
 
 ## Rollback And Retirement Gate
 
-Cloud Run remains the only supported public API path in the shared environment, so rollback uses the reviewed runtime trigger contract rather than reopening the VM app publicly. The narrower retirement question stays separate: the VM remains online while Airflow, MLflow, sync status, or operator monitoring still need the retained control plane.
+Cloud Run remains the only supported public API path in the shared environment, so rollback uses the reviewed runtime trigger contract rather than reopening the VM app publicly. The narrower retirement question stays separate: the VM remains online only while Airflow, MLflow, sync status, or operator monitoring still need the retained control plane.
 
 See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed rollback and retry runbooks.
 
 ## Why This Target Works
 
-- it keeps the full operator stack online in the active shared environment without forcing Airflow into Cloud Run
+- it keeps the full operator stack online in the active shared environment while the managed hosted control plane is still being defined
 - it reuses the same repository and application boundaries as the local evaluator target
 - it keeps the hosted runtime tied to reviewable Terraform outputs, GitHub delivery, and sync metrics
 - it keeps public exposure narrow enough that the app remains the only default internet-facing surface
+- it treats the retained host as a controlled transition surface instead of the desired permanent orchestration home
 
 See [Architecture](architecture.md), [Local Evaluator](local-evaluator.md), [Inference Pipeline](inference-pipeline.md), [Cloud Mapping](cloud-mapping.md), and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the surrounding runtime and deployment boundaries.

--- a/docs/site/system/inference-pipeline.md
+++ b/docs/site/system/inference-pipeline.md
@@ -1,14 +1,14 @@
 # Inference Pipeline
 
-FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs in three places: the local evaluator lane, the public API lane on Cloud Run, and the private operator lane on the hosted full-stack target. The serving path resolves the live MLflow alias, fetches fresh forecasts for configured spots, rebuilds the shared engineered feature vector, returns per-spot quality predictions, and optionally exposes the Feast-backed online lookup without pulling training or operator concerns into the request path.
+FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs in three places: the local evaluator lane, the public API lane on Cloud Run, and the private operator lane on the hosted full-stack target. The Cloud Run lane is the shared public API. The operator-lane app is a transitional support surface that stays private while the hosted control plane moves away from the retained host. The serving path resolves the live MLflow alias, fetches fresh forecasts for configured spots, rebuilds the shared engineered feature vector, returns per-spot quality predictions, and optionally exposes the Feast-backed online lookup without pulling training or operator concerns into the request path.
 
 This page records the current serving contract that is validated in the local stack and in endpoint, dashboard, and cloud-runtime tests. It focuses on what the running app owns today and what stays optional or operator-controlled.
 
 !!! note "Scope"
 
     This page describes the current validated inference-path contract.
-    It is not a roadmap.
-    Future changes should be documented after they are chosen and implemented.
+    It does not redefine the hosted build or orchestration plan.
+    The serving contract stays stable even as the surrounding hosted control plane moves toward Cloud Build and Cloud Composer.
 
 ## Inference Shape
 
@@ -132,7 +132,7 @@ This keeps the inference service responsible for request-side facts while leavin
 |------|----------------|-----------|
 | Local evaluator lane | local Compose app | validate the full serving contract locally |
 | Shared API lane | hosted inference target on Cloud Run | serve the shared public API |
-| Operator lane | hosted full-stack target on one GCP host | keep the same app available for private operator checks next to Airflow and MLflow |
+| Operator lane | hosted full-stack target on one GCP host | keep the same app available for private operator checks next to Airflow and MLflow while the retained operator lane still exists |
 
 <div class="mermaid">
 flowchart LR
@@ -141,14 +141,14 @@ flowchart LR
     APP --> HOST[Operator host lane]
 </div>
 
-The same FastAPI app runs across these serving targets. Cloud Run owns the shared public API, while the hosted full-stack target keeps the app available only for private operator checks next to the runtime services. See [Hosted Full-Stack](hosted-full-stack.md) and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the hosted exposure and rollback rules around that split.
+The same FastAPI app runs across these serving targets. Cloud Run owns the shared public API. The hosted full-stack target keeps the app available only for private operator checks next to the current runtime services, and that private lane should shrink rather than become the long-term public serving path. See [Hosted Full-Stack](hosted-full-stack.md) and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the hosted exposure, transition, and rollback rules around that split.
 
 ## Why This Structure Works
 
 - it keeps live requests narrow enough to verify through simple route and dashboard tests
 - it reuses the shared feature contract instead of inventing a serving-only schema
 - it ties responses back to a concrete registry version without giving the app promotion authority
-- it lets one FastAPI contract run locally, on Cloud Run, and on the retained hosted full-stack surface
+- it lets one FastAPI contract run locally, on Cloud Run, and on the current retained hosted full-stack surface without changing the serving contract
 - it keeps the Feast lookup path useful for integration checks while leaving prediction and ranking available from the core app alone
 
 See [Architecture](architecture.md), [Training Pipeline](training-pipeline.md), [Monitoring](monitoring.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding system boundaries.

--- a/docs/site/system/interfaces-and-surfaces.md
+++ b/docs/site/system/interfaces-and-surfaces.md
@@ -62,7 +62,9 @@ The important split is that not every HTTP route is rider-facing, and not every 
 |------|----------------|-----------|----------|
 | Local evaluator lane | local Compose stack | run the full evaluation surface on one machine | local-only |
 | Shared API lane | hosted inference target on Cloud Run | expose the public product and service routes | public |
-| Operator lane | hosted full-stack target on one GCP host | keep Airflow, MLflow, monitoring, and private app checks online | private by default |
+| Operator lane | hosted full-stack target on one GCP host | keep Airflow, MLflow, monitoring, and private app checks online while the managed hosted control plane is still transitional | private by default |
+
+The surface classes stay the same even as the hosted control plane changes. Today the operator lane still uses the retained host. The intended hosted direction is to keep the same operator-versus-public boundary while moving hosted build and orchestration into Google-managed services.
 
 ## Current Surface Classes
 
@@ -125,7 +127,7 @@ The delivery layer is separate from the runtime operator layer.
 | Terraform | declare the cloud contract and apply reviewed infrastructure changes |
 | Bootstrap helpers | perform one-time environment setup and repository-variable seeding |
 
-These surfaces are not the runtime orchestrator. For this horizon, GitHub Actions advances reviewed delivery, while hosted Airflow on GCP remains the runtime scheduling, retry, and backfill surface.
+These surfaces are not the runtime orchestrator. GitHub Actions advances reviewed delivery. Today the runtime scheduling, retry, and backfill surface still lives on the retained hosted Airflow path, and the target hosted orchestrator is Cloud Composer.
 See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed delivery-versus-runtime ownership and retry or backfill rules.
 
 ## Public-Safe Docs And Evidence

--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -1,14 +1,14 @@
 # Monitoring
 
-FoehnCast keeps monitoring as an operator surface, not a rider-facing one. The monitoring stack turns pipeline summaries, retained prediction events, drift signals, and hosted sync state into scrapeable metrics and checked-in alert rules without changing the runtime contracts those signals describe.
+FoehnCast keeps monitoring as an operator surface, not a rider-facing one. The monitoring stack turns pipeline summaries, retained prediction events, drift signals, and hosted sync state into scrapeable metrics and checked-in alert rules without changing the runtime contracts those signals describe. In the shared hosted path today, some of that operator evidence still comes from the retained host. That host is transitional, but the monitoring boundary itself stays the same.
 
 This page records the current monitoring design that is validated in the local stack and in regression tests. It focuses on what is measured today, where the evidence comes from, and how the operator path stays separate from the public docs surface.
 
 !!! note "Scope"
 
     This page describes the current validated monitoring contract.
-    It is not a roadmap.
-    Future changes should be documented after they are chosen and implemented.
+    It focuses on the current monitoring evidence and boundaries.
+    It does not treat the retained host as the desired long-term hosted control plane.
 
 ## Signal Path
 
@@ -33,7 +33,7 @@ The important split is that monitoring consumes persisted or runtime monitoring 
 | Runtime mode | Monitoring contract | Exposure boundary |
 |------|---------------------|-------------------|
 | Local evaluator | app `/metrics`, StatsD drift export, persisted pipeline summaries, and local Grafana dashboards validate the full monitoring path on one machine | local-only |
-| Shared hosted environment | Cloud Run exposes the app-owned `/metrics` contract, while the operator host keeps Prometheus, Grafana, hosted sync evidence, and operator review online | operator stack stays private by default |
+| Shared hosted environment | Cloud Run exposes the app-owned `/metrics` contract, while the current operator host keeps Prometheus, Grafana, hosted sync evidence, and operator review online until the managed hosted control plane absorbs more of that work | operator stack stays private by default |
 | Public docs | rendered metrics snippets, screenshots, checked-in configs, and summary artifacts explain the monitoring contract | no live control planes |
 
 The public-versus-private surface rule itself is documented in [Interfaces and Surfaces](interfaces-and-surfaces.md). This page stays focused on what monitoring measures and how operators verify it.
@@ -117,6 +117,8 @@ That makes the dashboard a view over checked-in metrics contracts rather than a 
 
 The same dashboard contract works in the local evaluator and in the active shared environment. What changes is the runtime around it, not the meaning of the monitored signals.
 
+That distinction matters during the hosted migration too. The operator evidence sources may move, but the monitoring contract should stay reviewable through the same metrics, alerts, and checked-in dashboards.
+
 ## Alert Rules
 
 The checked-in alert rules cover the main operator failure modes.
@@ -145,7 +147,7 @@ Recovery work should leave durable evidence that operators can compare before an
 
 Capture the initiating run reference with the summary artifacts: the GitHub workflow URL for reviewed delivery, or the logical date and DAG run id for hosted Airflow recovery.
 
-These checks stay intentionally small. They give operators one repeatable evidence pack without turning the monitoring stack into the system that performs the recovery itself. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the retry and backfill procedures.
+These checks stay intentionally small. They give operators one repeatable evidence pack without turning the monitoring stack into the system that performs the recovery itself. The retained-host sync evidence is part of the current operational contract, not a claim that the VM should remain the permanent monitoring or orchestration anchor. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the retry and backfill procedures.
 
 ## Reading Evidence Safely
 
@@ -166,6 +168,7 @@ This keeps the public docs understandable in review while leaving live Grafana, 
 - it keeps operator monitoring separate from the rider-facing app and docs pages
 - it preserves durable monitoring evidence across restarts without turning runtime state into product data
 - it keeps alerting reviewable because dashboards, rules, and scrape config live in git
+- it keeps the monitoring boundary stable even while the hosted operator surface changes underneath it
 - it lets one `/metrics` surface describe the app-owned monitoring contract while StatsD handles Evidently drift export
 
 See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Feature Pipeline](feature-pipeline.md), and [Getting Started](../getting-started.md) for the surrounding system and local operator path.

--- a/docs/site/system/training-pipeline.md
+++ b/docs/site/system/training-pipeline.md
@@ -1,14 +1,14 @@
 # Training Pipeline
 
-FoehnCast keeps training downstream from the curated feature store. The same training contract runs in the local evaluator and in the active shared environment: the training path reads stored curated rows, rebuilds schema-derived features when needed, generates synthetic rideability labels, trains the configured regressor, writes evaluation evidence, and registers a versioned model in MLflow without pushing training concerns back into the feature pipeline.
+FoehnCast keeps training downstream from the curated feature store. The same training contract runs in the local evaluator and in the current shared hosted environment: the training path reads stored curated rows, rebuilds schema-derived features when needed, generates synthetic rideability labels, trains the configured regressor, writes evaluation evidence, and registers a versioned model in MLflow without pushing training concerns back into the feature pipeline. The surrounding hosted orchestration surface is transitional, but the training contract itself stays the same.
 
 This page records the current training design that is validated in the local stack and in regression tests. It focuses on what each stage owns today and what remains an explicit operator control rather than an automatic side effect.
 
 !!! note "Scope"
 
     This page describes the current validated training-path contract.
-    It is not a roadmap.
-    Future changes should be documented after they are chosen and implemented.
+    It focuses on what the training path owns, not on the hosted control-plane migration.
+    The target hosted direction may change where orchestration runs, but it does not change the training contract described here.
 
 ## Pipeline Shape
 
@@ -37,7 +37,7 @@ The key point is that the training path stays explicit:
 | Runtime mode | Training role today |
 |------|---------------------|
 | Local evaluator | local Airflow and MLflow run labeling, training, evaluation, and registration |
-| Active shared environment | the hosted full-stack target runs the same Airflow and MLflow contract online |
+| Active shared environment | the current hosted full-stack target runs the same Airflow and MLflow contract online while the managed hosted control plane is still transitional |
 | Hosted inference target | serves a registered alias; it does not run training |
 
 ## Stage Responsibilities
@@ -124,6 +124,8 @@ That hand-off matters because it keeps the orchestration boundary visible:
 
 This makes the Airflow Assets view reflect the real dependency graph between curated feature persistence, training, evaluation, and registration.
 
+In the shared hosted path today, those Airflow-owned steps still run on the retained operator lane. The target hosted orchestrator is Cloud Composer, but that change should preserve the same training-stage ownership and evidence boundaries.
+
 ## Alias Controls Outside The DAG
 
 Promotion and rollback are explicit controls layered on top of the registry aliases, not hidden inside normal training.
@@ -142,5 +144,6 @@ That separation is deliberate. Training can succeed without immediately changing
 - it preserves reviewable evidence through MLflow runs and markdown evaluation reports
 - it keeps candidate and champion semantics explicit in the registry rather than buried in deployment scripts
 - it makes automatic retraining visible in Airflow through asset hand-offs instead of opaque trigger chains
+- it keeps the training contract stable even while the hosted orchestration surface is being simplified
 
 See [Architecture](architecture.md), [Feature Pipeline](feature-pipeline.md), [Monitoring](monitoring.md), and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the surrounding system boundaries.


### PR DESCRIPTION
### What Changed

- updated nine system pages so the hosted GCP story separates current, transitional, and target runtime surfaces
- clarified that Cloud Run remains the public API lane while the retained operator host is current but transitional
- made Cloud Build and Cloud Composer the explicit managed hosted direction without changing the underlying serving, training, monitoring, or configuration contracts

### Why

- the system pages should describe the working hosted path accurately without presenting the retained host as the desired long-term architecture
- the current-versus-target boundary needs to stay clear before later Cloud Build and Composer migration work

### Verification

- `PATH=/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin:$PATH PYTHONPATH=$PWD/src mkdocs build -f docs/mkdocs.yml --strict`

### Closes

- Closes #221
