### PR TITLE
docs(site): simplify Mermaid diagrams across docs and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,12 @@ The repo keeps the same Feature-Training-Inference split across local runs, host
 
 ```mermaid
 flowchart LR
-    Forecasts[Forecast APIs] --> Features[Feature pipeline]
-    Features --> Curated[Curated features]
-    Curated --> Training[Training pipeline]
-    Training --> Registry[MLflow registry]
-    Registry --> API[FastAPI predict and rank API]
-    Forecasts --> API
-    Drive[OSRM drive times] --> API
-    Curated --> Feast[Feast serving layer]
-    Feast --> API
+  Forecasts[Forecast APIs] -->|Feature path| Curated[Curated features]
+  Curated -->|Training path| Registry[MLflow registry]
+  Curated --> Feast[Feast layer]
+  Inputs[Forecast + OSRM] --> API[FastAPI API]
+  Feast --> API
+  Registry --> API
 ```
 
 ## Current Scope
@@ -35,25 +32,19 @@ flowchart LR
 FoehnCast has one supported contributor setup path: run everything locally with Docker. The shared cloud path is a separate maintainer workflow.
 
 ```mermaid
-flowchart TB
-  subgraph Contributor[Contributor path]
-    Clone[Clone repo]
-    Local[./scripts/bootstrap-local.sh]
-    Compose[Local evaluator stack]
+flowchart LR
+  subgraph Contributor[Contributor lane]
+    direction TB
+    Local[Clone + bootstrap-local.sh] --> Compose[Local stack]
   end
 
-  subgraph Maintainer[Maintainer path]
-    Shell[Google Cloud Shell]
-    Bootstrap[./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions]
-    Cloud[GitHub Actions + remote Terraform]
-    Host[Hosted full-stack control plane]
-    Run[Primary Cloud Run API]
+  subgraph Maintainer[Maintainer lane]
+    direction LR
+    Shell[Cloud Shell + bootstrap-gcp.sh] --> Release[Actions + remote TF]
   end
 
-  Clone --> Local --> Compose
-  Shell --> Bootstrap --> Cloud
-  Cloud --> Host
-  Cloud --> Run
+  Release --> Host[Hosted ops]
+  Release --> Run[Cloud Run API]
 ```
 
 ## Quick Start

--- a/containers/README.md
+++ b/containers/README.md
@@ -5,25 +5,30 @@ This directory holds the service definitions used by the validated local stack a
 ## Container Stack In One View
 
 ```mermaid
-flowchart LR
-	subgraph Shared[Shared runtime services]
-		Airflow[Airflow services]
+flowchart TD
+	subgraph Shared[Shared runtime]
+		direction TB
+		Airflow[Airflow]
+		Feature[Feature DAGs]
 		MLflow[MLflow]
 		API[FastAPI app]
-		Monitor[Prometheus + StatsD exporter + Grafana]
+		Monitor[Monitoring]
+		Airflow --> Feature
+		MLflow --> API --> Monitor
 	end
-	subgraph LocalOnly[Local-only services]
-		Dev[optional development_env]
+
+	subgraph LocalOnly[Local add-ons]
+		direction TB
+		Dev[Dev shell]
 		Objectstore[MinIO]
-		Emulator[Feast Datastore emulator]
+		Emulator[Feast emulator]
+		Checks[Local checks]
+		Dev --> Checks
 	end
-	Airflow --> Feature[Feature and training DAGs]
-	MLflow --> API
+
 	Objectstore --> Airflow
 	Objectstore --> API
 	Emulator --> API
-	API --> Monitor
-	Dev --> Tests[Local tools and tests]
 ```
 
 ## Runtime Role

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -35,6 +35,11 @@ markdown_extensions:
   - def_list
   - md_in_html
   - tables
+  - pymdownx.emoji:
+      # yaml-language-server-disable Unresolved tag
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      # yaml-language-server-disable Unresolved tag
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.details
   - pymdownx.highlight:
       anchor_linenums: true
@@ -49,6 +54,7 @@ plugins:
 nav:
   - Home: index.md
   - Overview:
+      - Overview: overview.md
       - Getting Started: getting-started.md
       - Use Case and Data: system/use-case.md
       - Repository: system/repository.md

--- a/docs/site/assets/javascripts/mermaid.js
+++ b/docs/site/assets/javascripts/mermaid.js
@@ -2,6 +2,7 @@
     const MERMAID_MODULE_URL = "https://unpkg.com/mermaid@10.4.0/dist/mermaid.esm.min.mjs";
     const MERMAID_CONFIG = {
         startOnLoad: false,
+        htmlLabels: true,
         securityLevel: "loose",
         theme: "neutral",
     };
@@ -42,6 +43,43 @@
         });
     }
 
+    function parseSvgNumber(value) {
+        const number = Number.parseFloat(value || "0");
+        return Number.isFinite(number) ? number : 0;
+    }
+
+    function adjustClusterLabels(root) {
+        for (const svg of root.querySelectorAll(".mermaid svg")) {
+            for (const cluster of svg.querySelectorAll("g.cluster")) {
+                const rect = cluster.querySelector("rect");
+                const label = cluster.querySelector("g.cluster-label");
+                const foreignObject = label?.querySelector("foreignObject");
+                const container = foreignObject?.firstElementChild;
+                const nodeLabel = container?.querySelector(".nodeLabel");
+
+                if (!rect || !label || !foreignObject || !container || !nodeLabel) {
+                    continue;
+                }
+
+                const rectX = parseSvgNumber(rect.getAttribute("x"));
+                const rectY = parseSvgNumber(rect.getAttribute("y"));
+                const rectWidth = parseSvgNumber(rect.getAttribute("width"));
+                const padding = Math.max(10, Math.min(18, rectWidth * 0.05));
+                const labelWidth = Math.max(48, rectWidth - (padding * 2));
+
+                label.setAttribute("transform", `translate(${rectX + padding}, ${rectY})`);
+                foreignObject.setAttribute("width", String(labelWidth));
+                container.style.display = "block";
+                container.style.width = `${labelWidth}px`;
+                container.style.whiteSpace = "nowrap";
+                container.style.textAlign = "left";
+                nodeLabel.style.display = "block";
+                nodeLabel.style.width = "100%";
+                nodeLabel.style.textAlign = "left";
+            }
+        }
+    }
+
     async function renderMermaid(root) {
         const nodes = findPendingDiagrams(root);
         if (!nodes.length) {
@@ -51,6 +89,7 @@
         const mermaid = await loadMermaid();
         mermaid.initialize(MERMAID_CONFIG);
         await mermaid.run({ nodes });
+        adjustClusterLabels(root);
     }
 
     function scheduleRender(root) {

--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -2,9 +2,9 @@
 
 This page keeps setup intentionally simple. The supported contributor path is the local evaluator flow with Docker. The shared cloud path is maintainer-only and documented separately.
 
-## Local Evaluator
+## Default Path
 
-This is the default path for a fresh machine.
+This is the default path for almost every reader.
 
 1. Install Docker.
 2. Clone the repository.
@@ -12,26 +12,30 @@ This is the default path for a fresh machine.
 
 You do not need `gcloud`, Terraform, GitHub Actions variables, or a local compiler toolchain for this path.
 
-The local evaluator path bundles MinIO for curated features and MLflow artifacts, the Datastore-mode emulator for Feast online serving, and the checked-in Prometheus, StatsD exporter, and Grafana stack. The bootstrap waits for the feature-to-training hand-off, verifies Grafana starter resources, and prints alternate endpoints automatically if the default ports are already busy. The optional `development_env` notebook container stays off unless you explicitly target notebook or dev-shell commands. See [Local Evaluator](system/local-evaluator.md) for the full runtime contract.
+<div class="mermaid">
+flowchart TD
+  DOCKER["fab:fa-docker Docker"] --> BOOT["./scripts/bootstrap-local.sh"]
+  BOOT --> APP["FastAPI app"]
+  BOOT --> AIR["Airflow"]
+  BOOT --> MLF["MLflow"]
+  BOOT --> MON["Prometheus + Grafana"]
+  BOOT --> DATA["MinIO + Feast emulator"]
+</div>
 
-If you maintain the shared cloud environment, use [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md). Contributors do not need the cloud path for normal work.
+The bootstrap starts the local evaluator stack, waits for the feature-to-training hand-off, verifies starter monitoring resources, and prints alternate endpoints when default ports are busy. The optional `development_env` container stays off unless you explicitly ask for notebook or dev-shell workflows. See [Local Evaluator](system/local-evaluator.md) for the full runtime contract.
 
-## Surface Roles
+## Local Endpoints
 
-The local stack still keeps the same surface split as the wider docs: Streamlit and prediction responses are rider-facing evaluation surfaces, FastAPI routes are service surfaces, and `/metrics`, Prometheus, Grafana, Airflow, and MLflow stay on the operator side. The bootstrap also keeps retained monitoring history under `.state/monitoring/`, republishes persisted pipeline summaries through `/metrics`, and verifies the Airflow health payload plus Grafana provisioning before it reports success. For the full surface boundary, use [Interfaces and Surfaces](system/interfaces-and-surfaces.md).
+| Surface | URL | Role |
+|------|-----|------|
+| App | `http://127.0.0.1:8000` | service surface for health, prediction, and ranking |
+| App metrics | `http://127.0.0.1:8000/metrics` | service-owned monitoring surface |
+| Airflow | `http://127.0.0.1:8080` | operator surface for orchestration |
+| MLflow | `http://127.0.0.1:5001` | operator surface for runs and model versions |
+| Prometheus | `http://127.0.0.1:9090` | operator surface for scraped metrics |
+| Grafana | `http://127.0.0.1:3000` | operator surface for dashboards and alerts |
 
-After bootstrap completes, the main local endpoints are:
-
-- App: `http://127.0.0.1:8000`
-- App metrics: `http://127.0.0.1:8000/metrics`
-- Airflow: `http://127.0.0.1:8080`
-- MLflow: `http://127.0.0.1:5001`
-- Prometheus: `http://127.0.0.1:9090`
-- Grafana: `http://127.0.0.1:3000`
-- Objectstore UI: printed by the bootstrap helper when the stack comes up
-- Feast online store emulator: printed by the bootstrap helper when the stack comes up
-
-The app and app-metrics routes are service surfaces. Airflow, MLflow, Prometheus, and Grafana are operator surfaces in this local evaluator path.
+The objectstore UI and the Feast emulator endpoint are printed by the bootstrap helper when the stack comes up. For the full surface boundary, use [Interfaces and Surfaces](system/interfaces-and-surfaces.md).
 
 Example check:
 
@@ -41,40 +45,14 @@ curl -fsS -X POST http://127.0.0.1:8000/rank \
   -d '{"spot_ids":["silvaplana","urnersee"]}'
 ```
 
-## Shared Cloud Automation
+## Maintainer Path
 
-The shared hosted environment is maintained separately from normal contributor setup. Contributors only need Docker and the local evaluator bootstrap, not local Terraform, `gcloud`, or `gh`. Maintainers should start with [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md) for the bootstrap and remote Terraform path, and use `terraform/README.md` only when maintaining the shared cloud environment.
+Most contributors can stop at the local evaluator path. If you maintain the shared cloud environment, start with [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md). The cloud path stays separate from the default contributor path and does not belong in the first-run setup.
 
-Hosted deployment keeps the runtime scope tight. The cloud targets deploy runtime services only; `development_env`, notebooks, docs build tooling, the local objectstore, and the local Datastore emulator stay local or CI-only.
-
-## What Lives Where
-
-See [Repository](system/repository.md) for the dedicated layout guide. The short version is: `src/foehncast/` holds the application code, `dags/` holds Airflow entry points, `scripts/` and `terraform/` hold maintainer tooling, and `docs/` plus `tests/` hold the public docs and regression coverage.
+Hosted deployment keeps the runtime scope tight. Runtime services deploy to the cloud path. Local notebooks, docs tooling, and local emulators stay local or CI-only.
 
 ## Read Next
 
-### Overview
-
-- [Use Case and Data](system/use-case.md)
-- [Repository](system/repository.md)
-- [Configuration and Contracts](system/configuration-and-contracts.md)
-- [Interfaces and Surfaces](system/interfaces-and-surfaces.md)
-
-### Runtime and Deployment
-
-- [Architecture](system/architecture.md)
-- [Local Evaluator](system/local-evaluator.md)
-- [Hosted Full-Stack](system/hosted-full-stack.md)
-- [Cloud Mapping](system/cloud-mapping.md)
-- [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md)
-
-### Pipelines and Modeling
-
-- [Feature Pipeline](system/feature-pipeline.md)
-- [Training Pipeline](system/training-pipeline.md)
-- [Inference Pipeline](system/inference-pipeline.md)
-- [Seasonality](system/seasonality.md)
-
-### Operations
-
-- [Monitoring](system/monitoring.md)
+- [Local Evaluator](system/local-evaluator.md) for the full local runtime contract.
+- [Interfaces and Surfaces](system/interfaces-and-surfaces.md) for rider, service, and operator boundaries.
+- [Repository](system/repository.md) for the project layout.

--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -2,88 +2,62 @@
 
 FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live weather forecasts, engineered wind features, drive-time information, and a trained quality model. Use the repository README for the short summary. Use this site for setup help, product scope, runtime notes, and operator guidance.
 
-The default contributor path stays local with Docker. The shared cloud path is maintainer-owned and documented separately. Surface boundaries also stay explicit here: rider demos and service routes explain the product, while operator dashboards stay private and public docs rely on rendered evidence instead of live control-plane embeds.
-
-## Start Here
-
-| Need | Read this |
-|------|-----------|
-| Run the project locally with the default evaluator workflow | [Getting Started](getting-started.md) |
-| Maintain the shared cloud environment or understand the setup split | [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md) |
-| Understand what stays in package config versus runtime wiring | [Configuration and Contracts](system/configuration-and-contracts.md) |
-| Understand which routes and tools are rider-facing, service-only, or operator-only | [Interfaces and Surfaces](system/interfaces-and-surfaces.md) |
-| Understand the Feature-Training-Inference split | [Architecture](system/architecture.md) |
-| See how the hosted path maps onto GCP | [Cloud Mapping](system/cloud-mapping.md) |
-| Understand the main code and folder layout | [Repository](system/repository.md) |
-| Understand the rider scope and data inputs | [Use Case and Data](system/use-case.md) |
-
-## Operating Model
-
-| Mode | Who runs it | Purpose |
-|------|-------------|---------|
-| Local stack | Any reader or contributor | Development, evaluation, and reproducible validation |
-| Shared cloud environment | Repository maintainer or fork owner after one-time bootstrap | Maintainer-owned hosted runtime and operator stack |
-| GitHub automation | Repository maintainer or fork owner after bootstrap | Image publishing, Terraform workflows, and docs publishing |
-
-Public images are convenience artifacts, not a shared hosting promise. If you want a running online environment, deploy it in infrastructure you control.
-
-## Surface Guide
-
-Use rider demos and API examples to explain the product surface. Use rendered artifacts or screenshots to explain operations in public docs. Keep live operator dashboards private unless you are intentionally running your own environment. For the full audience and exposure breakdown, use [Interfaces and Surfaces](system/interfaces-and-surfaces.md).
-
-## System In One View
+## Product In One View
 
 <div class="mermaid">
 flowchart LR
-    OME[Open-Meteo forecast] --> FEAT[Feature DAG]
-    FEAT --> PAR[(Curated features)]
-    PAR --> TRAIN[Training DAG]
-    TRAIN --> MLF[(MLflow registry)]
-
-    OME --> APP[FastAPI app]
-    OSRM[OSRM drive times] --> APP
-    MLF --> APP
-    APP --> API[Predict and rank endpoints]
-
-    PAR --> FEAST[(Feast serving layer)]
-    FEAST --> APP
+    WX[Forecast + spot context] --> RANK[Rank session options]
+    RIDER[Rider + drive context] --> RANK
+    RANK --> DECIDE[Choose where to ride next]
 </div>
 
-## Current Status
+## Main Capabilities
 
-| Area | Status | Meaning |
-|------|--------|---------|
-| Feature pipeline | Working | The feature DAG ingests, engineers, validates, and stores curated weather features |
-| Training pipeline | Working | The training DAG labels data, trains the model, evaluates it, and registers fresh versions in MLflow under the requested registry alias |
-| Inference pipeline | Working | The app serves the model-backed API routes used for health, prediction, and ranking |
-| Hosted runtime | Working | The maintainer-owned hosted runtime follows the documented public-API and operator-surface split |
-| CI/CD | Working | GitHub Actions validates docs and infrastructure and supports remote Terraform operations |
+<div class="grid cards fc-feature-grid" markdown>
 
-## Documentation Map
+- **Rank the next session**
 
-### Overview
+    Compare a fixed set of Swiss lake spots instead of browsing a generic forecast map.
 
-- [Getting Started](getting-started.md): choose the right setup path and run the first commands.
-- [Use Case and Data](system/use-case.md): the rider profile, spot set, and data sources behind the ranking.
-- [Repository](system/repository.md): where the code, orchestration, tests, docs, and demo live.
-- [Configuration and Contracts](system/configuration-and-contracts.md): what belongs in `config.yaml`, what runtime env resolves, and what infrastructure keeps outside the package.
-- [Interfaces and Surfaces](system/interfaces-and-surfaces.md): which screens, routes, dashboards, and docs belong to riders, services, operators, or public review.
+- **Personalize the choice**
 
-### Runtime and Deployment
+    Combine weather, rider profile, spot context, and drive time in one ranking decision.
 
-- [Architecture](system/architecture.md): the stable Feature-Training-Inference split and runtime surfaces.
-- [Local Evaluator](system/local-evaluator.md): the default local runtime contract for contributors.
-- [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md): the maintainer path for shared cloud bootstrap and day-2 delivery.
-- [Hosted Full-Stack](system/hosted-full-stack.md): the active shared hosted runtime target and sync contract.
-- [Cloud Mapping](system/cloud-mapping.md): how local boundaries map onto hosted storage and runtime choices.
+- **Serve the same product through code and UI**
 
-### Pipelines and Modeling
+    Expose the model through API routes and rider-facing demo surfaces built on the same inference path.
 
-- [Feature Pipeline](system/feature-pipeline.md): how data moves from forecast ingestion to curated features.
-- [Training Pipeline](system/training-pipeline.md): how labeled data becomes a registered serving model.
-- [Inference Pipeline](system/inference-pipeline.md): how prediction, ranking, and online feature lookup are served.
-- [Seasonality](system/seasonality.md): how cyclical time features capture recurring daily and yearly structure.
+- **Keep the system reproducible**
 
-### Operations
+    Separate feature, training, and inference so local validation and deployment share the same core design.
 
-- [Monitoring](system/monitoring.md): how Prometheus, Grafana, alerts, and runtime evidence stay on the operator side.
+</div>
+
+## System Flow
+
+<div class="mermaid">
+flowchart LR
+    INGEST[Ingest forecasts] --> FEATURES[Build curated features] --> TRAIN[Train and register model] --> SERVE[Serve prediction and ranking]
+</div>
+
+## Read Next
+
+<div class="grid cards" markdown>
+
+- **Overview**
+
+    Read [Overview](overview.md) for the documentation map, the shared system core, and the local-versus-cloud split.
+
+- **Getting Started**
+
+    Read [Getting Started](getting-started.md) for the default local evaluator path.
+
+- **Use Case and Data**
+
+    Read [Use Case and Data](system/use-case.md) for the rider scope, spots, and inputs.
+
+- **Architecture**
+
+    Read [Architecture](system/architecture.md) for the feature, training, and inference boundaries.
+
+</div>

--- a/docs/site/overview.md
+++ b/docs/site/overview.md
@@ -1,0 +1,111 @@
+# Overview
+
+FoehnCast is a local-first ML system for deciding where to kite next. This page explains how the system is organized, how the docs are split, and where local and cloud designs stay the same or differ.
+
+## Shared System Core
+
+<div class="mermaid">
+flowchart LR
+  %% Branded colors
+  classDef app fill:#222,stroke:#333,color:#fff
+  classDef data fill:#ececff,stroke:#9370db,color:#000
+  classDef pipeline fill:#e1f5fe,stroke:#01579b,color:#000
+  classDef registry fill:#fff,stroke:#d32f2f,color:#000
+
+  DATA["Raw Forecasts"]:::data
+
+  subgraph BuildPath ["Build path"]
+    direction TB
+    FEAT["Feature Pipeline"]:::pipeline
+    CURATED["Curated Features"]:::data
+    TRAIN["Training Pipeline"]:::pipeline
+    REG["MLflow Registry"]:::registry
+    FEAT --> CURATED --> TRAIN --> REG
+  end
+
+  subgraph ServePath ["Serving path"]
+    direction TB
+    SERVE["FastAPI App"]:::app
+    RANK["Ranked Sessions"]:::data
+    SERVE --> RANK
+  end
+
+  DATA --> FEAT
+  CURATED --> SERVE
+  REG --> SERVE
+</div>
+
+The core design stays stable across runtimes. FoehnCast collects weather data, builds curated features, trains and registers a model, and serves ranked session options through the application layer.
+
+## Local And Cloud In One View
+
+<div class="mermaid">
+flowchart TD
+  %% Style definitions
+  classDef shared fill:#f5f5f5,stroke:#333,stroke-dasharray: 5 5
+  classDef local fill:#e1f5fe,stroke:#01579b
+  classDef cloud fill:#fff8e1,stroke:#f57f17
+
+  CORE["Shared ML core"]:::shared
+
+  subgraph LocalStack ["fab:fa-docker Local lane"]
+    direction LR
+    LOPS["Airflow + MLflow + monitoring"]:::local
+    LAPP["MinIO + Feast + FastAPI"]:::local
+  end
+
+  subgraph CloudStack ["fab:fa-google Cloud lane"]
+    direction LR
+    CDATA["BigQuery + GCS + Datastore"]:::cloud
+    CAPI["Cloud Run public API"]:::cloud
+    COPS["Private operator lane"]:::cloud
+  end
+
+  CORE --> LocalStack
+  CORE --> CloudStack
+  LOPS --> LAPP
+  CDATA --> CAPI
+  CDATA --> COPS
+</div>
+
+<div class="fc-compare-note">
+The common components matter more than the hosting details. Comparison pages should show the shared core first, then the deployment-specific differences.
+</div>
+
+## Read The Docs In This Order
+
+1. [Use Case and Data](system/use-case.md) explains the rider problem, spot scope, and inputs.
+2. [Getting Started](getting-started.md) gets the local evaluator running.
+3. [Architecture](system/architecture.md) shows the stable system boundaries.
+4. [Feature Pipeline](system/feature-pipeline.md), [Training Pipeline](system/training-pipeline.md), and [Inference Pipeline](system/inference-pipeline.md) explain the three main flows.
+5. [Interfaces and Surfaces](system/interfaces-and-surfaces.md), [Monitoring](system/monitoring.md), and [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md) explain exposure, operations, and delivery.
+
+## Documentation Map
+
+<div class="grid cards" markdown>
+
+- **Product scope**
+
+  Use [Use Case and Data](system/use-case.md) for the rider story, the fixed spot set, and the data inputs.
+
+- **Local-first setup**
+
+  Use [Getting Started](getting-started.md) and [Local Evaluator](system/local-evaluator.md) for the default contributor path.
+
+- **System design**
+
+  Use [Architecture](system/architecture.md), [Configuration and Contracts](system/configuration-and-contracts.md), and [Interfaces and Surfaces](system/interfaces-and-surfaces.md) for the stable design rules.
+
+- **Deployment comparison**
+
+  Use [Hosted Full-Stack](system/hosted-full-stack.md), [Cloud Mapping](system/cloud-mapping.md), and [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md) when comparing local and cloud responsibilities.
+
+- **Pipelines**
+
+  Use [Feature Pipeline](system/feature-pipeline.md), [Training Pipeline](system/training-pipeline.md), and [Inference Pipeline](system/inference-pipeline.md) for the execution flow.
+
+- **Operations**
+
+  Use [Monitoring](system/monitoring.md) for metrics, alerts, and evidence.
+
+</div>

--- a/docs/site/stylesheets/extra.css
+++ b/docs/site/stylesheets/extra.css
@@ -1,3 +1,5 @@
+@import url("https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css");
+
 :root {
     --fc-accent: #0f766e;
     --fc-accent-soft: #e6f4f1;
@@ -67,6 +69,48 @@
     max-width: 100%;
 }
 
-.md-sidebar--primary .md-nav--primary > .md-nav__list > .md-nav__item + .md-nav__item {
+.md-typeset .mermaid .cluster-label foreignObject {
+    overflow: visible;
+}
+
+.md-typeset .mermaid .cluster-label div,
+.md-typeset .mermaid .cluster-label .nodeLabel {
+    width: 100%;
+    text-align: left;
+}
+
+.md-typeset .mermaid .cluster-label .nodeLabel {
+    display: block;
+    padding-left: 0.15rem;
+}
+
+.md-typeset .fc-feature-grid {
+    margin-top: 1rem;
+}
+
+.md-typeset .fc-feature-grid .twemoji {
+    display: block;
+    width: 2.2rem;
+    height: 2.2rem;
+    margin: 0 auto 0.8rem;
+    color: var(--fc-accent);
+}
+
+.md-typeset .fc-feature-grid p {
+    text-align: center;
+}
+
+.md-typeset .fc-feature-grid strong {
+    display: inline-block;
+    margin-bottom: 0.2rem;
+}
+
+.md-typeset .fc-compare-note {
+    border-left: 3px solid rgba(15, 118, 110, 0.3);
+    padding-left: 1rem;
+    margin: 1rem 0;
+}
+
+.md-sidebar--primary .md-nav--primary>.md-nav__list>.md-nav__item+.md-nav__item {
     margin-top: 0.45rem;
 }

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -1,162 +1,223 @@
 # Architecture
 
-FoehnCast keeps the same Feature-Training-Inference split in every runtime mode. What changes is the supporting delivery and operator lane around that split. Today the shared cloud path has a public API lane on Cloud Run and a private operator lane on a retained host. That operator lane is transitional while hosted image builds move toward Cloud Build and hosted orchestration moves toward Cloud Composer.
+FoehnCast keeps the same Feature-Training-Inference split in every runtime. The cloud path adds a public API lane on Cloud Run and a private operator lane for Airflow, MLflow, monitoring, and private app checks. In the active shared environment that operator lane is implemented on a retained host, while image builds move to Cloud Build and orchestration moves to Cloud Composer.
 
 !!! note "How to read this page"
 
-    The validated baseline is the local Compose stack.
-    The shared cloud path today splits into a public API lane on Cloud Run and a private retained operator lane.
-    The intended hosted direction keeps Cloud Run as the public API, moves hosted image builds to Cloud Build, and moves hosted orchestration to Cloud Composer.
-    The hosted paths use the same feature, training, and inference modules, but move storage, auth, and runtime services onto GCP in different ways.
-    The rider-facing demo and prediction outputs are not the same thing as operator dashboards, and Grafana is not treated as the main product UI.
+    Start with the local Compose stack.
+    In the cloud, Cloud Run is the public API lane.
+    The retained host is the active implementation of the private operator lane.
+    The target hosted direction keeps Cloud Run and moves build and orchestration into managed services.
+    Rider-facing screens are separate from operator dashboards.
 
 ## System In One View
 
 <div class="mermaid">
 flowchart LR
-    subgraph Feature[Feature pipeline]
-        ING[Ingest forecasts]
-        ENG[Engineer features]
-        VAL[Validate rows]
-        STO[Store curated features]
-        ING --> ENG --> VAL --> STO
+    %% Styling
+    classDef cloud fill:#f5f5f5,stroke:#333
+    classDef pipe fill:#e1f5fe,stroke:#01579b
+    classDef store fill:#ececff,stroke:#9370db
+    classDef app fill:#222,stroke:#333,color:#fff
+
+    EXT["External inputs"]:::cloud
+
+    subgraph FeatureP ["Feature path"]
+        direction TB
+        ING[Ingest] --> ENG[Engineer] --> VAL[Validate] --> STO[Store]
     end
 
-    subgraph Training[Training pipeline]
-        LAB[Label rows]
-        TRN[Train and evaluate]
-        REG[Register in MLflow]
-        LAB --> TRN --> REG
+    subgraph TrainingP ["Training path"]
+        direction TB
+        LAB[Label] --> TRN[Train] --> EVAL[Eval] --> REG[Register]
     end
 
-    subgraph Inference[Inference pipeline]
-        API[FastAPI service]
-        RANK[Predict and rank]
-        API --> RANK
+    subgraph InferenceP ["Serving path"]
+        direction TB
+        API[API Endpoint] --> PRED[Predict] --> RANK[Rank]
     end
 
+    FEAST["Feast layer"]:::store
+    MLF["Registry"]:::store
+
+    EXT --> ING
     STO --> LAB
-    REG --> API
-    OME[Open-Meteo] --> ING
-    OME --> API
-    OSRM[OSRM] --> API
-    STO --> FEAST[Feast serving layer]
+    STO --> FEAST
+    REG --> MLF
+
     FEAST --> API
+    MLF --> API
+    EXT --> API
 </div>
 
 ## Surface Boundaries
 
 See [Interfaces and Surfaces](interfaces-and-surfaces.md) for the dedicated public overview of this boundary.
 
-| Surface class | Primary audience | Exposure | Current examples |
+| Surface class | Primary audience | Exposure | Example surfaces |
 |------|------------------|----------|------------------|
 | Rider-facing demo surface | rider, reviewer, contributor | public-safe when shown as screenshots or rendered examples | Streamlit rider console and the online-features demo page |
 | Service endpoints | clients, smoke tests, support services | service-only | `/health`, `/spots`, `/predict`, `/rank`, `/features/online`, and `/metrics` |
 | Operator dashboards and control planes | maintainer or deployment operator | internal-only by default | Airflow, MLflow, Prometheus, and Grafana |
 | Public docs and rendered evidence | course reviewer, fork reader, maintainer | public-safe | docs pages, evaluation markdown, summary JSON-derived charts, and screenshots |
 
-Grafana stays on the operator side of that boundary. The rider-facing experience is the ranking and demo surface served from the application layer. Public docs should therefore show rendered evidence or screenshots rather than live iframe embeds of private operational dashboards.
+Grafana stays on the operator side. The rider-facing experience comes from the app layer. Public docs should therefore show rendered evidence or screenshots, not live embeds of private dashboards.
 
 ## Runtime Lanes
 
-| Lane | Current target | State | Main role | Exposure |
+| Lane | Concrete target | State | Main role | Exposure |
 |------|----------------|-------|-----------|----------|
 | Local evaluator lane | local Compose stack | stable baseline | validate the full system on one machine | local-only |
 | Shared API lane | hosted inference target on Cloud Run | active hosted target | serve the shared FastAPI product and service routes | public |
-| Operator lane | hosted full-stack target on one GCP host | active but transitional | keep Airflow, MLflow, monitoring, and private app checks online while the hosted control plane is simplified | private by default |
+| Operator lane | hosted full-stack target on one GCP host | implemented on retained host | provide the private operator surface for Airflow, MLflow, monitoring, and private app checks | private by default |
 
 ## Stable Pipeline Boundaries
 
-| Layer | Responsibility | Current runtime surface |
+| Layer | Responsibility | Representative runtime surface |
 |------|----------------|-------------------------|
 | Feature pipeline | Collect data, engineer curated rows, validate them, and store the result | local Airflow DAG plus the configured storage backend |
 | Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
 | Inference pipeline | Serve health, predict, rank, and spot-list responses | FastAPI app container |
-| Orchestration | Schedule runtime DAGs, retries, backfills, and operator inspection | local Airflow today; retained-host Airflow today; Cloud Composer is the target hosted orchestrator |
+| Orchestration | Schedule runtime DAGs, retries, backfills, and operator inspection | local Airflow in the local evaluator; retained-host Airflow in the active shared environment; Cloud Composer is the target hosted orchestrator |
 | Online features | Surface curated fields through an online lookup route | Feast-backed service path plus demo page |
 | Monitoring | Scrape runtime metrics, collect pushed gauges, and visualize starter alerts | Prometheus, StatsD exporter, and Grafana operator stack |
 
-The orchestration layer now models the main data products as Airflow assets instead of only sequencing opaque tasks. In the validated local stack, the feature DAG publishes curated-feature, Feast-sync, and training-request assets, and the training DAG consumes the training request and emits MLflow training, evaluation, and registry assets.
+The orchestration layer models the main data products as Airflow assets. In the validated local stack, the feature DAG publishes curated-feature, Feast-sync, and training-request assets. The training DAG consumes the training request and emits MLflow training, evaluation, and registry assets.
 
 ## Deployment Targets
 
 <div class="mermaid">
 flowchart LR
-    CORE[Shared Feature-Training-Inference boundaries]
-    CORE --> LOCAL[Local evaluator target]
-    CORE --> HOST[Operator host lane]
-    CORE --> RUN[Cloud Run API lane]
+    classDef core fill:#f5f5f5,stroke:#333
+    classDef local fill:#e1f5fe,stroke:#01579b
+    classDef cloud fill:#fff8e1,stroke:#f57f17
+
+    CORE["Shared pipeline boundaries"]:::core
+
+    subgraph LocalTarget ["fab:fa-docker Local lane"]
+        direction TB
+        LFLOW["Airflow + MLflow + app"]:::local
+        LDATA["MinIO + Feast + metrics"]:::local
+    end
+
+    subgraph HostedTargets ["fab:fa-google Hosted lanes"]
+        direction TB
+        RUN["Cloud Run API"]:::cloud
+        HOST["Operator lane"]:::cloud
+        MGD["Managed plane"]:::cloud
+    end
+
+    CORE --> LocalTarget
+    CORE --> HostedTargets
 </div>
 
-| Target | Deploys | Leaves out | Primary use |
-|------|---------|------------|-------------|
-| Local evaluator target | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, Grafana, MinIO, the Feast Datastore emulator, and optional `development_env` tooling | shared GCP baseline | default development and evaluation |
-| Hosted full-stack target (transitional operator lane) | Airflow, MLflow, FastAPI, Prometheus, a StatsD exporter, and Grafana on one GCP host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | keep current operator duties online while the hosted build and orchestration contracts are cleaned up |
-| Hosted inference target (API lane) | FastAPI only, backed by shared GCP services | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | primary hosted API surface |
-| Managed hosted direction | Cloud Build for hosted runtime images and Cloud Composer for hosted Airflow workloads | VM-owned orchestration and host-built image responsibility | intended steady hosted build and orchestration path |
-| GitHub automation | review, workflow dispatch, and Terraform workflows | runtime services | shared cloud delivery control plane, not a runtime target |
+| Target | What runs | Main use |
+|------|-----------|----------|
+| Local evaluator target | Airflow, MLflow, FastAPI, Prometheus, StatsD exporter, Grafana, MinIO, Feast emulator, and optional `development_env` | default development and evaluation |
+| Hosted full-stack target | Airflow, MLflow, FastAPI, Prometheus, StatsD exporter, and Grafana on one GCP host | provide the active operator surface while the managed hosted control plane is not yet in place |
+| Hosted inference target | FastAPI only, backed by shared GCP services | primary hosted API surface |
+| Managed hosted direction | Cloud Build for runtime images and Cloud Composer for hosted Airflow workloads | intended steady hosted build and orchestration path |
+| GitHub automation | review, workflow dispatch, and Terraform workflows | shared cloud delivery control plane |
 
-The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. Cloud Run already owns the public API lane. The retained host stays private by default and is treated as a transitional operator surface, not as the desired long-term hosted control plane.
+The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. Cloud Run owns the public API lane. The retained host stays private by default and is treated as a retained operator surface, not as the long-term hosted control plane.
 
-See [Cloud Mapping](cloud-mapping.md) and [Hosted Full-Stack](hosted-full-stack.md) for the current hosted topology, the transitional retained-host contract, and the intended managed direction.
+See [Cloud Mapping](cloud-mapping.md) and [Hosted Full-Stack](hosted-full-stack.md) for the active hosted topology, the retained-host contract, and the intended managed direction.
+
+## Shared Core Vs Runtime Differences
+
+| Shared in every runtime | Local evaluator adds | Cloud path adds |
+|------|----------------------|-----------------|
+| Feature, training, and inference boundaries | one-machine validation with Airflow, MLflow, MinIO, Feast emulator, and monitoring | Cloud Run public API lane, private operator lane, and managed cloud services |
+| FastAPI product and service contract | local app routes and local evaluation surfaces | public API serving on Cloud Run and private hosted app checks |
+| Curated data, model registry, and Feast-backed feature path | local object-backed and emulator-backed support services | BigQuery, GCS, Datastore, and runtime identities |
+
+Read the left column as the stable design. Read the other columns as deployment choices around that design.
 
 ## Hosted Orchestration Direction
 
-Today the private operator lane still runs the hosted Airflow surface used for scheduling, retries, backfills, and runtime release handoff. That is the current operational contract.
+The private operator lane runs the hosted Airflow surface used for scheduling, retries, backfills, and runtime release handoff in the active shared environment. The target hosted control plane is Cloud Composer. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the active-versus-target boundary.
 
-The target hosted control plane is Cloud Composer. The managed cutover should replace host-owned Airflow responsibilities without changing the core feature, training, and inference split. The detailed current-versus-target boundary stays in [Delivery and Operator Workflow](delivery-and-operator-workflow.md).
-
-## Current Local Architecture
+## Local Evaluator Architecture
 
 <div class="mermaid">
-flowchart TD
-    OME[Open-Meteo] --> FEAT
-    FEAT --> PAR[(MinIO curated features)]
-    PAR --> TRAIN[Training DAG]
-    TRAIN --> MLF[(MLflow registry)]
+flowchart LR
+    %% Stylings
+    classDef infra fill:#f5f5f5,stroke:#333
+    classDef pipeline fill:#e1f5fe,stroke:#01579b
+    classDef registry fill:#fff,stroke:#d32f2f
+    classDef app fill:#222,stroke:#333,color:#fff
+    classDef storage fill:#fff,stroke:#9370db
+    classDef monitor fill:#fff,stroke:#f57f17
 
-    OME --> APP[FastAPI app]
-    OSRM[OSRM] --> APP
-    MLF --> APP
+    EXT["External APIs"]:::infra
 
-    PAR --> OFF[Feast offline export]
-    OFF --> FEAST[(Datastore-mode emulator)]
+    subgraph LocalStack ["fab:fa-docker Local stack"]
+        direction LR
+        FEAT["Feature DAG"]:::pipeline
+        MIN["MinIO curated store"]:::storage
+        TRAIN["Training DAG"]:::pipeline
+        MLF["MLflow registry"]:::registry
+        FEAST["Feast layer"]:::storage
+        APP["FastAPI API"]:::app
+        MON["Monitoring stack"]:::monitor
+    end
+
+    EXT --> FEAT
+    FEAT -- "Persist rows" --> MIN
+    FEAT -- "Emit request" --> TRAIN
+    MIN --> TRAIN
+    TRAIN --> MLF
+    MIN --> FEAST
     FEAST --> APP
-    APP --> MON[Prometheus + StatsD exporter + Grafana]
+    MLF --> APP
+    APP --> MON
 </div>
 
-The Airflow control plane reflects those hand-offs directly. The feature pipeline owns the curated-row and Feast-sync publication steps, then emits a training-request asset. The training pipeline is scheduled from that asset rather than a direct DAG-to-DAG trigger, so the Assets view shows the real dependency graph between feature persistence, Feast serving preparation, model training, evaluation, and registration.
+The Airflow control plane reflects those hand-offs directly. The feature pipeline owns curated-row and Feast-sync publication, then emits a training-request asset. The training pipeline starts from that asset instead of a direct DAG-to-DAG trigger, so the Assets view shows the real dependency graph between feature persistence, Feast serving preparation, model training, evaluation, and registration.
 
-## Hosted Runtime Detail Today
+## Active Hosted Runtime Detail
 
 <div class="mermaid">
 flowchart LR
-    subgraph Host[Operator host lane]
-        HAF[Airflow]
-        HML[MLflow]
-        HAPI[FastAPI]
+    classDef data fill:#ececff,stroke:#9370db
+    classDef operator fill:#fff8e1,stroke:#f57f17
+
+    subgraph DataPlane ["fab:fa-google Cloud data"]
+        direction TB
+        OPSDATA["GCS artifacts + BigQuery"]:::data
+        APPDATA["BigQuery + Datastore"]:::data
     end
-    GCS[(GCS)] --> HAF
-    GCS --> HML
-    BQ[(BigQuery curated features)] --> HAF
-    BQ --> HAPI
-    HML --> HAPI
-    DS[(Datastore online store)] --> HAPI
+
+    subgraph Host ["fab:fa-google Ops lane"]
+        direction TB
+        HOPS["Airflow + MLflow"]:::operator
+        HAPI["FastAPI app"]:::operator
+        HOPS --> HAPI
+    end
+
+    OPSDATA --> HOPS
+    APPDATA --> HAPI
 </div>
 
 <div class="mermaid">
 flowchart LR
-    subgraph Run[Cloud Run API lane]
-        RAPI[FastAPI]
+    classDef input fill:#f5f5f5,stroke:#333
+    classDef data fill:#ececff,stroke:#9370db
+    classDef serve fill:#fff8e1,stroke:#f57f17
+
+    LIVE["Forecast + drive-time inputs"]:::input
+    DATA["BigQuery + Datastore + MLflow"]:::data
+
+    subgraph Run ["fab:fa-google Cloud Run API"]
+        direction TB
+        RAPI["FastAPI app"]:::serve
     end
-    BQ2[(BigQuery curated features)] --> RAPI
-    DS2[(Datastore online store)] --> RAPI
-    MLF2[(Reachable MLflow)] --> RAPI
-    OME2[Open-Meteo] --> RAPI
-    OSRM2[OSRM] --> RAPI
+
+    LIVE --> RAPI
+    DATA --> RAPI
 </div>
 
-The hosted lanes reuse the same application boundaries, but they deploy different runtime surfaces. The first diagram shows the retained private operator lane that exists today. The second shows the public API lane on Cloud Run. The managed hosted direction changes the build and orchestration plane around those diagrams; it does not change the core pipeline split.
+The hosted lanes reuse the same application boundaries, but they deploy different runtime surfaces. The first diagram shows the retained private operator lane used in the active shared environment. The second shows the public API lane on Cloud Run. The managed hosted direction changes the build and orchestration plane around those diagrams; it does not change the core pipeline split.
 
 ## Representative Validation
 
@@ -173,7 +234,7 @@ The hosted lanes reuse the same application boundaries, but they deploy differen
 - The personalized ranking logic stays in the inference layer.
 - Feature engineering and training remain reusable across local and hosted paths.
 - Hosted changes mostly affect storage, auth, orchestration, and image delivery.
-- The retained operator lane is a support structure for the current hosted path, not the desired long-term hosted design.
+- The retained operator lane supports the active hosted path, but it is not the desired long-term hosted design.
 - Feast layers on top of the same curated features instead of splitting the design.
 
 ## Storage Contract
@@ -182,7 +243,7 @@ The hosted lanes reuse the same application boundaries, but they deploy differen
 - The local default uses MinIO-backed object storage for curated features and MLflow artifacts, plus local Feast parquet and a Datastore-mode emulator for online serving.
 - The local stack mirrors the hosted object-access layer as closely as possible without pretending BigQuery and Datastore are themselves object storage.
 - In the cloud, raw landing fits object storage, while curated features fit native BigQuery tables.
-- Retained prediction-event history is a monitoring fact store, not a rider-facing page or a substitute for live dashboards.
+- Retained prediction-event history is a monitoring fact store, not a rider-facing page or a substitute for dashboards.
 - Feast stays attached to the curated layer rather than becoming the primary ingestion or archive system.
 
 See [Use Case and Data](use-case.md) for the rider-focused problem framing, [Cloud Mapping](cloud-mapping.md) for the hosted path details, and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the contributor and maintainer rollout split.

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -1,12 +1,12 @@
 # Cloud Mapping
 
-FoehnCast keeps one public hosted lane and one private operator lane today. Cloud Run carries the shared API, while the hosted full-stack target still runs on one Compute Engine host for Airflow, MLflow, monitoring, and private app checks. That retained host is current but transitional while hosted image builds move toward Cloud Build and hosted orchestration moves toward Cloud Composer. This page maps the validated local stack onto the current and target GCP lanes without changing the core Feature-Training-Inference boundaries.
+FoehnCast has one public hosted lane and one private operator lane. Cloud Run serves the shared API. A private operator surface carries Airflow, MLflow, monitoring, and private app checks. In the active shared environment that surface is implemented by a retained Compute Engine host, while the intended managed direction moves image builds toward Cloud Build and orchestration toward Cloud Composer. This page maps the cloud lanes without changing the core Feature-Training-Inference boundaries.
 
 !!! note "What this page covers"
 
-    The shared GCP baseline and both hosted lanes already exist.
+    The shared GCP baseline defines one public API lane and one private operator lane.
     Cloud Run is the shared public API lane.
-    The hosted full-stack target is the current private operator lane.
+    The hosted full-stack target is the active implementation of the private operator lane.
     Cloud Build and Cloud Composer are the intended managed hosted direction.
 
 ## Cloud Paths In One View
@@ -18,8 +18,8 @@ FoehnCast keeps one public hosted lane and one private operator lane today. Clou
 <p>Terraform provisions APIs, Artifact Registry, GCS, BigQuery, and GitHub OIDC.</p>
 </li>
 <li>
-<p><strong>Current operator lane</strong></p>
-<p>One Compute Engine host still runs Airflow, MLflow, monitoring, and private app checks.</p>
+<p><strong>Active operator lane</strong></p>
+<p>One Compute Engine host runs Airflow, MLflow, monitoring, and private app checks in the shared environment.</p>
 </li>
 <li>
 <p><strong>Managed hosted direction</strong></p>
@@ -37,9 +37,42 @@ FoehnCast keeps one public hosted lane and one private operator lane today. Clou
 | Lane | Concrete target | State | Default exposure | Main job |
 |------|-----------------|-------|------------------|----------|
 | Shared API lane | hosted inference target on Cloud Run | active | public | serve the FastAPI product and service routes |
-| Operator lane | hosted full-stack target on Compute Engine | active but transitional | private by default | run Airflow, MLflow, monitoring, and private app checks |
+| Operator lane | hosted full-stack target on Compute Engine | implemented on retained host | private by default | provide the private operator surface for Airflow, MLflow, monitoring, and private app checks |
 | Managed hosted control plane | Cloud Build and Cloud Composer | target direction | private or platform-only | build hosted images and run hosted Airflow workloads without VM-owned orchestration |
 | Delivery lane | GitHub Actions plus Terraform plus OIDC | active review gate | not a runtime surface | publish reviewed artifacts and apply reviewed infrastructure changes |
+
+## Shared Core And Deployment Differences
+
+<div class="mermaid">
+flowchart TD
+    %% Colors
+    classDef core fill:#f5f5f5,stroke:#333
+    classDef local fill:#e1f5fe,stroke:#01579b
+    classDef cloud fill:#fff8e1,stroke:#f57f17
+
+    CORE["Shared core and pipeline boundaries"]:::core
+
+    subgraph LocalSurface ["fab:fa-docker Local lane"]
+        direction LR
+        LSUP["Airflow + MLflow + metrics"]:::local
+        LAPP["MinIO + Feast + app"]:::local
+        LSUP --> LAPP
+    end
+
+    subgraph CloudSurface ["fab:fa-google Cloud lane"]
+        direction LR
+        CDATA["BigQuery + GCS + Datastore"]:::cloud
+        CAPI["Cloud Run API"]:::cloud
+        COPS["Operator lane"]:::cloud
+        CDATA --> CAPI
+        CDATA --> COPS
+    end
+
+    CORE --> LocalSurface
+    CORE --> CloudSurface
+</div>
+
+The shared core stays the same. Local and cloud differ mainly in the support surfaces around that core.
 
 ## Mapping Principle
 
@@ -61,90 +94,129 @@ FoehnCast keeps one public hosted lane and one private operator lane today. Clou
 
 This boundary matters because the hosted app is the product and service surface. Grafana remains an operator dashboard, and public docs should prefer rendered evidence over live embeds of private hosted tools.
 
-## Current Hosted Topology
+## Active Hosted Topology
 
 <div class="mermaid">
 flowchart LR
-    TF[Terraform baseline] --> GCP[Shared GCP resources]
-    GCP --> HOST[Hosted full-stack target]
-    GCP --> RUN[Hosted inference target]
-    TF --> GH[GitHub OIDC delivery]
-    HOST --> STACK[Airflow + MLflow + API + monitoring]
-    RUN --> API[Inference API only]
-    GH --> HOST
-    GH -. app image publish .-> RUN
+    %% Styling
+    classDef infra fill:#f5f5f5,stroke:#333
+    classDef runner fill:#f4f1ea,stroke:#f05032
+    classDef platform fill:#fff,stroke:#4285F4
+    classDef operator fill:#fff8e1,stroke:#f57f17
+
+    TF["Terraform baseline"]:::infra
+    GH["fab:fa-github Delivery + OIDC"]:::runner
+
+    subgraph GCP ["fab:fa-google Hosted environment"]
+        direction TB
+        BASE["IAM + Registry + GCS + BigQuery"]:::platform
+
+        subgraph PublicLane ["API lane"]
+            RUN["Cloud Run API"]:::platform
+        end
+
+        subgraph PrivateLane ["Ops lane"]
+            HOST["Compute Engine host"]:::operator
+            OPS["Airflow + MLflow + metrics + app checks"]:::operator
+            HOST --> OPS
+        end
+
+        BASE --> RUN
+        BASE --> HOST
+    end
+
+    TF --> BASE
+    GH -- "Deploy" --> RUN
+    GH -- "Refresh" --> HOST
 </div>
 
 ## Managed Direction
 
 <div class="mermaid">
 flowchart LR
-    GH[GitHub review gate] --> CB[Cloud Build]
-    CB --> AR[Artifact Registry]
-    AR --> RUN[Cloud Run API lane]
-    TF[Terraform baseline] --> GCP[Shared GCP resources]
-    GCP --> CMP[Cloud Composer]
-    CMP --> BQ[(BigQuery curated features)]
-    CMP --> GCS[(GCS artifacts)]
+        classDef managed fill:#fff8e1,stroke:#f57f17
+        classDef git fill:#f4f1ea,stroke:#f05032
+        classDef store fill:#ececff,stroke:#9370db
+
+        GH["fab:fa-github GitHub Actions"]:::git
+
+        subgraph ManagedGCP ["fab:fa-google Managed plane"]
+            direction LR
+            CB["Cloud Build"]:::managed --> CRUN["Cloud Run API"]:::managed
+            CMP["Cloud Composer"]:::managed --> DATA["BigQuery + GCS"]:::store
+        end
+
+        GH -- "Build" --> CB
 </div>
 
-The managed direction keeps the same shared storage and API surfaces, but it changes two supporting planes: hosted image builds move into Cloud Build, and hosted orchestration moves into Cloud Composer. The retained host should then shrink to only the services that still need it.
+The managed direction keeps the same storage and API surfaces, but it changes two supporting planes: image builds move into Cloud Build, and orchestration moves into Cloud Composer. The retained host should then shrink to only the services that still need it.
 
-## What Exists Today
+## Implemented Hosted Surfaces
 
-| Surface | Deploys | Leaves out | Current state |
+| Surface | Deploys | Leaves out | Implementation status |
 |--------|---------|------------|---------------|
 | Shared GCP baseline | APIs, Artifact Registry, GCS, BigQuery, Datastore, and OIDC identities | app containers | implemented through Terraform |
-| Hosted full-stack target (operator lane) | Airflow, MLflow, and the API on one Compute Engine host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented and retained for operator control-plane duties |
+| Hosted full-stack target (operator lane) | Airflow, MLflow, and the API on one Compute Engine host | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented as the active operator surface |
 | Hosted inference target (API lane) | the FastAPI inference API on Cloud Run | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | implemented and promoted as the primary hosted API path |
 | GitHub delivery | image publishing and remote Terraform runs | runtime services | implemented and bootstrapped for the shared environment |
-| Hosted runtime image publishing | app image in Artifact Registry, other runtime images still mixed | n/a | transitional; not yet one managed build contract |
+| Hosted runtime image publishing | app image in Artifact Registry, other runtime images still mixed | n/a | partial; not yet one managed build contract |
 | BigQuery backend support | support for a BigQuery storage backend in the app | none | available in both local and hosted runtimes |
 
-The hosted targets deploy runtime services only. Development assets stay local or CI-only. Cloud Run is the only promoted public API path. The hosted full-stack target stays private by default and keeps Airflow, MLflow, Prometheus, and Grafana together on the operator side for now.
+The hosted targets deploy runtime services only. Development assets stay local or CI-only. Cloud Run is the only promoted public API path. The hosted full-stack target stays private by default and keeps Airflow, MLflow, Prometheus, and Grafana together on the operator side.
 
 ## Active Shared Deployment Path
 
-Today the shared environment keeps a stable split: Cloud Run carries the shared public API URL, one Compute Engine host stays online as the private operator lane for Airflow, MLflow, monitoring, and private app checks, and GitHub Actions plus remote Terraform advance reviewed day-2 changes after maintainer bootstrap. This is the current operational contract, not the desired end state.
+The shared environment keeps a stable split: Cloud Run carries the shared public API URL, one Compute Engine host stays online as the private operator lane for Airflow, MLflow, monitoring, and private app checks, and GitHub Actions plus remote Terraform advance reviewed day-2 changes after maintainer bootstrap. This is the active operating contract, not the desired end state.
 
-The intended hosted direction keeps Cloud Run as the public API, moves hosted image builds to Cloud Build, and moves hosted orchestration to Cloud Composer. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed current-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
+The intended hosted direction keeps Cloud Run as the public API, moves hosted image builds to Cloud Build, and moves hosted orchestration to Cloud Composer. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed active-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
 
 ## Managed Orchestration Direction
 
 Cloud Composer is the target managed orchestration direction.
 
-Before a later cutover, DAG packaging, Python dependency delivery, secret and runtime-config injection, network and API reachability, and a reviewed runtime release entry that reaches the managed Airflow surface directly still need to stop depending on the retained operator host. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed current-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
+Before a later cutover, DAG packaging, Python dependency delivery, secret and runtime-config injection, network and API reachability, and a reviewed runtime release entry that reaches the managed Airflow surface directly still need to stop depending on the retained operator host. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed active-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
 
-## Current And Target Hosted Mapping
+## Active And Target Hosted Mapping
 
-| Concern | Current hosted path | Target hosted direction |
+| Concern | Active hosted path | Target hosted direction |
 |---------|---------------------|-------------------------|
 | FastAPI app | Cloud Run API lane for shared traffic, plus the private operator lane for host-local checks | Cloud Run remains the only shared public API lane |
 | Hosted image builds | GitHub-hosted workflows publish an app image to Artifact Registry and other runtime images through a mixed path | Cloud Build publishes all hosted runtime images to Artifact Registry |
-| Airflow orchestration | retained operator lane today | Cloud Composer |
-| MLflow tracking | operator lane today with GCS-backed artifacts | stays on a separate operator surface until a later decision changes it |
-| Monitoring | operator lane today | stays private on an operator surface, whether retained-host or later replacement |
+| Airflow orchestration | retained operator lane in the active shared environment | Cloud Composer |
+| MLflow tracking | operator lane in the active shared environment with GCS-backed artifacts | stays on a separate operator surface until a later decision changes it |
+| Monitoring | operator lane in the active shared environment | stays private on an operator surface, whether retained-host or later replacement |
 | Curated storage | BigQuery backend already available | stays on BigQuery |
 | Feast serving path | sits on top of the same curated data | keeps the same logical feature view against cloud storage |
 
 ## Cloud Pipeline Shape
 
 <div class="mermaid">
-flowchart TD
-    OME[Open-Meteo] --> RAW[(GCS raw landing)]
-    RAW --> FEAT[Feature job]
-    FEAT --> BQ[(BigQuery curated features)]
-    BQ --> TRAIN[Training job]
-    TRAIN --> MLF[(MLflow)]
-    MLF --> HOST[Operator host lane]
-    MLF --> RUN[Cloud Run API lane]
-    OME --> HOST
-    OME --> RUN
-    OSRM[OSRM] --> HOST
-    OSRM --> RUN
-    BQ --> FEAST[Feast view]
-    FEAST --> HOST
+flowchart LR
+    classDef source fill:#f5f5f5,stroke:#333
+    classDef process fill:#e1f5fe,stroke:#01579b
+    classDef data fill:#ececff,stroke:#9370db
+    classDef serving fill:#fff8e1,stroke:#f57f17
+
+    WX["Forecasts"]:::source --> RAW
+    RAW[(GCS landing)]:::data --> FEAT
+    FEAT["Feature job"]:::process --> BQ
+    BQ[(BigQuery curated features)]:::data --> TRAIN
+    TRAIN["Training job"]:::process --> MLF
+    MLF[(MLflow registry)]:::data --> HOST
+    MLF --> RUN
+    BQ --> FEAST
+    FEAST["Feast layer"]:::data --> HOST
     FEAST --> RUN
+    ROUTE["OSRM API"]:::source --> LIVE
+    WX --> LIVE
+    LIVE["Live inputs"]:::source --> HOST
+    LIVE --> RUN
+
+    subgraph Serving ["fab:fa-google Serving lane"]
+        direction TB
+        HOST["Operator lane"]:::serving
+        RUN["Cloud Run API"]:::serving
+    end
 </div>
 
 | Layer | Cloud direction |
@@ -157,7 +229,7 @@ flowchart TD
 
 ## Storage Layering In Cloud
 
-The current cloud design works best when storage is split by role instead of forcing every layer into one system.
+The cloud design works best when storage is split by role.
 
 | Data role | Recommended cloud surface | Why |
 |----------|---------------------------|-----|
@@ -193,7 +265,7 @@ In practice, GCS stores raw landing data and registry-style metadata for the clo
 | Storage | MinIO-backed curated objects plus local Feast parquet and a Datastore-mode emulator | GCS holds raw landing and artifacts; BigQuery becomes the shared curated cloud data surface |
 | Artifacts | MinIO-backed MLflow artifact path | GCS bucket |
 | Auth | local `.env` plus developer credentials | runtime service accounts and GitHub OIDC |
-| Image source | local builds | mixed GitHub-hosted image publication today; target is Cloud Build plus Artifact Registry for all hosted runtime images |
+| Image source | local builds | mixed GitHub-hosted image publication in the active shared environment; target is Cloud Build plus Artifact Registry for all hosted runtime images |
 | Public exposure | local ports on the developer machine | Cloud Run is the shared hosted API surface; the operator lane stays private by default; dashboards stay private unless you deliberately publish them |
 
 ## Recovery Evidence In Cloud
@@ -215,16 +287,16 @@ The stable evidence surfaces are:
 - The application already supports a `bigquery` storage backend through the shared feature-store abstraction.
 - Local container runs can already mount ADC for BigQuery-based checks.
 
-## Current Transitional Points
+## Remaining Hosted Simplifications
 
-- MLflow stays on the retained host in the active shared environment.
-- Airflow still stays on the retained host today, so runtime release, retries, and backfills still depend on VM-backed orchestration.
+- MLflow stays on the retained operator lane in the active shared environment.
+- Airflow still runs on the retained operator lane, so runtime release, retries, and backfills still depend on VM-backed orchestration.
 - Cloud Run already owns the public API lane and should keep that role.
 - Hosted image delivery is still split between GitHub-hosted execution and mixed registries; the target is Cloud Build plus Artifact Registry.
 - The monitoring stack stays intentionally small and reviewable through checked-in dashboards, alert rules, and scrape config.
 
 ## Why This Fits The Project Brief
 
-The goal is cloud-ready pipelines and cloud orchestration. This mapping keeps the validated backend design, makes the current retained-host dependency explicit, and points the hosted path toward Google-managed build and orchestration services without discarding the working local baseline.
+The goal is cloud-ready pipelines and cloud orchestration. This mapping keeps the validated backend design, makes the retained-host dependency explicit, and points the hosted path toward Google-managed build and orchestration services without discarding the working local baseline.
 
-See [Architecture](architecture.md) for the current runtime view and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the maintainer path that bootstraps and advances these hosted targets. The repository root also includes a Terraform README with the deployment details.
+See [Architecture](architecture.md) for the runtime view and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the maintainer path that bootstraps and advances these hosted targets. The repository root also includes a Terraform README with the deployment details.

--- a/docs/site/system/configuration-and-contracts.md
+++ b/docs/site/system/configuration-and-contracts.md
@@ -1,12 +1,12 @@
 # Configuration and Contracts
 
-FoehnCast keeps workload configuration, runtime wiring, infrastructure inputs, and generated runtime state separate on purpose. This page describes that current contract so readers do not have to reconstruct it from `config.yaml`, `src/foehncast/config.py`, the repository notes, and the operator docs.
+FoehnCast keeps workload configuration, runtime wiring, infrastructure inputs, and generated runtime state separate. This page describes that contract so readers do not have to reconstruct it from `config.yaml`, `src/foehncast/config.py`, the repository notes, and the operator docs.
 
 The goal is not to document every environment variable in isolation. The goal is to make the ownership boundary explicit: what the package owns, what the runtime injects, and what infrastructure or operator tooling should keep outside the package config.
 
 !!! note "Scope"
 
-    This page describes the current validated configuration boundary.
+    This page describes the validated configuration boundary.
     It is not a proposal for a future settings system.
     New settings should follow these ownership rules unless the architecture changes first.
 
@@ -14,20 +14,20 @@ The goal is not to document every environment variable in isolation. The goal is
 
 <div class="mermaid">
 flowchart LR
-    YAML[config.yaml] --> PY[src/foehncast/config.py]
-    ENV[.env and environment variables] --> PY
-    TF[Terraform and GitHub delivery variables] --> ENV
-    PY --> APP[App, DAGs, training, inference]
-    ENV --> FEASTCFG[.state/feast/feature_store.runtime.yaml]
-    FEASTCFG --> FEAST[Feast runtime]
-    APP --> MON[.state and airflow/reports contracts]
+    TF["Terraform and GitHub delivery variables"] --> ENV[".env and environment variables"]
+    YAML["config.yaml"] --> PY["src/foehncast/config.py"]
+    ENV --> PY
+    PY --> APP["App, DAGs, training, inference"]
+    APP --> MON[".state and airflow/reports contracts"]
+    ENV --> FEASTCFG[".state/feast/feature_store.runtime.yaml"]
+    FEASTCFG --> FEAST["Feast runtime"]
 </div>
 
-The important rule is that the package should own workload semantics, while runtime and infrastructure layers own deployment-specific wiring.
+The important rule is that the package owns workload semantics, while runtime and infrastructure layers own deployment-specific wiring.
 
 ## Ownership Boundary
 
-| Surface | Owns | Current examples | Must not become |
+| Surface | Owns | Example values | Must not become |
 |------|------|------------------|-----------------|
 | `config.yaml` | workload defaults and app-facing contracts | rider profile, spot list, API source settings, validation rules, model features, labeling bands, MLflow names, inference weights, monitoring thresholds | a dump of project IDs, service names, bind hosts, or deployment topology |
 | `.env` and environment variables | concrete runtime wiring for one local or hosted instance | `STORAGE_BACKEND`, `STORAGE_S3_BUCKET`, `STORAGE_BIGQUERY_*`, `MLFLOW_TRACKING_URI`, bind hosts, Feast source selection | the source of truth for rider, spot, or model semantics |
@@ -42,12 +42,12 @@ This split keeps the workload code smaller and clearer. The package does not nee
 
 The checked-in YAML owns the stable workload and product contract.
 
-| Section | What it controls today |
+| Section | What it controls |
 |------|-------------------------|
 | `rider` | baseline rider profile and home location used by ranking |
 | `api` | upstream weather and routing source settings |
 | `spots` | the fixed spot list and shore metadata |
-| `storage` | the default curated-storage mode, currently `s3` or `bigquery` |
+| `storage` | the curated-storage mode and its supported values, including `s3` and `bigquery` |
 | `warehouse` | retained warehouse contracts for curated features and prediction events |
 | `validation` | required columns, completeness rules, and accepted numeric ranges |
 | `model` | algorithm choice, feature sets, target field, split ratio, and seed |
@@ -56,13 +56,13 @@ The checked-in YAML owns the stable workload and product contract.
 | `inference` | live horizon and ranking weights |
 | `monitoring` | drift threshold, evaluation window, and local retention knobs |
 
-This is why the current training and inference pages can point back to `config.yaml` for feature lists, ranking weights, and label semantics without treating those values as runtime secrets.
+This is why the training and inference pages can point back to `config.yaml` for feature lists, ranking weights, and label semantics without treating those values as runtime secrets.
 
 ## What Runtime Wiring Resolves
 
 `src/foehncast/config.py` keeps the YAML and the runtime wiring separate instead of mutating one into the other.
 
-The current resolution rules are:
+The resolution rules are:
 
 - `FOEHNCAST_CONFIG_PATH` can point the loader at a different YAML file when needed
 - the loader caches the checked-in YAML, but runtime helpers resolve environment overrides when the caller asks for storage or MLflow settings
@@ -79,11 +79,11 @@ The test contract in `tests/test_config.py` already checks the most important be
 
 That means the package does not need a second handwritten runtime config file just to switch from local to hosted wiring.
 
-## Current Runtime Wiring Examples
+## Runtime Wiring Examples
 
 The checked-in `.env.example` shows the kind of values that belong in runtime wiring.
 
-| Runtime surface | Current examples |
+| Runtime surface | Example values |
 |------|------------------|
 | Curated storage binding | `STORAGE_BACKEND`, `STORAGE_S3_BUCKET`, `STORAGE_S3_ENDPOINT`, `STORAGE_BIGQUERY_PROJECT_ID`, `STORAGE_BIGQUERY_DATASET`, `STORAGE_BIGQUERY_TABLE` |
 | MLflow connection | `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_DESTINATION` |
@@ -93,25 +93,25 @@ The checked-in `.env.example` shows the kind of values that belong in runtime wi
 
 These values describe one concrete runtime instance. They should stay overridable because the local evaluator, hosted full-stack target, and hosted inference target do not all bind to the same services.
 
-In the shared hosted path today, the full-stack target still represents the current operator lane. That lane is transitional, so the runtime wiring should stay explicit instead of being treated as a permanent deployment shape.
+In the shared hosted path, the full-stack target represents the active operator lane. That lane is a retained operator surface, so the runtime wiring should stay explicit instead of being treated as a permanent deployment shape.
 
 ## Cloud Runtime Inventory
 
 The shared cloud path uses four value surfaces plus identity-backed auth. The simple split is this: delivery surfaces carry reviewed hosted identifiers and toggles, runtime surfaces carry concrete per-environment wiring, and identities carry cloud access.
 
-| Source surface | What shows up there today | Owned by | Consumed by | Secret rule |
+| Source surface | Example values | Owned by | Consumed by | Secret rule |
 |------|---------------------------|----------|-------------|-------------|
 | checked-in examples and repo defaults | `.env.example` placeholders, `terraform/terraform.tfvars.example`, checked-in operator docs | repository | bootstrap prompts, local operators, reviewers | structural examples only; never live credentials |
 | bootstrap outputs in the working tree | `.env`, `terraform/terraform.tfvars`, Terraform outputs echoed by `./scripts/bootstrap-gcp.sh` | maintainer running bootstrap for one environment | local preview applies, bootstrap verification, `scripts/configure-github-actions.sh` | hosted identifiers and toggles only; not a long-term secret store |
 | GitHub repository variables | `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_ARTIFACT_REPOSITORY`, `GCP_BIGQUERY_*`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT_EMAIL`, Cloud Run sizing and enablement flags | GitHub delivery control plane, normally synced from Terraform outputs | `.github/workflows/terraform.yml`, image-publish workflows, repo-config action | structural delivery contract only; do not store runtime passwords, API tokens, or key files here |
-| runtime `.env` and hosted runtime env vars | `MLFLOW_TRACKING_URI`, `AIRFLOW__API_AUTH__JWT_SECRET`, `FOEHNCAST_GRAFANA_ADMIN_*`, `GRAFANA_API_*`, `cloud_run_env_vars`, `online_compose_env_vars` | runtime operator or platform for one running surface | local evaluator, current operator lane, shared API lane, Grafana and Airflow auth checks | concrete runtime wiring; secret-bearing values should stay local-only or move to Secret Manager or another managed secret path |
+| runtime `.env` and hosted runtime env vars | `MLFLOW_TRACKING_URI`, `AIRFLOW__API_AUTH__JWT_SECRET`, `FOEHNCAST_GRAFANA_ADMIN_*`, `GRAFANA_API_*`, `cloud_run_env_vars`, `online_compose_env_vars` | runtime operator or platform for one running surface | local evaluator, active operator lane, shared API lane, Grafana and Airflow auth checks | concrete runtime wiring; secret-bearing values should stay local-only or move to Secret Manager or another managed secret path |
 | identity-backed auth surfaces | GitHub OIDC, Cloud Run service account, compose-host VM service account | repository admin plus GCP IAM | GitHub workflows and hosted runtimes | prefer identities over stored cloud credentials; not a secret distribution path |
 
-This inventory keeps the current boundary explicit:
+This inventory keeps the boundary explicit:
 
 - `config.yaml` keeps workload semantics.
 - `terraform/terraform.tfvars` and GitHub repository variables keep structural hosted rollout inputs.
-- runtime `.env` and hosted env injections carry concrete per-environment wiring for the local evaluator, the current operator lane, or the shared API lane.
+- runtime `.env` and hosted env injections carry concrete per-environment wiring for the local evaluator, the active operator lane, or the shared API lane.
 - secret-bearing runtime values should not move into committed examples or repository variables just because they are cloud-facing.
 
 This page inventories where those values live. [Delivery and Operator Workflow](delivery-and-operator-workflow.md) owns the maintainer bootstrap, repository-variable sync, and remote-apply runbook that moves between those surfaces.
@@ -120,7 +120,7 @@ This page inventories where those values live. [Delivery and Operator Workflow](
 
 The storage boundary is intentionally narrow.
 
-The current curated-storage contract is:
+The curated-storage contract is:
 
 - `s3` is the local MinIO-backed baseline
 - `bigquery` is the hosted analytical baseline
@@ -136,7 +136,7 @@ This matters because retained monitoring facts belong in retained event history 
 
 ## Feast And Monitoring Runtime State
 
-Two generated state areas are part of the current contract even though they are not workload config.
+Two generated state areas are part of the runtime contract even though they are not workload config.
 
 | Generated surface | Why it exists |
 |------|----------------|

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -1,61 +1,53 @@
 # Delivery and Operator Workflow
 
-FoehnCast keeps contributor onboarding and shared-cloud delivery separate on purpose. Contributors use `./scripts/bootstrap-local.sh` to run the validated local evaluator. Maintainers use `./scripts/bootstrap-gcp.sh`, GitHub Actions, and Terraform to bootstrap and advance the shared hosted environment. The current hosted runtime still uses a retained operator host for Airflow handoff and operator surfaces, but the intended hosted direction is Cloud Build plus Cloud Composer. This page records the current workflow contract and the boundary that future hosted changes should move toward.
+FoehnCast keeps contributor onboarding and shared-cloud delivery separate. Contributors use `./scripts/bootstrap-local.sh` to run the validated local evaluator. Maintainers use `./scripts/bootstrap-gcp.sh`, GitHub Actions, and Terraform to bootstrap and advance the shared hosted environment. The intended hosted direction is Cloud Build plus Cloud Composer. This page describes the workflow contract and the boundary that later hosted work should move toward.
 
 !!! note "Scope"
 
-    This page describes the current validated delivery and operator workflow.
-    It also names the intended managed hosted direction so the current host-backed path is not mistaken for the final design.
+    This page describes the validated delivery and operator workflow.
+    It also names the intended managed hosted direction so the active host-backed path is not mistaken for the final design.
     It is not a cutover runbook for Composer or Cloud Build.
 
 ## Workflow In One View
 
 <div class="mermaid">
-flowchart LR
-    subgraph Local[Default contributor lane]
-        CLONE[Clone repo]
-        LOCAL[./scripts/bootstrap-local.sh]
-        LSTACK[Local evaluator stack]
-        LVERIFY[Feature and training hand-off plus Feast and monitoring checks]
+flowchart TD
+    subgraph Local["fab:fa-docker Contributor lane"]
+        direction LR
+        CLONE["Clone repo"]
+        LOCAL["bootstrap-local.sh"]
+        LVERIFY["Local stack + checks"]
+        CLONE --> LOCAL --> LVERIFY
     end
 
-    subgraph Bootstrap[One-time maintainer bootstrap]
-        SHELL[Google Cloud Shell]
-        BGCP[./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions]
-        BACKEND[Remote Terraform backend]
-        VARS[GitHub repository variables]
+    subgraph Maintainer["fab:fa-google Maintainer lane"]
+        direction LR
+        SHELL["Cloud Shell"]
+        BGCP["bootstrap-gcp.sh"]
+        HANDOFF["Remote TF + repo vars"]
+        PUSH["Push or dispatch"]
+        TFWF["fab:fa-github terraform.yml"]
+        HOST["Hosted ops lane"]
+        RUN["Cloud Run API"]
+        SHELL --> BGCP --> HANDOFF --> TFWF
+        PUSH --> TFWF
+        TFWF --> HOST
+        TFWF --> RUN
     end
-
-    subgraph Remote[Normal shared-cloud delivery]
-        PUSH[Push to main or manual workflow dispatch]
-        TFWF[.github/workflows/terraform.yml]
-        HOST[Hosted full-stack target]
-        RUN[Primary Cloud Run target]
-    end
-
-    CLONE --> LOCAL --> LSTACK --> LVERIFY
-    SHELL --> BGCP
-    BGCP --> BACKEND
-    BGCP --> VARS
-    PUSH --> TFWF
-    BACKEND --> TFWF
-    VARS --> TFWF
-    TFWF --> HOST
-    TFWF --> RUN
 </div>
 
-The split matters because the local path is the supported public onboarding path, while the cloud path assumes GCP ownership, GitHub repository administration, and access to private operator surfaces.
+The split matters because the local path is the supported onboarding path, while the cloud path assumes GCP ownership, GitHub repository administration, and access to private operator surfaces.
 
-Today the remote workflow still lands on two hosted runtime surfaces: Cloud Run for the public API lane and the retained operator host for Airflow, MLflow, monitoring, and private recovery work. The target managed direction keeps the same onboarding split but replaces host-owned build and orchestration duties with Cloud Build and Cloud Composer.
+The remote workflow lands on two hosted runtime surfaces: Cloud Run for the public API lane and the retained operator host for Airflow, MLflow, monitoring, and private recovery work. The target managed direction keeps the same onboarding split but replaces host-owned build and orchestration duties with Cloud Build and Cloud Composer.
 
-## Current Lanes
+## Supported Paths
 
-| Lane | Current target | State | Main job |
-|------|----------------|-------|----------|
-| Local evaluator lane | `./scripts/bootstrap-local.sh` plus local Compose | stable baseline | run the default contributor path |
-| Delivery lane | GitHub Actions plus Terraform plus OIDC | active review gate | publish reviewed artifacts and apply reviewed infrastructure changes |
-| Shared API lane | hosted inference target on Cloud Run | active hosted target | serve the shared public API |
-| Operator lane | hosted full-stack target on one GCP host | active but transitional | keep Airflow, MLflow, monitoring, and private recovery work online until the managed hosted control plane is ready |
+| Path | Audience | Main tools | Main result |
+|------|----------|------------|-------------|
+| Default contributor path | contributor or reviewer | local Docker plus `./scripts/bootstrap-local.sh` | validated one-machine evaluator stack |
+| One-time shared-cloud bootstrap | maintainer | Google Cloud Shell plus `./scripts/bootstrap-gcp.sh` | remote Terraform backend, repository-variable contract, and first hosted setup |
+| Reviewed day-2 delivery | maintainer | GitHub Actions plus Terraform plus OIDC | reviewed infrastructure and runtime updates |
+| Runtime recovery | maintainer | hosted Airflow on the retained operator host plus the runtime trigger workflow | retries, backfills, and reviewed serving handoffs |
 
 ## Default Contributor Path
 
@@ -79,36 +71,34 @@ The script is interactive by design. It asks the operator to authenticate with `
 
 In `--bootstrap-only` mode, the script prepares the remote Terraform control plane, prints the remote-state and identity handoff, and leaves the broader hosted apply to the remote workflow. It also writes `.env` and `terraform/terraform.tfvars` in the working tree so the local checkout reflects the selected project and platform identifiers.
 
-When the script runs a normal apply instead of bootstrap-only mode, it verifies both hosted lanes. Cloud Run must answer `/health`, `/spots`, and `/metrics`, and the health payload must expose the served alias and model version. The operator host must keep its app URL private. If that app URL is public, bootstrap fails fast instead of treating the VM as a public fallback.
+When the script runs a normal apply instead of bootstrap-only mode, it verifies both hosted lanes. Cloud Run must answer `/health`, `/spots`, and `/metrics`, and the operator host must keep its app URL private.
 
-## Day-2 Delivery Contract
+## Reviewed Day-2 Delivery
 
 After the one-time bootstrap establishes OIDC, the remote backend, and the repository-variable contract, GitHub Actions becomes the primary operator surface for Terraform-managed changes.
 
-| Surface | Current role | Current contract |
-|------|---------------|------------------|
-| `.github/workflows/terraform.yml` | primary Terraform operator path | pushes to `main` automatically resolve to `apply` after bootstrap; manual dispatch stays available for `plan`, `destroy`, `cleanup`, and explicit overrides |
-| `scripts/configure-github-actions.sh` | repo-variable sync | Terraform outputs are copied into GitHub repository variables so the remote workflow reads one shared contract |
-| `terraform/terraform.tfvars` | bootstrap input | used during the interactive bootstrap path, not as the day-2 source of truth for remote applies |
-| runtime image workflows | reviewed artifact publishing | GitHub-reviewed workflows now submit hosted image builds to Cloud Build and publish the reviewed images to Artifact Registry, but they still do not deploy Cloud Run, shift traffic, or mutate MLflow aliases directly |
-| `.github/workflows/trigger-runtime-release.yml` | reviewed runtime handoff | today GitHub sends one explicit runtime release request into hosted Airflow after the retained operator host refreshes to the reviewed git ref; this handoff is transitional until Composer owns it |
-| `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up | run this after a remote apply succeeds and curated BigQuery rows exist |
+| Surface | Purpose |
+|------|---------|
+| `.github/workflows/terraform.yml` | primary Terraform operator path for reviewed apply, plan, destroy, cleanup, and explicit overrides |
+| `scripts/configure-github-actions.sh` | sync Terraform outputs into GitHub repository variables |
+| `terraform/terraform.tfvars` | interactive bootstrap input, not the day-2 source of truth |
+| runtime image workflows | submit reviewed hosted image builds to Cloud Build and publish images to Artifact Registry |
+| `.github/workflows/trigger-runtime-release.yml` | send one explicit reviewed runtime release request into hosted Airflow while the retained host still owns that handoff |
+| `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up after a remote apply and curated BigQuery rows exist |
 
 The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as container port, CPU, and memory stay repo-variable-backed instead of becoming manual workflow inputs.
 
 Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables stay structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. Both hosted lanes still read the same Terraform-managed storage, Feast, and MLflow contract. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
 
-## Current Retained-Host Dependencies
+## Retained-Host Responsibilities
 
-The shared environment still depends on the retained operator host in a few specific places. This table is the current inventory for the active migration wave.
+The shared environment still depends on the retained operator host in a few specific places.
 
-| Surface | Current dependency | Classification | Next migration issue |
-|------|--------------------|----------------|----------------------|
-| runtime release handoff | `.github/workflows/trigger-runtime-release.yml` still refreshes the VM checkout over SSH and runs `scripts/trigger-runtime-release.sh` to trigger the host-local `runtime_release` DAG | transitional | #224 |
-| hosted DAG execution and recovery | runtime retries, backfills, and manual replay still assume SSH access to the retained host and host-local Airflow | transitional | #224 |
-| bootstrap and repo-variable plumbing | `scripts/bootstrap-gcp.sh`, `.github/workflows/terraform.yml`, and `scripts/terraform-platform-state.sh` still resolve and sync `GCP_ONLINE_COMPOSE_*` inputs | transitional | #224 |
-| sync evidence and operator checks | the retained host still writes `.state/online-compose-sync/last-success.json`, and hosted verification still checks that sync evidence through `/metrics` | keep for now | later host-shrink issue |
-| cloud-operator regression tests | `tests/test_cloud_operator_contract.py` and the online-compose sync tests still enforce the retained-host contract directly | keep while migrating | same issue as the production surface being changed |
+| Responsibility | Why it still uses the host | Target direction |
+|------|-----------------------------|------------------|
+| runtime release handoff | GitHub still refreshes the VM checkout over SSH and triggers the host-local `runtime_release` DAG | reviewed request should reach Composer without VM SSH |
+| hosted DAG execution and recovery | retries, backfills, and manual replay still assume host-local Airflow | Composer should own hosted orchestration and recovery |
+| sync evidence and private operator checks | the host still writes `.state/online-compose-sync/last-success.json` and keeps operator surfaces online | shrink or replace this VM role after orchestration leaves the host |
 
 ## Hosted Orchestration Boundary
 
@@ -120,34 +110,32 @@ The current hosted orchestration path and the target managed direction are diffe
 | Reviewed runtime release entry | GitHub OIDC plus SSH to the retained host, then local `runtime_release` DAG trigger | reviewed request should reach Composer without VM SSH |
 | Scheduling, retries, and backfills | retained-host Airflow | Composer |
 | Operator host role | Airflow, MLflow, monitoring, and private app checks on one VM | shrink after Composer absorbs orchestration; keep only the services that still need a VM |
+
 Today the retained host path remains the operational recovery surface. It is not the intended long-term hosted orchestration authority.
 
 ## GitHub Versus GCP Boundary
 
 The reviewed delivery plane and the runtime execution plane still have different responsibilities.
 
-| Plane | Current owner | What it owns | What it must not own |
+| Plane | Active owner | What it owns | What it must not own |
 |------|---------------|--------------|----------------------|
 | Reviewed delivery | GitHub Actions plus Terraform | lint, test, build, image publish, Terraform plan/apply/destroy, and reviewed deploy workflows | runtime scheduling, retries, backfills, and long-lived operator state |
-| Runtime execution | GCP-hosted runtime surfaces | Cloud Run serving, current hosted Airflow scheduling, retries, backfills, runtime environment injection, and operator telemetry | source control, CI review, and infrastructure policy review |
-| Shared handoff | repository variables, published images, Terraform outputs, and runtime release requests | reviewed contract from GitHub into GCP runtime surfaces; today it reaches runtime through the retained-host handoff and later should reach managed Airflow directly | ad hoc operator-only divergence from the declared contract |
+| Runtime execution | GCP-hosted runtime surfaces | Cloud Run serving, hosted Airflow scheduling, retries, backfills, runtime environment injection, and operator telemetry | source control, CI review, and infrastructure policy review |
+| Shared handoff | repository variables, published images, Terraform outputs, and runtime release requests | reviewed contract from GitHub into GCP runtime surfaces; it reaches runtime through the retained-host handoff today and later should reach managed Airflow directly | ad hoc operator-only divergence from the declared contract |
 
-GitHub Actions may trigger reviewed delivery workflows, but runtime scheduling does not belong to GitHub. Today that runtime orchestration still lives on the retained operator host. The target managed surface is Cloud Composer.
+GitHub Actions may trigger reviewed delivery workflows, but runtime scheduling does not belong to GitHub. In the active shared environment, that runtime orchestration still lives on the retained operator host. The target managed surface is Cloud Composer.
 
-## Current Runtime Release Trigger Contract
+## Runtime Release Trigger Contract
 
 GitHub now has exactly one reviewed handoff into runtime execution.
 
 <div class="mermaid">
 flowchart LR
-    GHW[Trigger Runtime Release workflow]
-    SSH[OIDC plus SSH to retained operator host]
-    SCRIPT[trigger-runtime-release.sh]
-    DAG[runtime_release DAG]
-    REPORT[runtime-release-latest.json]
-    SUMMARY[GitHub workflow summary]
-
-    GHW --> SSH --> SCRIPT --> DAG --> REPORT --> SUMMARY
+    GHW["fab:fa-github Runtime release workflow"] --> SSH["OIDC + SSH to retained host"]
+    SSH --> SCRIPT["trigger-runtime-release.sh"]
+    SCRIPT --> DAG["runtime_release DAG"]
+    DAG --> REPORT["runtime-release-latest.json"]
+    REPORT --> SUMMARY["GitHub workflow summary"]
 </div>
 
 - signal: `.github/workflows/trigger-runtime-release.yml` sends one JSON request with a single action and the associated release coordinates
@@ -161,7 +149,7 @@ Supported actions:
 - `promote_candidate`
 - `rollback_live`
 
-This keeps the handoff explicit while deeper runtime automation still lives behind the Airflow side of the boundary. It is the current operational contract, not the intended long-term hosted entry path. The target managed direction is the same reviewed request reaching Composer without a retained-host refresh step.
+This keeps the handoff explicit while deeper runtime automation still lives behind the Airflow side of the boundary. It is the active contract, not the intended long-term hosted entry path. The target managed direction is the same reviewed request reaching Composer without a retained-host refresh step.
 
 ## Composer Readiness Requirements
 
@@ -177,9 +165,7 @@ Cloud Composer is still a target, not a provisioned surface in this repo. Before
 
 ## Retry And Backfill Runbooks
 
-The recovery lane is now explicit too. Operators should retry work on the same plane that owns it instead of jumping between GitHub and runtime surfaces.
-
-These are the current runbooks while hosted orchestration still lives on the retained host.
+Operators should retry work on the same plane that owns it instead of jumping between GitHub and runtime surfaces. These are the retained-host runbooks while hosted orchestration still lives on the retained host.
 
 | Situation | Where to act | Normal procedure | Minimum evidence |
 |------|---------------|------------------|------------------|
@@ -227,27 +213,14 @@ Practical recovery split:
 - use hosted Airflow retries and backfills when runtime data or orchestration work failed after delivery
 - use the runtime trigger contract when the serving release handoff itself must be retried
 
-## What The Cloud-Operator Tests Enforce
+## Reviewable Boundaries
 
-The cloud-operator tests keep the delivery path honest in a few specific ways:
-
-- Terraform output names and GitHub repository variable names must stay in one shared mapping
-- the remote workflow must read the repository-backed contract instead of requiring operators to re-enter the same platform values on every run
-- pushes to `main` only become automatic remote applies after bootstrap has populated the required repository variables; before that, push runs explain the skip and manual runs fail fast
-- hosted verification fails if Cloud Run is not provisioned or if the VM app is public, because Cloud Run is the only supported public API path in this configuration
-- repository-variable resync after apply is best effort, so a GitHub token limitation does not invalidate a successful Terraform apply
-- destroy and cleanup remain explicit maintainer actions with project-id confirmation checks
-
-That is why the public docs can describe the shared-cloud path as reviewable and repeatable without pretending it is a casual contributor setup.
-
-## Delivery Boundaries That Stay Deliberate
-
-These boundaries stay explicit across the scripts, Terraform reference, and tests:
+These boundaries stay explicit across the scripts, Terraform reference, and workflow contract:
 
 - the local Docker evaluator remains the only default contributor path
 - the shared cloud environment stays operator-owned, even though the repository and images are public
 - `terraform/terraform.tfvars` belongs to bootstrap and local preview work, while day-2 remote runs read GitHub repository variables
-- runtime scheduling, retries, and backfills belong to hosted Airflow today and to Composer after the managed cutover, not to GitHub Actions
+- runtime scheduling, retries, and backfills belong to hosted Airflow in the active shared environment and to Composer after the managed cutover, not to GitHub Actions
 - runtime promotion, rollback, and live traffic control do not run inside GitHub workflows; GitHub only sends the reviewed runtime release request
 - Grafana, Airflow, MLflow, and Prometheus remain operator surfaces rather than rider-facing product surfaces
 - public docs should explain those surfaces with rendered evidence and checked-in configuration, not live control-plane embeds
@@ -256,10 +229,10 @@ The same split also keeps cloud retirement reviewable. Destroy and cleanup stay 
 
 ## Why This Workflow Works
 
-- it gives contributors one small supported setup path instead of parallel onboarding stories
+- it gives contributors one supported setup path instead of parallel onboarding stories
 - it keeps the one-time cloud bootstrap explicit and interactive, which is safer for project, billing, and hosted-target choices
 - it moves normal day-2 infrastructure changes into GitHub Actions so operators do not need local Terraform for routine work
 - it keeps shared-cloud configuration reviewable because Terraform outputs, repository variables, and workflow behavior are tied together by regression tests
-- it records the current retained-host workflow without pretending that VM-backed orchestration is the desired hosted end state
+- it records the retained-host workflow without pretending that VM-backed orchestration is the desired hosted end state
 
 See [Interfaces and Surfaces](interfaces-and-surfaces.md), [Hosted Full-Stack](hosted-full-stack.md), [Cloud Mapping](cloud-mapping.md), and [Monitoring](monitoring.md) for the surrounding runtime and exposure boundaries.

--- a/docs/site/system/feature-pipeline.md
+++ b/docs/site/system/feature-pipeline.md
@@ -1,30 +1,48 @@
 # Feature Pipeline
 
-FoehnCast keeps the feature pipeline as a clear set of boundaries. The same curated feature contract drives the local evaluator and the hosted paths: forecast data is ingested, turned into curated features, checked against explicit bounds, stored through a backend abstraction, and then reshaped for Feast serving use without changing the meaning of the feature set.
+FoehnCast keeps the feature pipeline as a clear set of boundaries. The same curated feature contract drives the local evaluator and the hosted paths: forecast data is ingested, turned into curated features, checked against explicit bounds, stored through a backend abstraction, and then reshaped for Feast serving without changing the meaning of the feature set.
 
-This page records the current design that has been validated in the local stack and in the review notebook. It focuses on what each stage owns today and what stays outside its scope.
+This page describes the validated feature contract. It focuses on what each stage owns and what stays outside its scope.
 
 !!! note "Scope"
 
-    This page describes the current validated feature-path contract.
+    This page describes the validated feature-path contract.
     It is not a roadmap.
-    Future changes should be documented after they are chosen and implemented.
+    Future changes belong here only after the contract changes.
 
 ## Pipeline Shape
 
 <div class="mermaid">
 flowchart LR
-    CFG[Spot and storage config] --> ING[Ingest raw forecast rows]
-    ING --> ENG[Engineer curated features]
-    ENG --> VAL[Validate schema and ranges]
-    VAL --> STO[Store curated rows]
-    STO --> OFF[Build Feast offline frame]
-    OFF --> EXP[Export Feast-ready parquet]
-    EXP --> FEAST[Publish Feast-sync asset]
-    FEAST --> REQ[Publish training-request asset]
+    subgraph Input ["Inputs"]
+        direction TB
+        CFG["Spot and storage config"]
+        ING["Ingest raw forecast rows"]
+        CFG --> ING
+    end
+
+    subgraph Curated ["Curated path"]
+        direction TB
+        ENG["Engineer curated features"]
+        VAL["Validate schema and ranges"]
+        STO["Store curated rows"]
+        ENG --> VAL --> STO
+    end
+
+    subgraph Handoff ["Handoff"]
+        direction TB
+        OFF["Build Feast offline frame"]
+        EXP["Export Feast-ready parquet"]
+        FEAST["Publish Feast-sync asset"]
+        REQ["Publish training-request asset"]
+        OFF --> EXP --> FEAST --> REQ
+    end
+
+    ING --> ENG
+    STO --> OFF
 </div>
 
-The key point is that each stage has one clear job:
+Each stage has one clear job:
 
 - ingest proves the upstream weather contract
 - engineering creates the curated feature frame
@@ -35,7 +53,7 @@ The key point is that each stage has one clear job:
 
 ## Runtime Role
 
-| Runtime mode | What the feature path does today |
+| Runtime mode | What the feature path does |
 |------|-----------------------------|
 | Local evaluator | Airflow writes curated rows to the local storage baseline and prepares Feast downstream |
 | Active shared environment | the same DAG and curated contract write to BigQuery and keep Feast downstream through the hosted storage surfaces |
@@ -54,7 +72,7 @@ The key point is that each stage has one clear job:
 
 ## Ingest Boundary
 
-The ingest stage uses the live forecast helper rather than a notebook-only mock. That matters because the first contract to defend is upstream shape and timestamp behavior.
+The ingest stage uses the live forecast helper rather than a notebook-only mock. The first contract to defend is upstream shape and timestamp behavior.
 
 The validated ingest assumptions are:
 
@@ -64,13 +82,13 @@ The validated ingest assumptions are:
 - timezone semantics are made explicit before later storage and Feast hand-offs
 - the upstream wind-unit contract is explicit: Open-Meteo is requested with `wind_speed_unit=kmh`, the returned `hourly_units` map is validated at ingest, and the persisted pipeline summary records those units for later review
 
-For this project, raw weather features stay in source weather units, which currently means km/h for wind speed and gusts. That is separate from domain-facing rideability thresholds, which remain configured in knots and are converted at scoring time instead of changing the stored feature contract.
+For this project, raw weather features stay in source weather units, which means km/h for wind speed and gusts. That is separate from domain-facing rideability thresholds, which remain configured in knots and are converted at scoring time instead of changing the stored feature contract.
 
 Ingest keeps the upstream payload boundary explicit instead of mixing raw capture with curated enrichment.
 
 ## Curated Feature Boundary
 
-The engineering layer creates the project's curated feature frame. The current feature set already reflects several design choices that should remain stable:
+The engineering layer creates the project's curated feature frame. The feature set already reflects several design choices that should stay stable:
 
 - cyclical time variables are encoded with sine and cosine instead of plain integers
 - shoreline fit is represented with circular math through `shore_alignment`
@@ -79,13 +97,13 @@ The engineering layer creates the project's curated feature frame. The current f
 - raw columns remain available alongside engineered columns so downstream validation and storage operate on one complete curated frame
 - the datetime index and time basis are preserved so later storage and Feast preparation can add persistence and serving context without redefining the feature set
 
-The current training path is tree-based, so feature representation quality matters more than blanket scaling. Circular wind-direction encoding and the shift toward `gust_excess_10m` follow that same choice. The engineering stage stays narrow: create curated rows first, then let validation, storage, and Feast-specific projection happen downstream.
+The supported training path is tree-based, so feature representation quality matters more than blanket scaling. Circular wind-direction encoding and the shift toward `gust_excess_10m` follow that same choice. The engineering stage stays narrow: create curated rows first, then let validation, storage, and Feast-specific projection happen downstream.
 
 ## Validation Boundary
 
 Validation is structural, not semantic. It is there to stop broken feature frames before they reach storage, training, or Feast preparation.
 
-The current validated contract is:
+The validation contract is:
 
 - required columns cover the actual curated feature frame, not only raw ingest fields
 - configured range checks cover the engineered features that later storage and Feast preparation depend on
@@ -94,7 +112,7 @@ The current validated contract is:
 - completeness checks remain important because ratio-based features can go null when sustained wind approaches zero
 - validation is the explicit gate before downstream persistence and Feast projection
 
-This layer is not supposed to decide whether a forecast is good for riding. That belongs to the downstream ranking and prediction logic.
+This layer does not decide whether a forecast is good for riding. That belongs to the downstream ranking and prediction logic.
 
 ## Storage Boundary
 
@@ -102,13 +120,13 @@ Storage works only if it behaves like persistence rather than transformation. A 
 
 <div class="mermaid">
 flowchart LR
-    FEAT[Curated feature frame] --> WRITE[write_features]
-    WRITE --> BACKEND[Local, S3-compatible, or BigQuery backend]
-    BACKEND --> READ[read_features]
-    READ --> ROUND[Round-trip checks]
+    FEAT["Curated feature frame"] --> WRITE["write_features"]
+    WRITE --> BACKEND["Local, S3-compatible, or BigQuery backend"]
+    BACKEND --> READ["read_features"]
+    READ --> ROUND["Round-trip checks"]
 </div>
 
-The current storage contract is:
+The storage contract is:
 
 - local, S3-compatible, and BigQuery backends may use different write-time metadata internally
 - rerunning one logical spot-and-dataset write must replace that slice instead of accumulating cloud-only duplicates
@@ -118,7 +136,7 @@ The current storage contract is:
 - the stored frame should preserve the time basis needed for later Feast projection after read-back
 - storage should operate on validation-approved curated rows, not compensate for upstream quality failures
 
-This is why raw landing, curated storage, and Feast should remain separate responsibilities rather than one blurred storage layer.
+That is why raw landing, curated storage, and Feast should remain separate responsibilities rather than one blurred storage layer.
 
 ## Storage Layering
 
@@ -130,28 +148,21 @@ This is why raw landing, curated storage, and Feast should remain separate respo
 | Feast registry and staging | local files | GCS |
 | Feast online store | Datastore-mode emulator | Datastore |
 
-The local operator path mirrors the cloud storage roles more closely: MinIO-backed object storage for curated objects and MLflow artifacts, exported parquet for the local Feast offline source, and a Datastore-mode emulator for the local Feast online store.
-
-That role split matters more than the exact local implementation names: curated persistence stays separate from Feast serving, and both stay separate from registry metadata.
+The local operator path mirrors the cloud storage roles closely: MinIO-backed object storage for curated objects and MLflow artifacts, exported parquet for the local Feast offline source, and a Datastore-mode emulator for the local Feast online store. Curated persistence stays separate from Feast serving, and both stay separate from registry metadata.
 
 ## Storage Control Surface
 
 The storage split is not only conceptual. The repository exposes it through explicit runtime and infrastructure surfaces so the local path and the cloud target stay aligned.
 
-| Surface | Current implementation | Why it matters |
-|------|------------------------|----------------|
-| Backend selection | `storage.backend` in `config.yaml` with supported values `s3` or `bigquery` | keeps the curated persistence mode explicit without carrying a legacy file-backed path |
-| Curated local store | `S3FeatureStoreBackend` against the bundled MinIO service | keeps the local object-access layer aligned with the hosted architecture and MLflow artifact flow |
-| Curated cloud store | `BigQueryFeatureStoreBackend` writing the configured project, dataset, and table | matches the cloud analytical target and preserves rerun-safe slice replacement |
-| Feast offline local source | `export_offline_store(...)` writing `data/feast/<dataset>.parquet` | keeps Feast downstream from curated persistence |
-| Feast cloud source | BigQuery table or view referenced by the cloud Feast config | avoids duplicating feature logic in a separate serving path |
-| Feast local runtime state | `.state/feast/registry.db` and `.state/feast/feature_store.runtime.yaml` | keeps local integration state separate from the curated dataset while the emulator remains disposable |
-| Feast registry and staging | local state files in development, GCS in the cloud path | keeps registry metadata separate from the curated dataset |
-| Terraform baseline | Terraform-managed GCS, BigQuery, and Datastore-mode Firestore baseline | wires the cloud storage surfaces without changing the feature contract itself |
+| Surface | Role |
+|------|------|
+| Backend selection | `storage.backend` keeps curated persistence explicit with `s3` or `bigquery` |
+| Curated storage | `S3FeatureStoreBackend` is the local MinIO-backed path; `BigQueryFeatureStoreBackend` is the cloud path |
+| Feast offline source | local export writes `data/feast/<dataset>.parquet`; cloud Feast reads a BigQuery table or view |
+| Feast runtime state | local `.state/feast/*` files and cloud GCS paths keep Feast metadata separate from curated data |
+| Terraform baseline | Terraform provisions GCS, BigQuery, and Datastore surfaces without changing feature semantics |
 
-Terraform is part of the storage boundary because it provisions the cloud-side GCS and BigQuery surfaces that the feature pipeline expects. It should supply the bucket, dataset, and table baseline while leaving ingest, engineering, validation, storage, and Feast preparation responsible for their own stage contracts.
-
-That means storage normalization is role-specific. The local baseline now normalizes the blob-style surfaces onto MinIO, but the cloud target still keeps curated features in BigQuery and the Feast online store in Datastore rather than flattening everything behind one object API.
+Terraform is part of the storage boundary because it provisions the cloud-side GCS and BigQuery surfaces that the feature pipeline expects. It should supply the bucket, dataset, and table baseline while leaving ingest, engineering, validation, storage, and Feast preparation responsible for their own stage contracts. The local baseline uses MinIO for blob-style surfaces, but the cloud target still keeps curated features in BigQuery and the Feast online store in Datastore rather than flattening everything behind one object API.
 
 ## Feast Boundary
 
@@ -159,11 +170,11 @@ Feast is downstream from the curated feature store. It should consume curated ro
 
 <div class="mermaid">
 flowchart LR
-    STORED[Stored curated rows] --> OFF[build_offline_store_frame]
-    STORED --> ENT[build_entity_rows]
-    OFF --> HIST[Historical retrieval inputs]
+    STORED["Stored curated rows"] --> OFF["build_offline_store_frame"]
+    STORED --> ENT["build_entity_rows"]
+    OFF --> HIST["Historical retrieval inputs"]
     ENT --> HIST
-    HIST --> EXP[export_offline_store]
+    HIST --> EXP["export_offline_store"]
 </div>
 
 That means:

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -1,60 +1,85 @@
-# Hosted Full-Stack (Transitional Operator Host)
+# Hosted Full-Stack (Retained Operator Host)
 
-FoehnCast keeps the hosted full-stack target as the current private operator lane. It runs Airflow, MLflow, the FastAPI app, and the monitoring stack on one Compute Engine host while Cloud Run carries the public API lane. This host is transitional: it keeps the current operator stack online while hosted image builds move toward Cloud Build and hosted orchestration moves toward Cloud Composer.
+FoehnCast keeps the hosted full-stack target as the private operator lane in the active shared environment. It runs Airflow, MLflow, the FastAPI app, and the monitoring stack on one Compute Engine host while Cloud Run carries the public API lane. This retained host keeps the operator stack online while hosted image builds move toward Cloud Build and hosted orchestration moves toward Cloud Composer.
 
-This page records the current hosted full-stack contract that is described by the cloud bootstrap, Terraform reference, and cloud-operator tests. It focuses on the active shared runtime target, not on future migrations.
+This page describes the hosted full-stack contract. It focuses on the active shared runtime target, not on future migrations.
 
 !!! note "Scope"
 
-    This page describes the current retained operator host contract.
-    It explains why that host is transitional rather than the intended long-term hosted control plane.
+    This page describes the validated retained operator host contract.
+    It explains why that host is a retained operator surface rather than the intended long-term hosted control plane.
     It is not the Composer cutover plan.
 
 ## Target Shape
 
 <div class="mermaid">
 flowchart LR
-    TF[Terraform baseline] --> GCP[Shared GCP resources]
-    GCP --> HOST[Online compose host]
-    GH[GitHub OIDC delivery] --> HOST
+    classDef infra fill:#f5f5f5,stroke:#333
+    classDef runner fill:#f4f1ea,stroke:#f05032
+    classDef platform fill:#fff,stroke:#4285F4
+    classDef operator fill:#fff8e1,stroke:#f57f17
 
-    BQ[(BigQuery curated features)] --> HOST
-    GCS[(GCS artifacts and Feast registry)] --> HOST
-    DS[(Datastore online store)] --> HOST
+    TF["Terraform baseline"]:::infra
+    GH["fab:fa-github GitHub Actions + OIDC"]:::runner
 
-    HOST --> APP[FastAPI app]
-    HOST --> AIR[Airflow]
-    HOST --> MLF[MLflow]
-    HOST --> MON[Prometheus + StatsD exporter + Grafana]
-    HOST --> SYNC[Repo sync timer]
-    SYNC --> MET[/metrics sync status]
-    MET --> MON
+    subgraph GCP ["fab:fa-google Hosted environment"]
+        direction LR
+        DATA["BigQuery + GCS + Datastore"]:::platform
+        HOST["Compute Engine operator host"]:::operator
+        APP["FastAPI app"]:::operator
+        AIR["Airflow"]:::operator
+        MLF["MLflow"]:::operator
+        MON["Prometheus + StatsD + Grafana"]:::operator
+        SYNC["Repo sync timer"]:::operator
+    end
+
+    TF --> DATA
+    DATA --> HOST
+    GH --> HOST
+    HOST --> APP
+    HOST --> AIR
+    HOST --> MLF
+    HOST --> MON
+    HOST --> SYNC
+    SYNC --> APP
+    APP --> MON
 </div>
 
 ## Role In The Shared Environment
 
-| Lane | Current target | Main role |
+| Lane | Concrete target | Main role |
 |------|----------------|-----------|
 | Shared API lane | Cloud Run hosted inference target | serve the public FastAPI routes |
-| Operator lane | hosted full-stack target on one VM | keep Airflow, MLflow, monitoring, and private app checks online while the managed hosted control plane is not ready yet |
+| Operator lane | hosted full-stack target on one VM | provide the active operator surface until the managed hosted control plane is ready |
 
-The important boundary is that the hosted full-stack target stays a runtime target, not a contributor environment. It depends on shared GCP storage and identity surfaces instead of local emulators, updates through the maintainer bootstrap plus remote Terraform and host sync path, and stays on the private operator side while Cloud Run owns public serving. It is a retained support lane, not the target hosted architecture.
+The hosted full-stack target stays a runtime target, not a contributor environment. It depends on shared GCP storage and identities instead of local emulators, and it stays private while Cloud Run owns public serving.
+
+## Shared Core And Hosted Differences
+
+| Shared with the local evaluator | Different in the hosted operator lane |
+|------|--------------------------------------|
+| Same Feature-Training-Inference boundaries | BigQuery, GCS, and Datastore replace local object and emulator surfaces |
+| Same FastAPI app and Feast-backed feature path | Cloud Run carries the shared public API while the host stays private |
+| Same Airflow, MLflow, and monitoring roles | one VM bundles the operator stack until the managed control plane takes over |
+| Same repository and runtime contracts | service accounts and GitHub OIDC replace local developer credentials |
+
+That makes the hosted full-stack target a retained support lane, not the target hosted architecture.
 
 ## Surface Responsibilities
 
 | Surface | Main responsibility | Must not become |
 |------|----------------------|-----------------|
 | Shared GCP baseline | provide Artifact Registry, GCS, BigQuery, Datastore, and identity foundations | the application runtime itself |
-| Online compose host | keep the current operator stack online from one VM | a contributor setup path, notebook host, or long-term orchestration authority |
+| Online compose host | keep the active operator stack online from one VM | a contributor setup path, notebook host, or long-term orchestration authority |
 | FastAPI app | serve the product and service routes | a hidden deployment control plane |
 | Airflow, MLflow, Prometheus, StatsD exporter, and Grafana | operator orchestration, tracking, monitoring, and review | the rider-facing interface |
 | GitHub OIDC delivery | run remote Terraform and image-driven deploy updates | a substitute for the runtime host |
 
-This keeps the current shared environment honest. The runtime lives on the host, while Terraform and GitHub delivery keep the dependencies and rollout path reviewable.
+This keeps the shared environment honest. The runtime lives on the host, while Terraform and GitHub delivery keep the dependencies and rollout path reviewable.
 
 ## Runtime Contract
 
-The hosted full-stack target currently relies on these shared runtime dependencies:
+The hosted full-stack target relies on these shared runtime dependencies:
 
 - BigQuery for the curated cloud feature layer
 - GCS for MLflow artifacts and Feast registry-style storage
@@ -70,11 +95,11 @@ The identity split around this target is deliberate:
 - Cloud Run uses its own narrower runtime identity for the inference-only service.
 - the online compose host uses a separate runtime identity because it still bundles Airflow, training, MLflow, Feast preparation, and the app on one VM.
 
-That online compose runtime identity is the current transition contract. It remains broader than the Cloud Run identity only because the host still owns more responsibilities today. The intended hosted direction is to remove Airflow from this VM rather than to keep widening what the VM owns.
+That online compose runtime identity is the retained-operator contract. It remains broader than the Cloud Run identity only because the host still owns more responsibilities in the active shared environment. The intended hosted direction is to remove Airflow from this VM rather than to keep widening what the VM owns.
 
 ## Bootstrap And Day-2 Delivery
 
-The hosted full-stack target is not part of the default contributor path. Its lifecycle still splits into one-time maintainer bootstrap and GitHub-managed day-2 delivery after bootstrap. For this current target, the hosted-specific contract is simple: Terraform provisions the VM and shared cloud data surfaces, the host sync refreshes the repository and runtime `.env`, and the VM app must stay private while Cloud Run remains the public API lane.
+The hosted full-stack target is not part of the default contributor path. Its lifecycle still splits into one-time maintainer bootstrap and GitHub-managed day-2 delivery after bootstrap. For this target, the hosted-specific contract is simple: Terraform provisions the VM and shared cloud data surfaces, the host sync refreshes the repository and runtime `.env`, and the VM app must stay private while Cloud Run remains the public API lane.
 
 See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed bootstrap, remote Terraform, and runtime-release handoff steps.
 
@@ -82,7 +107,7 @@ See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the 
 
 The online compose host is not meant to drift indefinitely after the first apply.
 
-The current sync contract is:
+The sync contract is:
 
 - the host installs a `foehncast-online-compose-sync` systemd timer
 - each sync fetches the configured Git ref and refreshes the hosted compose stack
@@ -98,7 +123,7 @@ This sync path matters only while the retained host still owns operator duties. 
 
 The shared hosted target keeps exposure narrow by default.
 
-The current contract is:
+The exposure contract is:
 
 - `online_compose_public_ports = []` keeps the operator host private by default
 - Airflow and MLflow stay private unless you intentionally expose their ports

--- a/docs/site/system/inference-pipeline.md
+++ b/docs/site/system/inference-pipeline.md
@@ -1,12 +1,12 @@
 # Inference Pipeline
 
-FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs in three places: the local evaluator lane, the public API lane on Cloud Run, and the private operator lane on the hosted full-stack target. The Cloud Run lane is the shared public API. The operator-lane app is a transitional support surface that stays private while the hosted control plane moves away from the retained host. The serving path resolves the live MLflow alias, fetches fresh forecasts for configured spots, rebuilds the shared engineered feature vector, returns per-spot quality predictions, and optionally exposes the Feast-backed online lookup without pulling training or operator concerns into the request path.
+FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs locally, on Cloud Run, and on the private operator lane. Cloud Run is the shared public API. The operator-lane app stays private and supports internal checks on the hosted operator surface.
 
-This page records the current serving contract that is validated in the local stack and in endpoint, dashboard, and cloud-runtime tests. It focuses on what the running app owns today and what stays optional or operator-controlled.
+This page describes what the running app owns and what stays optional or operator-controlled.
 
 !!! note "Scope"
 
-    This page describes the current validated inference-path contract.
+    This page describes the validated inference-path contract.
     It does not redefine the hosted build or orchestration plan.
     The serving contract stays stable even as the surrounding hosted control plane moves toward Cloud Build and Cloud Composer.
 
@@ -14,19 +14,45 @@ This page records the current serving contract that is validated in the local st
 
 <div class="mermaid">
 flowchart LR
-    REQ[Requested spots] --> RES[Resolve configured spots]
-    RES --> WX[Fetch Open-Meteo forecast]
-    WX --> ENG[Engineer shared features]
-    REG[MLflow serving alias] --> MOD[Load served model]
+    subgraph RequestPath ["Request path"]
+        direction TB
+        REQ["Requested spots"]
+        RES["Resolve configured spots"]
+        WX["Fetch Open-Meteo forecast"]
+        ENG["Engineer shared features"]
+        REQ --> RES --> WX --> ENG
+    end
+
+    subgraph ModelPath ["Model path"]
+        direction TB
+        REG["MLflow serving alias"]
+        MOD["Load served model"]
+        REG --> MOD
+    end
+
+    subgraph OutputPath ["Outputs"]
+        direction TB
+        PRE["/predict response"]
+        RNK["Rank with rider profile and drive time"]
+        OUT["/rank response"]
+        MON["Prediction monitoring hand-off"]
+        PRE --> RNK --> OUT
+    end
+
+    subgraph OptionalPath ["Demo surfaces"]
+        direction TB
+        ONL["/features/online lookup"]
+        DEMO["Online-features demo"]
+        DASH["Streamlit live demo"]
+        ONL --> DEMO
+    end
+
     ENG --> MOD
-    MOD --> PRE[/predict response]
-    PRE --> RNK[Rank with rider profile and drive time]
-    RNK --> OUT[/rank response]
-    RES --> ONL[/features/online lookup]
-    ONL --> DEMO[Online-features demo]
-    DASH[Streamlit live demo] --> PRE
+    MOD --> PRE
+    RES --> ONL
+    DASH --> PRE
     DASH --> OUT
-    PRE --> MON[Prediction monitoring hand-off]
+    PRE --> MON
     OUT --> MON
 </div>
 
@@ -53,7 +79,7 @@ The app also serves `/metrics`, but that route belongs to the monitoring hand-of
 
 ## Model Resolution Boundary
 
-Inference serves one registry alias at a time. The current contract is:
+Inference serves one registry alias at a time. The serving contract is:
 
 - the registered model name is `foehncast-quality`
 - the default live alias is `champion`
@@ -68,8 +94,8 @@ This keeps serving aligned with the training registry contract without giving th
 The prediction path is intentionally narrow:
 
 - requested spot IDs are resolved against the configured spot list, and unknown spots return `404` instead of silently falling back
-- live weather comes from the current Open-Meteo forecast pull for each requested spot
-- the request horizon is capped by `inference.max_horizon_hours`, which is currently `14`
+- live weather comes from the Open-Meteo forecast pull for each requested spot
+- the request horizon is capped by `inference.max_horizon_hours`, which defaults to `14`
 - the same `engineer_features` step used by the feature path rebuilds the feature vector expected by the trained model
 - the served feature columns come from `model.features` in `config.yaml`
 - the app returns forecast rows as timestamps plus continuous `quality_index` values
@@ -80,9 +106,9 @@ That means the request path scores a trained model against fresh forecast featur
 
 `/rank` is not a second model. It reuses the prediction payload from `/predict` and then scores the candidate spots for the configured rider profile.
 
-The current ranking contract is:
+The ranking contract is:
 
-- ranking weights come from `config.yaml` and are currently `0.6` for peak quality, `0.3` for ride-versus-drive ratio, and `0.1` for rideable duration
+- ranking weights come from `config.yaml`; the default weights are `0.6` for peak quality, `0.3` for ride-versus-drive ratio, and `0.1` for rideable duration
 - drive-time cost comes from the rider profile plus the OSRM routing lookup
 - session duration is derived from the forecast hours that clear the rideable threshold
 - the route returns ranked numeric rows such as `quality_index`, `drive_minutes`, `session_hours`, `ride_drive_ratio`, and `score`
@@ -93,7 +119,7 @@ This keeps ranking personal without hiding another model behind the API. The Str
 
 The online feature route is a separate integration surface layered on top of the same curated contract.
 
-The current online-feature contract is:
+The online-feature contract is:
 
 - the default Feast repo path is `feature_repo/`, with `FOEHNCAST_FEAST_REPO_PATH` as an override
 - a call without explicit feature names uses the `foehncast_model_v1` feature service
@@ -107,18 +133,18 @@ This path stays optional. Normal `/predict` and `/rank` requests do not depend o
 
 FoehnCast keeps the rider-facing demo separate from operator dashboards.
 
-The current demo surfaces are:
+The demo surfaces are:
 
 - the Streamlit live demo, which loads live predictions, applies the ranking helper, and presents rider-facing cards and tables
 - the online-features demo page, which issues manual `/features/online` calls against the running app
 
-The Streamlit helper rounds continuous quality scores into stable rider-facing labels from `Unsafe` through `Perfect Storm`, uses the configured forecast horizon to describe the current live window, and exposes the current `model_version` in the returned payload. That makes it a public-safe evaluation surface, not an operator dashboard.
+The Streamlit helper rounds continuous quality scores into stable rider-facing labels from `Unsafe` through `Perfect Storm`, uses the configured forecast horizon to describe the live window, and exposes the served `model_version` in the returned payload. That makes it a public-safe evaluation surface, not an operator dashboard.
 
 ## Monitoring Hand-Off
 
 Prediction routes emit monitoring signals, but the monitoring surface itself stays separate.
 
-The current hand-off is:
+The monitoring hand-off is:
 
 - `/predict` and `/rank` schedule background prediction-monitoring work after a successful response payload is built
 - the background path records scheduling and execution outcomes and emits prediction-drift metrics from retained prediction history
@@ -126,29 +152,18 @@ The current hand-off is:
 
 This keeps the inference service responsible for request-side facts while leaving dashboards, alert rules, and long-range operator review to the monitoring stack.
 
-## Serving Targets Today
+## Serving Targets
 
-| Lane | Current target | Main role |
-|------|----------------|-----------|
-| Local evaluator lane | local Compose app | validate the full serving contract locally |
-| Shared API lane | hosted inference target on Cloud Run | serve the shared public API |
-| Operator lane | hosted full-stack target on one GCP host | keep the same app available for private operator checks next to Airflow and MLflow while the retained operator lane still exists |
+The same FastAPI app runs in the local evaluator, on Cloud Run, and on the private operator host. Cloud Run owns the shared public API. The operator host keeps the app available only for private checks next to the other hosted operator services.
 
-<div class="mermaid">
-flowchart LR
-    APP[Same FastAPI app] --> LOCAL[Local evaluator target]
-    APP --> RUN[Cloud Run API lane]
-    APP --> HOST[Operator host lane]
-</div>
-
-The same FastAPI app runs across these serving targets. Cloud Run owns the shared public API. The hosted full-stack target keeps the app available only for private operator checks next to the current runtime services, and that private lane should shrink rather than become the long-term public serving path. See [Hosted Full-Stack](hosted-full-stack.md) and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the hosted exposure, transition, and rollback rules around that split.
+See [Architecture](architecture.md) for the lane summary and [Hosted Full-Stack](hosted-full-stack.md) for the hosted exposure and transition rules.
 
 ## Why This Structure Works
 
 - it keeps live requests narrow enough to verify through simple route and dashboard tests
 - it reuses the shared feature contract instead of inventing a serving-only schema
 - it ties responses back to a concrete registry version without giving the app promotion authority
-- it lets one FastAPI contract run locally, on Cloud Run, and on the current retained hosted full-stack surface without changing the serving contract
+- it lets one FastAPI contract run locally, on Cloud Run, and on the retained hosted full-stack surface without changing the serving contract
 - it keeps the Feast lookup path useful for integration checks while leaving prediction and ranking available from the core app alone
 
 See [Architecture](architecture.md), [Training Pipeline](training-pipeline.md), [Monitoring](monitoring.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding system boundaries.

--- a/docs/site/system/interfaces-and-surfaces.md
+++ b/docs/site/system/interfaces-and-surfaces.md
@@ -1,170 +1,69 @@
 # Interfaces and Surfaces
 
-FoehnCast exposes different surfaces for riders, service clients, operators, delivery, and public-safe docs. This page records that boundary directly so readers do not have to reconstruct it from several other system pages.
+FoehnCast exposes five surface classes: rider, service, operator, delivery, and public-safe docs. This page defines who each surface is for and what should stay private.
 
 !!! note "Scope"
 
-    This page describes the current validated surface boundary.
-    It is not a proposal for a new product UI or admin model.
-    New routes or tools should be placed into one of these surface classes explicitly.
+    This page defines exposure boundaries.
+    Use runtime pages for deployed targets.
+    Use workflow pages for maintainer procedures.
 
 ## Surface Map
 
 <div class="mermaid">
 flowchart LR
-    subgraph Rider["Rider-facing demo surfaces"]
-        DASH[Streamlit rider console]
-        DEMO[/features/online/demo]
-    end
+    classDef public fill:#f5f5f5,stroke:#333
+    classDef service fill:#e1f5fe,stroke:#01579b
+    classDef operator fill:#fff8e1,stroke:#f57f17
+    classDef evidence fill:#ececff,stroke:#9370db
 
-    subgraph Service["Service endpoints"]
-        HEALTH[/health]
-        SPOTS[/spots]
-        PRED[/predict]
-        RANK[/rank]
-        FEAT[/features/online]
-    end
+    RIDER["Rider demos<br/>Streamlit and /features/online/demo"]:::public
+    SERVICE["Service routes<br/>/health, /spots, /predict, /rank, /features/online"]:::service
+    OPERATOR["Private operator surfaces<br/>/metrics, Airflow, MLflow, Prometheus, Grafana"]:::operator
+    DELIVERY["fab:fa-github Delivery<br/>GitHub Actions, Terraform, bootstrap"]:::public
+    EVIDENCE["Public-safe evidence<br/>Docs, summaries, screenshots"]:::evidence
 
-    subgraph Operator["Operator surfaces"]
-        MET[/metrics]
-        AIR[Airflow]
-        MLF[MLflow]
-        PROM[Prometheus]
-        GRAF[Grafana]
-    end
-
-    subgraph Delivery["Delivery surfaces"]
-        GHA[GitHub Actions]
-        TF[Terraform]
-        BSTR[Bootstrap scripts]
-    end
-
-    subgraph PublicSafe["Public-safe docs and evidence"]
-        DOCS[Docs pages]
-        EVID[Rendered summaries and screenshots]
-    end
-
-    DASH --> PRED
-    DASH --> RANK
-    DEMO --> FEAT
-    PRED --> MET
-    RANK --> MET
-    MET --> PROM
-    PROM --> GRAF
-    GHA --> TF
+    RIDER --> SERVICE
+    DELIVERY --> SERVICE
+    SERVICE --> OPERATOR
+    OPERATOR -. "Rendered outputs only" .-> EVIDENCE
 </div>
 
-The important split is that not every HTTP route is rider-facing, and not every visible screen is safe to treat as public documentation.
+The important split is simple: not every HTTP route is rider-facing, and not every visible screen is safe to treat as public documentation.
 
-## Runtime Lanes
+## Surface Classes
 
-| Lane | Current target | Main role | Exposure |
-|------|----------------|-----------|----------|
-| Local evaluator lane | local Compose stack | run the full evaluation surface on one machine | local-only |
-| Shared API lane | hosted inference target on Cloud Run | expose the public product and service routes | public |
-| Operator lane | hosted full-stack target on one GCP host | keep Airflow, MLflow, monitoring, and private app checks online while the managed hosted control plane is still transitional | private by default |
+| Surface class | Examples | Main audience | Default exposure |
+|------|----------|---------------|------------------|
+| Rider-facing demo surfaces | Streamlit rider console and `/features/online/demo` | rider, reviewer, contributor | public-safe when shown as screenshots, rendered examples, or a deliberate local demo |
+| Service endpoints | `/health`, `/spots`, `/predict`, `/rank`, and `/features/online` | clients, smoke tests, and app-side integrations | service-only |
+| Operator surfaces | `/metrics`, Airflow, MLflow, Prometheus, and Grafana | maintainer or deployment operator | private by default |
+| Delivery surfaces | GitHub Actions, Terraform, and bootstrap helpers | maintainer | review-controlled and not runtime-facing |
+| Public-safe docs and evidence | docs pages, rendered summaries, and screenshots | reviewer, fork reader, course audience | public-safe |
 
-The surface classes stay the same even as the hosted control plane changes. Today the operator lane still uses the retained host. The intended hosted direction is to keep the same operator-versus-public boundary while moving hosted build and orchestration into Google-managed services.
+## Exposure Rules
 
-## Current Surface Classes
-
-| Surface class | Current examples | Primary audience | Default exposure |
-|------|------------------|------------------|------------------|
-| Rider-facing demo surfaces | Streamlit live demo and `/features/online/demo` | rider, reviewer, contributor | public-safe when shown as screenshots, rendered examples, or a deliberate local demo |
-| Service endpoints | `/health`, `/spots`, `/predict`, `/rank`, and `/features/online` | clients, smoke tests, support services, and app-side integrations | service-only |
-| Operator dashboards and control planes | `/metrics`, Airflow, MLflow, Prometheus, and Grafana | maintainer or deployment operator | private by default, except for the hosted app route itself |
-| Delivery surfaces | GitHub Actions workflows, Terraform apply paths, and bootstrap helpers | maintainer | review-controlled and not runtime-facing |
-| Public-safe docs and evidence | docs pages, rendered markdown, summary JSON-derived charts, and screenshots | reviewer, fork reader, course audience | public-safe |
-
-So a surface can be technically reachable without being part of the rider-facing product boundary. The clearest example is `/metrics`: it is an application endpoint, but it belongs to the operator monitoring contract rather than to the public product surface.
-
-## Rider-Facing Demo Surfaces
-
-The current rider-facing layer is intentionally small.
-
-| Surface | What it does today | Must not become |
-|------|---------------------|-----------------|
-| Streamlit rider console | loads live predictions and rankings, shows configured rider profile, and presents rider-facing cards and tables | an operator dashboard or deployment control plane |
-| `/features/online/demo` | gives a lightweight manual page that calls `/features/online` against the running app | the main product UI |
-
-The Streamlit app is a real evaluation surface, not a separate hidden model path. It reuses the same prediction and ranking helpers as the API. The online-features demo is narrower: it exists to make the optional Feast-backed lookup path easy to test manually without turning that lookup into the product itself.
-
-## Service API Surfaces
-
-The current service API stays request-focused.
-
-| Endpoint | Current responsibility |
-|------|-------------------------|
-| `/health` | report readiness plus the served model alias and model version |
-| `/spots` | return the configured spot set |
-| `/predict` | return per-spot forecast rows with continuous `quality_index` values |
-| `/rank` | score the prediction payload for the configured rider profile |
-| `/features/online` | return Feast-backed online feature rows for app-side integrations |
-
-These endpoints are service surfaces, not hidden training or promotion paths. `/predict` and `/rank` schedule background monitoring work after they build the response payload, but they do not take on the rest of the operator monitoring stack.
-
-## Operator Surfaces
-
-The operator layer is where orchestration, tracking, monitoring, and review live.
-
-| Surface | Current role |
-|------|--------------|
-| `/metrics` | expose the composed Prometheus payload for app-owned monitoring signals |
-| Airflow | run and inspect feature and training orchestration |
-| MLflow | track runs, model versions, and registry aliases |
-| Prometheus | scrape time-series targets |
-| Grafana | visualize dashboards and evaluate alert rules |
-
-This operator layer stays separate from the rider-facing and public-docs layers on purpose. The checked-in monitoring config disables anonymous Grafana access, public dashboards, and embedding by default. The local bootstrap applies local-only overrides only so a local run can verify provisioning without changing the hosted policy.
-
-## Delivery Surfaces
-
-The delivery layer is separate from the runtime operator layer.
-
-| Surface | Current role |
-|------|--------------|
-| GitHub Actions | lint, test, build, publish, and reviewed deploy or Terraform workflows |
-| Terraform | declare the cloud contract and apply reviewed infrastructure changes |
-| Bootstrap helpers | perform one-time environment setup and repository-variable seeding |
-
-These surfaces are not the runtime orchestrator. GitHub Actions advances reviewed delivery. Today the runtime scheduling, retry, and backfill surface still lives on the retained hosted Airflow path, and the target hosted orchestrator is Cloud Composer.
-See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed delivery-versus-runtime ownership and retry or backfill rules.
-
-## Public-Safe Docs And Evidence
-
-The public docs site is a separate surface class, not a mirror of the live control plane.
-
-Preferred public-safe evidence sources are:
-
-- docs pages that summarize the current contracts
-- rendered markdown excerpts and summary-derived charts
-- screenshots of rider-facing or operator surfaces when explanation needs a picture
-- persisted summary artifacts under `airflow/reports/` or retained event history under `.state/monitoring/` when you are showing structure rather than sensitive live state
-
-Avoid treating these as public documentation surfaces:
-
-- live Grafana embeds
-- live Airflow or MLflow admin views
-- private hosted operator URLs pasted directly into public docs
-
-That rule keeps the docs understandable in review without leaking a live control plane into the public site.
+- `/metrics` is an operator surface even though it is an app route.
+- Streamlit and `/features/online/demo` are evaluation surfaces, not deployment control planes.
+- GitHub Actions and Terraform advance reviewed delivery, but they do not own runtime scheduling, retries, or backfills.
+- Public docs should use rendered evidence or screenshots instead of live Airflow, MLflow, Prometheus, or Grafana views.
 
 ## Exposure By Runtime Mode
 
 | Runtime mode | Product or service surface | Operator-only surface |
 |------|-----------------------------|-----------------------|
-| Local evaluator | local app routes, local Streamlit demo, optional online-features demo | local Airflow, MLflow, Prometheus, and Grafana |
-| Operator lane | no public app route by default | Airflow, MLflow, Prometheus, and Grafana stay private unless deliberately exposed |
+| Local evaluator | local app routes, local Streamlit demo, and the optional online-features demo | local Airflow, MLflow, Prometheus, and Grafana |
 | Shared API lane | hosted inference API only | no hosted Airflow or MLflow container in that target |
+| Operator lane | no public app route by default | Airflow, MLflow, Prometheus, and Grafana stay private unless deliberately exposed |
 | Public docs site | rendered docs and evidence only | no live control planes |
 
-The same rule holds in the shared hosted environment: app routes form the product and service surface, while operator tools stay private unless an operator intentionally publishes them. See [Hosted Full-Stack](hosted-full-stack.md) and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the hosted operator-lane and rollback rules.
+The same split applies in local and cloud runtimes: app routes form the product and service surface, while operator tools stay private unless an operator intentionally publishes them.
 
 ## Why This Boundary Works
 
 - it lets the rider-facing demo reuse the real serving path without turning the product into an admin console
 - it keeps service endpoints narrow enough for smoke tests and client integrations
-- it leaves orchestration, tracking, monitoring, and alerting on the operator side
+- it keeps orchestration, tracking, monitoring, and alerting on the operator side
 - it gives the public docs stable evidence sources that do not depend on exposing private hosted dashboards
 
 See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Inference Pipeline](inference-pipeline.md), [Monitoring](monitoring.md), [Local Evaluator](local-evaluator.md), and [Hosted Full-Stack](hosted-full-stack.md) for the surrounding runtime contracts.

--- a/docs/site/system/local-evaluator.md
+++ b/docs/site/system/local-evaluator.md
@@ -2,34 +2,47 @@
 
 FoehnCast uses the local evaluator lane as the default contributor runtime. `bootstrap-local` starts the validated service subset, resets disposable local state, runs one end-to-end feature and training hand-off, prepares Feast serving state, and verifies the app and operator contracts before it reports success.
 
-This page records the current local runtime contract that is validated by the bootstrap path and by the runtime-stack and monitoring-stack tests. It describes the current baseline, not a future migration plan.
+This page describes the default contributor runtime contract. It documents the supported baseline, not a migration plan.
 
 !!! note "Scope"
 
-    This page describes the current validated local evaluator target.
+    This page describes the validated local evaluator target.
     It is not a roadmap.
-    Future changes should be documented after they are chosen and implemented.
+    Future changes belong here only after the target changes.
 
 ## Target Shape
 
 <div class="mermaid">
 flowchart LR
-    BOOT[./scripts/bootstrap-local.sh] --> AIR[Airflow plus Postgres metadata]
-    BOOT --> APP[FastAPI app]
-    BOOT --> MLF[MLflow]
-    BOOT --> OBJ[MinIO objectstore]
-    BOOT --> FEAST[Feast Datastore emulator]
-    BOOT --> MON[Prometheus plus StatsD exporter plus Grafana]
+    classDef pipeline fill:#e1f5fe,stroke:#01579b
+    classDef registry fill:#fff,stroke:#d32f2f
+    classDef app fill:#222,stroke:#333,color:#fff
+    classDef storage fill:#fff,stroke:#9370db
+    classDef monitor fill:#fff,stroke:#f57f17
 
-    AIR --> FEAT[feature_pipeline DAG]
-    FEAT --> CUR[(Curated feature data)]
-    FEAT --> REQ[training-request asset]
-    REQ --> TRN[training_pipeline DAG]
-    TRN --> REG[(MLflow registry)]
-    REG --> APP
+    subgraph LocalStack ["fab:fa-docker Local stack"]
+        direction LR
+        AIR["Airflow"]:::pipeline
+        FEAT["Feature DAG"]:::pipeline
+        CUR["Curated feature data"]:::storage
+        REQ["Training-request asset"]:::pipeline
+        TRN["Training DAG"]:::pipeline
+        REG["MLflow registry"]:::registry
+        FEAST["Feast emulator"]:::storage
+        APP["FastAPI app"]:::app
+        MON["Prometheus + StatsD + Grafana"]:::monitor
+    end
+
+    AIR --> FEAT
+    AIR --> TRN
+    FEAT --> CUR
+    FEAT --> REQ
     CUR --> FEAST
-    APP --> MET[/metrics]
-    MET --> MON
+    REQ --> TRN
+    TRN --> REG
+    REG --> APP
+    FEAST --> APP
+    APP --> MON
 </div>
 
 The local evaluator is a real runtime target, not a mock environment:
@@ -55,7 +68,7 @@ If the preferred local ports are already occupied, the bootstrap moves the bindi
 
 ## Runtime Surfaces
 
-| Surface | Current role in the local evaluator | Must not become |
+| Surface | Role in the local evaluator | Must not become |
 |------|--------------------------------------|-----------------|
 | FastAPI app | serve `/health`, `/spots`, `/predict`, `/rank`, `/features/online`, and `/metrics` | a hidden training or operator control plane |
 | Airflow plus Postgres metadata database | run feature and training orchestration with asset hand-offs | a notebook-only demo path |
@@ -71,7 +84,7 @@ This keeps the local lane close to the hosted architecture. The object-access la
 
 The local evaluator reports success only after the runtime proves several real contracts.
 
-The current verification path includes:
+The verification path includes:
 
 - Airflow component health checks for the webserver, dag-processor, scheduler, triggerer, and metadata database
 - an Airflow API health payload check instead of treating `200 OK` alone as enough
@@ -87,7 +100,7 @@ That makes the local lane more than a container smoke test. It exercises the sam
 
 The local evaluator resets disposable state aggressively, but it still keeps the important contracts explicit.
 
-The current split is:
+The state split is:
 
 - disposable Airflow metadata and logs are cleared by the bootstrap path
 - curated features and MLflow artifacts use the MinIO-backed local objectstore baseline for the run

--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -1,29 +1,29 @@
 # Monitoring
 
-FoehnCast keeps monitoring as an operator surface, not a rider-facing one. The monitoring stack turns pipeline summaries, retained prediction events, drift signals, and hosted sync state into scrapeable metrics and checked-in alert rules without changing the runtime contracts those signals describe. In the shared hosted path today, some of that operator evidence still comes from the retained host. That host is transitional, but the monitoring boundary itself stays the same.
+FoehnCast keeps monitoring as an operator surface, not a rider-facing one. The monitoring stack turns pipeline summaries, retained prediction events, drift signals, and hosted sync state into scrapeable metrics and checked-in alert rules.
 
-This page records the current monitoring design that is validated in the local stack and in regression tests. It focuses on what is measured today, where the evidence comes from, and how the operator path stays separate from the public docs surface.
+This page describes what is measured, where the evidence comes from, and how operators verify it.
 
 !!! note "Scope"
 
-    This page describes the current validated monitoring contract.
-    It focuses on the current monitoring evidence and boundaries.
+    This page describes the validated monitoring contract.
+    It focuses on the monitoring evidence and boundaries.
     It does not treat the retained host as the desired long-term hosted control plane.
 
 ## Signal Path
 
 <div class="mermaid">
 flowchart LR
-    AIR[Airflow pipeline summaries] --> APP[/App /metrics/]
-    PRED[Prediction requests] --> LOG[Prediction log and event history]
-    LOG --> DRIFT[Evidently drift checks]
-    DRIFT --> STATSD[StatsD exporter]
-    SYNC[Hosted sync status file] --> APP
+    AIR["Airflow pipeline summaries"] --> APP["App /metrics"]
+    PRED["Prediction requests"] --> LOG["Prediction log and event history"]
+    LOG --> DRIFT["Evidently drift checks"]
+    DRIFT --> STATSD["StatsD exporter"]
+    SYNC["Hosted sync status file"] --> APP
     LOG --> APP
-    APP --> PROM[Prometheus]
+    APP --> PROM["Prometheus"]
     STATSD --> PROM
-    GRAFANA[Grafana] --> PROM
-    PROM --> DASH[Dashboards and alert rules]
+    PROM --> GRAFANA["Grafana"]
+    GRAFANA --> DASH["Dashboards and alert rules"]
 </div>
 
 The important split is that monitoring consumes persisted or runtime monitoring state after the pipeline and serving paths run. It does not own feature engineering, model scoring, or orchestration itself.
@@ -33,91 +33,38 @@ The important split is that monitoring consumes persisted or runtime monitoring 
 | Runtime mode | Monitoring contract | Exposure boundary |
 |------|---------------------|-------------------|
 | Local evaluator | app `/metrics`, StatsD drift export, persisted pipeline summaries, and local Grafana dashboards validate the full monitoring path on one machine | local-only |
-| Shared hosted environment | Cloud Run exposes the app-owned `/metrics` contract, while the current operator host keeps Prometheus, Grafana, hosted sync evidence, and operator review online until the managed hosted control plane absorbs more of that work | operator stack stays private by default |
+| Shared hosted environment | Cloud Run exposes the app-owned `/metrics` contract, while the active operator lane keeps Prometheus, Grafana, hosted sync evidence, and operator review online until the managed hosted control plane absorbs more of that work | operator stack stays private by default |
 | Public docs | rendered metrics snippets, screenshots, checked-in configs, and summary artifacts explain the monitoring contract | no live control planes |
 
 The public-versus-private surface rule itself is documented in [Interfaces and Surfaces](interfaces-and-surfaces.md). This page stays focused on what monitoring measures and how operators verify it.
 
-## Surface Roles
+## Evidence Sources
 
-| Surface | What it exposes | Why it matters |
-|------|------------------|----------------|
-| `airflow/reports/*.json` | latest feature and training pipeline summaries plus timestamped history | gives the app and operator tooling a stable pipeline-run contract |
-| `.state/monitoring/prediction-events.jsonl` | retained prediction-event history by model version | preserves inference evidence across restarts |
-| `.state/monitoring/prediction-log.jsonl` | bounded working set used for prediction-side drift evaluation | keeps drift windows small enough for local evaluation |
-| `.state/online-compose-sync/last-success.json` | latest hosted sync success marker | lets operators detect stale hosted updates |
-| app `/metrics` | pipeline summaries, retained prediction history, hosted sync state, and in-process monitoring counters | gives Prometheus one stable scrape surface for app-owned monitoring state |
-| StatsD exporter | drift metrics pushed from Evidently-backed checks | keeps drift signals scrapeable without inventing a second app-owned registry |
-| Prometheus and Grafana | time-series storage, dashboard panels, and alert evaluation | provides the operator view and alerting layer |
+| Source | Kind | What it shows |
+|------|------|---------------|
+| `airflow/reports/*.json` | durable evidence | latest feature and training pipeline summaries plus history |
+| `.state/monitoring/prediction-events.jsonl` | durable evidence | retained prediction-event history by model version |
+| `.state/monitoring/prediction-log.jsonl` | durable working set | recent prediction history for prediction-side drift evaluation |
+| `.state/online-compose-sync/last-success.json` | durable evidence | latest hosted sync success marker |
+| app `/metrics` | composed scrape surface | app-owned monitoring state and summary-derived metrics |
+| StatsD exporter | scrape surface | Evidently-backed drift metrics |
+| Prometheus and Grafana | operator tooling | time-series storage, dashboards, and alert evaluation |
 
-## Durable And Ephemeral Signals
+Durable files survive restarts and support audits. Runtime counters on `/metrics` describe process health and reset with the process.
 
-The monitoring stack uses both durable and ephemeral signals.
+## Metrics And Drift
 
-Durable signals survive restarts and provide historical evidence:
+The serving application publishes one composed Prometheus payload on `/metrics`. It includes feature and training summary metrics, retained prediction-history metrics, hosted sync status metrics, and in-process scheduling or execution counters.
 
-- feature and training pipeline summaries under `airflow/reports/`
-- timestamped summary history alongside the latest pipeline summaries
-- retained prediction-event history in `.state/monitoring/prediction-events.jsonl`
-- hosted compose sync status in `.state/online-compose-sync/last-success.json`
-
-Ephemeral signals are runtime-only counters that reset on restart:
-
-- prediction-monitoring schedule counts
-- prediction-monitoring execution counts
-- last successful background monitoring execution timestamps
-
-The app combines both kinds of signals on `/metrics`, but the distinction still matters operationally. Durable files support audits and restarts. Ephemeral counters describe current process health.
-
-## Metrics Surface
-
-The serving application publishes one composed Prometheus payload on `/metrics`.
-
-That payload includes:
-
-- feature pipeline summary metrics rendered from the latest persisted summary
-- training pipeline summary metrics rendered from the latest persisted summary
-- retained prediction-log metrics grouped by model version
-- hosted online-compose sync status metrics
-- in-process prediction-monitoring counters for scheduling and execution outcomes
+Drift detection is backed by Evidently and exported through StatsD. Feature drift compares reference and current feature datasets on shared columns. Prediction drift compares retained prediction history across reference and recent windows. Emitted StatsD metrics are mapped into Prometheus as `foehncast_drift_metric`.
 
 This keeps the operator scrape path simple: Prometheus reads the app surface for app-owned monitoring state and the StatsD exporter for drift metrics.
 
-## Drift Monitoring
+## Dashboards And Alerts
 
-Drift detection is backed by Evidently and exported through StatsD.
+Prometheus scrapes the app on `/metrics`, the StatsD exporter, and Grafana itself. Grafana is provisioned from repository-owned dashboards and alert rules.
 
-The current contract is:
-
-- feature drift compares reference and current feature datasets on shared columns
-- prediction drift compares retained prediction history across reference and recent windows
-- drift thresholds and evaluation windows come from the monitoring config, with validated fallbacks in code
-- emitted StatsD metrics are mapped into Prometheus as `foehncast_drift_metric`
-
-This means the Grafana dashboard can show both dataset-level drift share and column-level drift signals without making the app own another custom metric family.
-
-## Prometheus And Grafana
-
-The checked-in Prometheus config scrapes three operator targets:
-
-- the app on `/metrics`
-- the StatsD exporter
-- Grafana itself
-
-Grafana is provisioned from repository-owned dashboards and alert rules. The validated monitoring dashboard includes panels for:
-
-- feature and training pipeline summary counts
-- stage durations and stage failure counts
-- feature and inference drift share
-- retained prediction-log size and model coverage
-- prediction-monitoring schedule failures
-- seconds since the last hosted sync
-
-That makes the dashboard a view over checked-in metrics contracts rather than a manually assembled local-only artifact.
-
-The same dashboard contract works in the local evaluator and in the active shared environment. What changes is the runtime around it, not the meaning of the monitored signals.
-
-That distinction matters during the hosted migration too. The operator evidence sources may move, but the monitoring contract should stay reviewable through the same metrics, alerts, and checked-in dashboards.
+The checked-in dashboard covers pipeline summary counts, stage durations and failures, feature and inference drift share, retained prediction-log size and model coverage, prediction-monitoring schedule failures, and seconds since the last hosted sync.
 
 ## Alert Rules
 
@@ -138,26 +85,24 @@ The contact point and policy tree stay checked in too, so the alert routing cont
 
 Recovery work should leave durable evidence that operators can compare before and after the intervention.
 
-| Recovery task | Durable evidence to capture | Operator check |
-|------|-----------------------------|----------------|
-| feature retry or backfill | `airflow/reports/feature-pipeline-<dataset>-latest.json` plus the matching history file | the latest summary timestamp advances and the feature-stage failure alert clears |
-| training follow-up after a replay | `airflow/reports/training-pipeline-<dataset>-latest.json` plus the matching history file | the summary records the requested stage, registered model version, and no training-stage failure alert remains |
-| reviewed deploy, promote, or rollback handoff retry | `airflow/reports/runtime-release-latest.json` plus the matching history file | the GitHub workflow summary and the runtime-side acknowledgement describe the same action and coordinates |
-| retained operator host refresh verification | `.state/online-compose-sync/last-success.json` | the hosted-sync stale signal clears and the app republishes the updated sync state on `/metrics` |
+| Recovery task | Evidence | Check |
+|------|----------|-------|
+| feature retry or backfill | latest feature summary JSON plus history | summary timestamp advances and the feature-stage alert clears |
+| training follow-up after a replay | latest training summary JSON plus history | stage and model version are recorded and the training-stage alert clears |
+| deploy, promote, or rollback handoff retry | latest runtime-release summary JSON plus history | GitHub summary and runtime acknowledgement match |
+| retained operator host refresh verification | latest sync status file | hosted-sync stale signal clears and `/metrics` republishes the new sync state |
 
 Capture the initiating run reference with the summary artifacts: the GitHub workflow URL for reviewed delivery, or the logical date and DAG run id for hosted Airflow recovery.
 
-These checks stay intentionally small. They give operators one repeatable evidence pack without turning the monitoring stack into the system that performs the recovery itself. The retained-host sync evidence is part of the current operational contract, not a claim that the VM should remain the permanent monitoring or orchestration anchor. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the retry and backfill procedures.
+These checks stay intentionally small. They give operators one repeatable evidence pack without turning the monitoring stack into the system that performs the recovery itself. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the retry and backfill procedures.
 
-## Reading Evidence Safely
+## Public-Safe Evidence
 
 Explain monitoring with rendered evidence, not live control-plane embeds.
 
-Preferred public-safe evidence sources are:
-
 - rendered `/metrics` snippets or screenshots
-- the checked-in Prometheus scrape config
-- the checked-in Grafana dashboard and alert-rule definitions
+- checked-in Prometheus scrape config
+- checked-in Grafana dashboards and alert rules
 - pipeline summary JSON artifacts under `airflow/reports/`
 - retained prediction-event files under `.state/monitoring/` when showing structure rather than sensitive runtime data
 

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -2,7 +2,7 @@
 
 The repository keeps runtime code, orchestration, tests, and public documentation separate so the same Feature-Training-Inference split stays visible in both the source tree and the deployment story.
 
-## Current Layout
+## Main Layout
 
 ```text
 src/foehncast/
@@ -13,6 +13,7 @@ src/foehncast/
   monitoring/
   spots/
 dags/
+containers/
 scripts/
 terraform/
 feature_repo/
@@ -25,12 +26,11 @@ docs/
 ## Repository Roles
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
   CODE[src/foehncast] --> APP[Feature + Training + Inference + Monitoring code]
   DAGS[dags] --> ORCH[Airflow orchestration]
+  CNT[containers] --> PACK[Containerized runtime packaging]
   OPS[scripts + terraform] --> DELIV[Bootstrap and hosted delivery]
-  FEAST[feature_repo] --> STORE[Feast integration contract]
-  MON[prometheus_config + grafana_work] --> OBS[Checked-in operator monitoring]
   TESTS[tests] --> VERIFY[Regression validation]
   DOCS[docs] --> SITE[Public documentation]
 </div>
@@ -39,49 +39,20 @@ flowchart LR
 
 - `src/foehncast/`: the application modules for configuration, feature engineering, training, inference, monitoring, and spot metadata.
 - `dags/`: Airflow entry points for the feature and training workflows.
-- `scripts/`: local bootstrap, cloud bootstrap, remote Terraform, and helper scripts.
-- `terraform/`: hosted infrastructure definition plus operator-facing notes.
-- `feature_repo/`: the Feast integration repo and configuration surface.
-- `prometheus_config/` and `grafana_work/`: the checked-in operator-monitoring configuration for Prometheus and Grafana, not a separate product UI.
-- `tests/`: regression coverage for the core pipeline logic and API behavior.
-- `docs/`: the public documentation site and system notes.
 
-One local workload data root lives under `data/`, while local runtime state stays separate. For example, curated feature rows and Feast offline parquet belong under `data/`, but local Feast registry, rendered runtime config, and inference prediction logs belong under `.state/` instead of mixing service state into the workload dataset tree.
+| Area | What it holds |
+|------|---------------|
+| `src/foehncast/` | application code for configuration, features, training, inference, monitoring, and spot metadata |
+| `dags/` | Airflow entry points for feature and training workflows |
+| `containers/`, `scripts/`, and `terraform/` | runtime packaging, bootstrap helpers, and deployment tooling |
+| `feature_repo/`, `prometheus_config/`, and `grafana_work/` | Feast and operator-monitoring integration contracts |
+| `tests/` and `docs/` | regression coverage and public explanation |
 
-Airflow also writes operator-facing artifacts under `airflow/reports/`. That directory now includes the latest feature-pipeline run summary JSON and evaluation markdown outputs, and the local app mounts it so Prometheus and Grafana can expose the latest feature-pipeline monitoring panels. When those artifacts appear in public docs, prefer rendered markdown excerpts, static charts, or screenshots over live embeds of private operator tools.
+## Design Rules
 
-## Why The Layout Matters
+- Keep workload code inside `src/foehncast/`, but keep orchestration, infrastructure, delivery, tests, and docs beside it.
+- Keep workload defaults in `config.yaml`, and keep deployment-specific wiring in environment variables and Terraform inputs.
+- Keep workload data under `data/`, and keep runtime or integration state under `.state/`.
+- Keep operator evidence such as `airflow/reports/` reviewable, but show rendered evidence in public docs instead of live private dashboards.
 
-The runtime code lives under one package, while orchestration, operator scripts, infrastructure, tests, and docs stay beside it instead of being mixed into the same folder tree. That makes it easier to explain which parts define the model pipeline, which parts schedule it, which parts provision hosted environments, and which parts document the result.
-
-Central configuration lives in `config.yaml` and `src/foehncast/config.py`, so the feature, training, and inference paths read from the same settings model instead of scattering constants across modules.
-
-Feature engineering starts in `feature_pipeline/engineer.py`, where raw weather inputs are turned into the engineered feature vector shared by training and inference.
-
-There is no separate product UI package in the repository. The interactive demo surface lives inside the inference pipeline, for example `src/foehncast/inference_pipeline/demo.py`, rather than in a separate top-level app tree. Grafana does not fill that role; it remains an operator dashboard surface.
-
-## Configuration Ownership
-
-See [Configuration and Contracts](configuration-and-contracts.md) for the dedicated public overview of this boundary.
-
-- `config.yaml`: workload defaults and app-facing contracts such as rider, spots, API fields, validation, model settings, the default storage mode, and MLflow naming.
-- `.env` and environment variables: runtime-instance wiring such as bind hosts, selected backend, MLflow tracking URI, objectstore identifiers, BigQuery identifiers, and service URIs for a concrete local or hosted environment.
-- `terraform/terraform.tfvars`: infrastructure desired state such as regions, buckets, service names, machine shape, and deployment toggles.
-- `feature_repo/feature_store*.yaml`: checked-in Feast reference configs that stay separate from the base application config.
-- `.state/feast/feature_store.runtime.yaml`: the rendered runtime Feast binding generated from environment and used by the app and host-side Feast CLI commands.
-- `.state/monitoring/prediction-log.jsonl`: the bounded local inference-monitoring working set used for request-side drift checks.
-- `.state/monitoring/prediction-events.jsonl`: the retained local prediction-event history contract used by monitoring readers and promotable to shared storage through environment wiring.
-- `airflow/reports/feature-pipeline-*-latest.json`: the persisted feature-pipeline summary files that the local monitoring path republishes through the app `/metrics` endpoint.
-
-The supported curated-storage backends are intentionally narrow: `s3` for the local MinIO-backed baseline and `bigquery` for the hosted analytical surface. The older file-backed curated-store compatibility path is no longer part of the runtime contract.
-
-The same ownership rule now applies to MLflow connection details: the tracked experiment and model names stay in `config.yaml`, while the tracking URI is runtime wiring resolved from environment.
-
-## Local Data And State Boundary
-
-- `data/`: workload data such as curated parquet outputs and Feast offline export files.
-- `.state/`: local runtime or integration state such as Feast registry, rendered runtime configuration, and the local prediction-monitoring log.
-
-This matters because local development should still be inspectable, but the repo should not treat runtime state as if it were part of the workload dataset contract.
-
-This split matters because the package should not own deployment metadata it does not consume. Runtime and infrastructure layers can render values into the environment, while the workload code keeps a smaller and clearer configuration surface.
+See [Configuration and Contracts](configuration-and-contracts.md) for configuration ownership, [Architecture](architecture.md) for the system split, and [Monitoring](monitoring.md) for operator evidence.

--- a/docs/site/system/training-pipeline.md
+++ b/docs/site/system/training-pipeline.md
@@ -1,29 +1,29 @@
 # Training Pipeline
 
-FoehnCast keeps training downstream from the curated feature store. The same training contract runs in the local evaluator and in the current shared hosted environment: the training path reads stored curated rows, rebuilds schema-derived features when needed, generates synthetic rideability labels, trains the configured regressor, writes evaluation evidence, and registers a versioned model in MLflow without pushing training concerns back into the feature pipeline. The surrounding hosted orchestration surface is transitional, but the training contract itself stays the same.
+FoehnCast keeps training downstream from the curated feature store. The training path reads stored curated rows, rebuilds schema-derived features when needed, generates synthetic rideability labels, trains the configured regressor, writes evaluation evidence, and registers a versioned model in MLflow without pushing training concerns back into the feature pipeline.
 
-This page records the current training design that is validated in the local stack and in regression tests. It focuses on what each stage owns today and what remains an explicit operator control rather than an automatic side effect.
+This page describes what each stage owns and what remains an explicit operator control rather than an automatic side effect.
 
 !!! note "Scope"
 
-    This page describes the current validated training-path contract.
-    It focuses on what the training path owns, not on the hosted control-plane migration.
-    The target hosted direction may change where orchestration runs, but it does not change the training contract described here.
+    This page describes the validated training-path contract.
+    It focuses on what the training path owns.
+    Hosted orchestration may move, but the training contract described here stays the same.
 
 ## Pipeline Shape
 
 <div class="mermaid">
 flowchart LR
-    CUR[Curated feature store asset] --> LAB[Label curated rows]
-    REQ[Training-request asset] --> LAB
-    LAB --> TRN[Train model]
-    TRN --> EVA[Generate evaluation report]
-    EVA --> REG[Register model version]
-    REG --> ALS[Assign requested alias]
-    OPS[Promote and rollback controls] --> ALS
+    CUR["Curated feature store asset"] --> LAB["Label curated rows"]
+    REQ["Training-request asset"] --> LAB
+    LAB --> TRN["Train model"]
+    TRN --> EVA["Generate evaluation report"]
+    EVA --> REG["Register model version"]
+    REG --> ALS["Assign requested alias"]
+    OPS["Promote and rollback controls"] --> ALS
 </div>
 
-The key point is that the training path stays explicit:
+The training path stays explicit:
 
 - curated features arrive from the feature pipeline instead of being rebuilt from raw ingest
 - labeling owns the synthetic target definition
@@ -34,10 +34,10 @@ The key point is that the training path stays explicit:
 
 ## Runtime Role
 
-| Runtime mode | Training role today |
+| Runtime mode | Training role |
 |------|---------------------|
 | Local evaluator | local Airflow and MLflow run labeling, training, evaluation, and registration |
-| Active shared environment | the current hosted full-stack target runs the same Airflow and MLflow contract online while the managed hosted control plane is still transitional |
+| Active shared environment | the hosted full-stack operator lane runs the same Airflow and MLflow contract online |
 | Hosted inference target | serves a registered alias; it does not run training |
 
 ## Stage Responsibilities
@@ -52,7 +52,7 @@ The key point is that the training path stays explicit:
 
 ## Label Boundary
 
-Labeling is synthetic and physics-driven, not human-curated. The current label contract depends on curated wind and shoreline features that already exist in the stored dataset:
+Labeling is synthetic and physics-driven, not human-curated. The label contract depends on curated wind and shoreline features that already exist in the stored dataset:
 
 - `wind_speed_10m`
 - `wind_gusts_10m`
@@ -75,12 +75,12 @@ This means labeling is part of the training contract, not part of the inference 
 
 Training reads stored feature rows by spot and dataset, then rebuilds schema-derived time, direction, and gust features before labeling. That compatibility step keeps older stored slices usable when the curated schema gains new derived fields.
 
-The current training contract is:
+The training contract is:
 
 - the input comes from stored curated features, not raw forecast payloads
 - derived feature rebuilding is a compatibility guard, not a substitute for the feature pipeline
 - the configured feature list and target column remain explicit in `config.yaml`
-- the current model family is tree-based, with `random_forest` and `gradient_boosting` as the supported algorithms
+- the supported model families are tree-based, with `random_forest` and `gradient_boosting` as the supported algorithms
 - one MLflow run records parameters, regression metrics, class-bucket accuracy metrics, row counts, feature counts, and a feature-importance plot when the estimator exposes importances
 
 Training should stay narrow. It fits a model and records one reproducible run. It should not decide traffic rollout or silently rewrite registry aliases beyond the requested registration stage.
@@ -89,7 +89,7 @@ Training should stay narrow. It fits a model and records one reproducible run. I
 
 Evaluation resumes the same MLflow run after training and turns its metrics into a reviewable artifact.
 
-The current evaluation contract is:
+The evaluation contract is:
 
 - regression metrics include `mae`, `rmse`, and `r2`
 - rounded class-bucket accuracy is logged alongside the regression metrics
@@ -102,7 +102,7 @@ This keeps evaluation visible outside the notebook path. Reviewers and operators
 
 Registration converts one logged MLflow run into a named registry version and assigns the requested alias.
 
-The current registry contract is:
+The registry contract is:
 
 - the registered model name is `foehncast-quality`
 - the validated pre-live alias is `candidate`
@@ -115,26 +115,24 @@ Manual training runs default to the `Candidate` stage. Asset-triggered runs from
 
 The training DAG is scheduled from the feature pipeline's published training-request asset instead of a direct DAG-to-DAG trigger.
 
-That hand-off matters because it keeps the orchestration boundary visible:
+That keeps the orchestration boundary visible:
 
 - the feature DAG publishes curated-feature and training-request assets after persistence succeeds
 - the training DAG consumes the curated feature store and the training request
 - the training DAG emits MLflow training-run, evaluation-report, and model-registry assets
 - dataset and stage can still be overridden through DAG config when needed
 
-This makes the Airflow Assets view reflect the real dependency graph between curated feature persistence, training, evaluation, and registration.
-
-In the shared hosted path today, those Airflow-owned steps still run on the retained operator lane. The target hosted orchestrator is Cloud Composer, but that change should preserve the same training-stage ownership and evidence boundaries.
+This makes the Airflow Assets view reflect the real dependency graph between curated feature persistence, training, evaluation, and registration. In the shared hosted path, those Airflow-owned steps run on the retained operator lane until orchestration moves to Cloud Composer. That infrastructure change should preserve the same training-stage ownership and evidence boundaries.
 
 ## Alias Controls Outside The DAG
 
 Promotion and rollback are explicit controls layered on top of the registry aliases, not hidden inside normal training.
 
-The current operator controls are:
+The operator controls are:
 
-- `foehncast.training_pipeline.promote` can move an explicit version or the current `candidate` alias to the production stage
+- `foehncast.training_pipeline.promote` can move an explicit version or the `candidate` alias to the production stage
 - `foehncast.training_pipeline.rollback` can restore the `champion` alias to an explicit previous version
-- the same alias contract is reused by the shared cloud operator workflows and by the serving path that loads the current live alias
+- the same alias contract is reused by the shared cloud operator workflows and by the serving path that loads the live alias
 
 That separation is deliberate. Training can succeed without immediately changing the live serving version, and rollback can happen without retraining.
 

--- a/docs/site/system/use-case.md
+++ b/docs/site/system/use-case.md
@@ -1,45 +1,44 @@
 # Use Case and Data
 
-FoehnCast is not a generic forecast portal. It is a decision tool for one rider profile and a fixed set of Swiss kite spots, built around a simple question: where is the best session worth driving to next?
+FoehnCast is a trip-planning tool for one rider profile and a fixed set of Swiss kite spots. It answers one question: where is the best session worth driving to next?
 
-!!! note "Scope matters here"
+The scope stays intentionally narrow. The project ranks a small known spot set for one rider baseline instead of trying to be a universal weather portal.
 
-    The project stays intentionally narrow.
-    It ranks a small set of known spots for one rider baseline instead of trying to be a universal weather product.
-
-## Use Case In One View
-
-<div class="grid cards">
-<ul>
-<li>
-<p><strong>Rider</strong></p>
-<p>The baseline user is one rider based in Schwyz with a fixed quiver and weight profile.</p>
-</li>
-<li>
-<p><strong>Decision</strong></p>
-<p>The output is not just a forecast. It is a ranked session choice across multiple spots.</p>
-</li>
-<li>
-<p><strong>Personalization</strong></p>
-<p>Drive time, rider profile, and shore-specific wind context matter alongside raw weather.</p>
-</li>
-<li>
-<p><strong>Scope</strong></p>
-<p>The system is intentionally limited to six Swiss lake spots so the ranking logic stays concrete and testable.</p>
-</li>
-</ul>
-</div>
+## Decision Model
 
 <div class="mermaid">
-flowchart LR
-    WX[Weather forecasts] --> QUAL[Per-spot quality prediction]
-    SPOT[Spot metadata and shore orientation] --> QUAL
-    QUAL --> RANK[Ranked session options]
-    RIDER[Rider profile] --> RANK
-    DRIVE[OSRM drive time] --> RANK
+flowchart TD
+        WX[Weather forecasts] --> QUAL[Per-spot quality]
+        SPOT[Spot metadata and shore orientation] --> QUAL
+        QUAL --> RANK[Rank session options]
+        WINDOW[Rideable time window] --> RANK
+        RIDER[Rider profile] --> RANK
+        DRIVE[OSRM drive time] --> RANK
 </div>
 
-## Rider Profile
+## What Shapes The Ranking
+
+<div class="grid cards" markdown>
+
+- **Wind quality**
+
+    The model predicts how good each spot looks for the configured rider profile.
+
+- **Session window**
+
+    Longer rideable periods score better than short spikes.
+
+- **Drive time**
+
+    Distance matters because the system is choosing a trip, not only a forecast.
+
+- **Spot fit**
+
+    Shore orientation and local spot rules shape whether the forecast is useful.
+
+</div>
+
+## Rider Baseline
 
 | Field | Baseline value |
 |-------|----------------|
@@ -48,18 +47,6 @@ flowchart LR
 | Quiver | 5 / 7 / 8 / 10 / 12 m2 |
 
 This baseline keeps the ranking problem consistent across the project. The model does not try to optimize for every possible rider at once.
-
-## What The System Ranks
-
-The ranking layer combines more than one signal.
-
-| Factor | Why it matters |
-|--------|----------------|
-| Predicted quality index | identifies whether a spot looks rideable and how good the session could be |
-| Session duration | rewards spots that stay rideable for longer windows |
-| Drive time | discounts distant options that are not worth the trip |
-
-That is why the system is better described as a trip-planning tool than as a plain weather dashboard.
 
 ## Spots in Scope
 
@@ -72,23 +59,23 @@ That is why the system is better described as a trip-planning tool than as a pla
 | Walensee | SG | intermediate | lake | 220°-320° |
 | Thunersee | BE | advanced | lake | 220°-330° |
 
-These are not example rows. They are the actual fixed spot set used in the current configuration baseline.
+These six spots define the ranking scope.
 
-## Data Sources
+## Main Inputs
 
-| Source | Role in the project | Current status |
-|--------|---------------------|----------------|
-| Open-Meteo | primary forecast and archive weather source | implemented |
-| OSRM | drive-time personalization for ranking | implemented |
-| MeteoSwiss | not part of the current runtime contract | not active |
+| Input | Role |
+|-------|------|
+| Open-Meteo | forecast weather inputs for feature generation and prediction |
+| OSRM | drive-time inputs for trip ranking |
+| Spot metadata | local wind context, shore orientation, and spot-level rules |
 
-Open-Meteo supplies the forecast data and OSRM contributes travel-time ranking inputs. MeteoSwiss is not part of the current stack.
+Open-Meteo supplies the weather signal. OSRM supplies travel time. Spot metadata keeps the ranking grounded in the local riding context.
 
-## Why The Scope Is Fixed
+## Why The Scope Stays Fixed
 
 - It keeps the labeling and ranking problem aligned with one real rider scenario.
 - It makes route-time personalization meaningful instead of theoretical.
-- It avoids turning the course project into a generic weather portal with weak decision support.
+- It avoids turning the project into a generic weather portal with weak decision support.
 - It keeps implementation work focused on one concrete product question.
 
-See [Architecture](architecture.md) for the current system structure and [Feature Pipeline](feature-pipeline.md) for how the data moves through the stack.
+See [Architecture](architecture.md) for the system structure and [Feature Pipeline](feature-pipeline.md) for how the data moves through the stack.

--- a/feature_repo/README.md
+++ b/feature_repo/README.md
@@ -17,10 +17,10 @@ Use [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/system/
 Use this repo when you want to operate the Feast serving layer on top of the same curated weather features already produced by the project.
 
 ```mermaid
-flowchart LR
+flowchart TD
    Curated[Curated features] --> FeastRepo[Feast repo]
    FeastRepo --> Online[Online feature store]
-   Online --> API[/features/online path]
+   Online --> API["/features/online path"]
 ```
 
 ## What Lives Here

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -16,7 +16,7 @@ Start with [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/
 | GitHub OIDC delivery | remote Terraform and image-based deploys | no runtime services |
 
 ```mermaid
-flowchart LR
+flowchart TD
    TF[Terraform] --> BASE[Shared GCP baseline]
    BASE --> HOST[Hosted full-stack target]
    BASE --> RUN[Hosted inference target]


### PR DESCRIPTION
Closes #229.

## What changed

- simplify Mermaid diagrams across the docs site and GitHub-facing README surfaces
- add docs-site Mermaid label alignment support and tighter layout styling
- add a top-level overview page and wire it into the MkDocs site navigation

## Why

- the densest diagrams were hard to scan in both GitHub and the docs site
- the update reduces lane height, label collisions, and boundary ambiguity around Cloud Run, the retained operator surface, and the managed hosted direction

## Verification

- `PATH=/Users/jvr/github/HSLU/MLOPS/foehncast/.venv/bin:$PATH PYTHONPATH=$PWD/src mkdocs build -f docs/mkdocs.yml --strict`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs && node readme-mermaid-audit.js | sort`
- `cd /Users/jvr/github/HSLU/MLOPS/workdocs && npx playwright test diagram-render-audit.spec.js --reporter=line`
