### PR TITLE
feature(orchestration): publish Composer DAG bundle

### DIFF
--- a/.github/actions/load-gcp-repo-config/action.yml
+++ b/.github/actions/load-gcp-repo-config/action.yml
@@ -68,6 +68,9 @@ outputs:
   cloud_composer_environment_name:
     description: Configured Cloud Composer environment name repository variable
     value: ${{ steps.repo_config.outputs.cloud_composer_environment_name }}
+  cloud_composer_dag_gcs_prefix:
+    description: Cloud Composer DAG bucket prefix repository variable
+    value: ${{ steps.repo_config.outputs.cloud_composer_dag_gcs_prefix }}
   provision_online_compose_host:
     description: Online compose host provisioning repository variable
     value: ${{ steps.repo_config.outputs.provision_online_compose_host }}
@@ -135,6 +138,7 @@ runs:
           echo "mlflow_tracking_uri=$(read_repo_var GCP_MLFLOW_TRACKING_URI)"
           echo "provision_cloud_composer_environment=$(read_repo_var GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT)"
           echo "cloud_composer_environment_name=$(read_repo_var GCP_CLOUD_COMPOSER_ENVIRONMENT_NAME)"
+          echo "cloud_composer_dag_gcs_prefix=$(read_repo_var GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX)"
           echo "provision_online_compose_host=$(read_repo_var GCP_PROVISION_ONLINE_COMPOSE_HOST)"
           echo "online_compose_host_name=$(read_repo_var GCP_ONLINE_COMPOSE_HOST_NAME)"
           echo "online_compose_host_zone=$(read_repo_var GCP_ONLINE_COMPOSE_HOST_ZONE)"

--- a/.github/workflows/publish-composer-dags.yml
+++ b/.github/workflows/publish-composer-dags.yml
@@ -1,0 +1,155 @@
+name: Publish Composer DAG Bundle
+
+on:
+    push:
+        branches: [main]
+        paths:
+            - .github/workflows/publish-composer-dags.yml
+            - .github/actions/load-gcp-repo-config/action.yml
+            - dags/**
+            - src/**
+            - feature_repo/**
+            - scripts/publish-composer-dags.sh
+            - config.yaml
+            - pyproject.toml
+    workflow_dispatch:
+        inputs:
+            cloud_composer_dag_gcs_prefix:
+                description: Optional override for the Composer DAG GCS prefix
+                required: false
+                type: string
+
+permissions:
+    contents: read
+    id-token: write
+
+jobs:
+    config:
+        runs-on: ubuntu-latest
+        outputs:
+            owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
+            project_id: ${{ steps.repo_config.outputs.project_id }}
+            workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
+            service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
+            cloud_composer_environment_name: ${{ steps.repo_config.outputs.cloud_composer_environment_name }}
+            dag_gcs_prefix: ${{ steps.derived.outputs.dag_gcs_prefix }}
+            publish_ready: ${{ steps.derived.outputs.publish_ready }}
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            - id: flags
+              env:
+                  ACTOR: ${{ github.actor }}
+                  TRIGGERING_ACTOR: ${{ github.triggering_actor }}
+                  REPOSITORY_OWNER: ${{ github.repository_owner }}
+              run: |
+                  set -euo pipefail
+
+                  owner_allowed=false
+                  if [[ "$ACTOR" == "$REPOSITORY_OWNER" && "$TRIGGERING_ACTOR" == "$REPOSITORY_OWNER" ]]; then
+                    owner_allowed=true
+                  fi
+
+                  echo "owner_allowed=$owner_allowed" >> "$GITHUB_OUTPUT"
+
+            - id: repo_config
+              uses: ./.github/actions/load-gcp-repo-config
+              with:
+                  repo-vars-json: ${{ toJson(vars) }}
+
+            - id: derived
+              env:
+                  DAG_GCS_PREFIX_INPUT: ${{ github.event.inputs.cloud_composer_dag_gcs_prefix }}
+                  REPO_DAG_GCS_PREFIX: ${{ steps.repo_config.outputs.cloud_composer_dag_gcs_prefix }}
+                  PROJECT_ID: ${{ steps.repo_config.outputs.project_id }}
+                  PROVISION_CLOUD_COMPOSER_ENVIRONMENT: ${{ steps.repo_config.outputs.provision_cloud_composer_environment }}
+                  WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
+                  SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
+              run: |
+                  set -euo pipefail
+
+                  dag_gcs_prefix="$(printf '%s' "${DAG_GCS_PREFIX_INPUT:-}" | tr -d '\r')"
+                  if [[ -z "$dag_gcs_prefix" ]]; then
+                    dag_gcs_prefix="$(printf '%s' "${REPO_DAG_GCS_PREFIX:-}" | tr -d '\r')"
+                  fi
+                  dag_gcs_prefix="${dag_gcs_prefix%/}"
+
+                  publish_ready=false
+                  if [[ "$PROVISION_CLOUD_COMPOSER_ENVIRONMENT" == 'true' \
+                    && -n "$PROJECT_ID" \
+                    && -n "$dag_gcs_prefix" \
+                    && -n "$WORKLOAD_IDENTITY_PROVIDER" \
+                    && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
+                    publish_ready=true
+                  fi
+
+                  {
+                    echo "dag_gcs_prefix=$dag_gcs_prefix"
+                    echo "publish_ready=$publish_ready"
+                  } >> "$GITHUB_OUTPUT"
+
+    publish:
+        needs: config
+        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.publish_ready == 'true' }}
+        runs-on: ubuntu-latest
+        env:
+            DAG_GCS_PREFIX: ${{ needs.config.outputs.dag_gcs_prefix }}
+            CLOUD_COMPOSER_ENVIRONMENT_NAME: ${{ needs.config.outputs.cloud_composer_environment_name }}
+        steps:
+            - uses: actions/checkout@v6.0.2
+
+            - name: Authenticate to Google Cloud
+              uses: google-github-actions/auth@v2
+              with:
+                  workload_identity_provider: ${{ needs.config.outputs.workload_identity_provider }}
+                  service_account: ${{ needs.config.outputs.service_account_email }}
+
+            - name: Set up gcloud
+              uses: google-github-actions/setup-gcloud@v2
+              with:
+                  project_id: ${{ needs.config.outputs.project_id }}
+
+            - name: Publish Composer DAG bundle
+              run: |
+                  set -euo pipefail
+
+                  bash ./scripts/publish-composer-dags.sh \
+                    --dag-gcs-prefix "$DAG_GCS_PREFIX" \
+                    --bundle-dir composer-dag-bundle \
+                    --manifest-path composer-dag-bundle-manifest.json
+
+            - name: Summarize bundle
+              run: |
+                  {
+                    echo "## Published Composer DAG bundle"
+                    echo
+                    echo "- Composer environment: ${CLOUD_COMPOSER_ENVIRONMENT_NAME:-not set}"
+                    echo "- DAG bucket prefix: $DAG_GCS_PREFIX"
+                    echo "- Bundle path: composer-dag-bundle"
+                    echo "- Manifest: composer-dag-bundle-manifest.json"
+                    echo "- Delivery: repo-managed DAG and source bundle"
+                    echo
+                    echo '```json'
+                    cat composer-dag-bundle-manifest.json
+                    echo '```'
+                  } >> "$GITHUB_STEP_SUMMARY"
+
+    skipped:
+        needs: config
+        if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.publish_ready != 'true' }}
+        runs-on: ubuntu-latest
+        steps:
+            - name: Explain skipped publish
+              run: |
+                  {
+                    echo "## Composer DAG bundle publish skipped"
+                    echo
+                    echo "Set these repository variables to enable reviewed Composer DAG publication:"
+                    echo "- GCP_PROJECT_ID"
+                    echo "- GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT=true"
+                    echo "- GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX"
+                    echo "- GCP_WORKLOAD_IDENTITY_PROVIDER"
+                    echo "- GCP_SERVICE_ACCOUNT_EMAIL"
+                    echo
+                    echo "This publishes the repo-managed DAG and source bundle only. Runtime release still uses the retained-host handoff until a later cutover issue lands."
+                  } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -174,7 +174,7 @@ The intended hosted direction keeps Cloud Run as the public API, moves hosted im
 
 Cloud Composer is the target managed orchestration direction, and Terraform can now provision a Cloud Composer environment for readiness work.
 
-Before a later cutover, DAG packaging, Python dependency delivery, secret and runtime-config injection, network and API reachability, and a reviewed runtime release entry that reaches the managed Airflow surface directly still need to stop depending on the retained operator host. The retained host remains the active orchestration authority until those boundaries move. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed active-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
+A reviewed DAG and source bundle can now sync to the provisioned Composer DAG bucket. That narrows the packaging gap, but Python dependency delivery, secret and runtime-config injection, and a reviewed runtime release entry that reaches the managed Airflow surface directly still need to stop depending on the retained operator host. The retained host remains the active orchestration authority until those boundaries move. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed active-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
 
 ## Active And Target Hosted Mapping
 

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -83,10 +83,13 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 | `scripts/configure-github-actions.sh` | sync Terraform outputs into GitHub repository variables |
 | `terraform/terraform.tfvars` | interactive bootstrap input, not the day-2 source of truth |
 | runtime image workflows | submit reviewed hosted image builds to Cloud Build and publish images to Artifact Registry |
+| `.github/workflows/publish-composer-dags.yml` | publish the reviewed DAG and source bundle to the provisioned Composer DAG bucket |
 | `.github/workflows/trigger-runtime-release.yml` | send one explicit reviewed runtime release request into hosted Airflow while the retained host still owns that handoff |
 | `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up after a remote apply and curated BigQuery rows exist |
 
 The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as minimum and maximum instance count, container port, CPU, and memory stay repo-variable-backed instead of becoming manual workflow inputs.
+
+GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket. Dependency packaging, runtime secret delivery, and the reviewed runtime release entry still need separate cutover work.
 
 Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables stay structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. Both hosted lanes still read the same Terraform-managed storage, Feast, and MLflow contract. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
 
@@ -163,6 +166,8 @@ Cloud Composer is now provisionable as a managed-Airflow readiness surface, but 
 | Secrets and runtime config | the retained host reads runtime configuration from the VM-local environment and service identity | a managed secret and runtime-config path for hosted orchestration |
 | Network and API reachability | the current trigger contract reaches Airflow through VM SSH and host-local API access | a reviewed runtime-release entry path that reaches Composer without VM SSH |
 | Operator access model | retries, backfills, and recovery currently assume SSH to the retained host | a clear managed operator access model for Composer-owned orchestration |
+
+GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket. This creates a reviewed DAG delivery path that does not depend on a VM checkout for the checked-in DAG and source bundle. It intentionally publishes the DAG entrypoints, the `foehncast` Python package, `config.yaml`, `pyproject.toml`, and `feature_repo`, but it does not yet solve Composer-specific dependency installation, secret injection, or the reviewed runtime release entry without VM SSH.
 
 ## Retry And Backfill Runbooks
 

--- a/scripts/configure-github-actions.sh
+++ b/scripts/configure-github-actions.sh
@@ -95,6 +95,7 @@ fi
 
 cloud_run_synced=false
 mlflow_tracking_uri_synced=false
+cloud_composer_dag_gcs_prefix_synced=false
 while IFS=$'\t' read -r variable_name variable_value; do
   set_variable "$REPOSITORY_PATH" "$variable_name" "$variable_value"
 
@@ -104,6 +105,10 @@ while IFS=$'\t' read -r variable_name variable_value; do
 
   if [[ "$variable_name" == "GCP_MLFLOW_TRACKING_URI" ]]; then
     mlflow_tracking_uri_synced=true
+  fi
+
+  if [[ "$variable_name" == "GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX" ]]; then
+    cloud_composer_dag_gcs_prefix_synced=true
   fi
 done < <(terraform_repo_variable_pairs "$TERRAFORM_DIR")
 
@@ -115,6 +120,11 @@ fi
 if [[ "$mlflow_tracking_uri_synced" != "true" ]]; then
   delete_variable "$REPOSITORY_PATH" GCP_MLFLOW_TRACKING_URI
   echo "Skipping GCP_MLFLOW_TRACKING_URI because Terraform does not currently define an MLflow tracking URI."
+fi
+
+if [[ "$cloud_composer_dag_gcs_prefix_synced" != "true" ]]; then
+  delete_variable "$REPOSITORY_PATH" GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX
+  echo "Skipping GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX because Terraform has not provisioned a Cloud Composer DAG bucket prefix yet."
 fi
 
 echo "GitHub Actions variables are configured for ${REPOSITORY_PATH}."

--- a/scripts/publish-composer-dags.sh
+++ b/scripts/publish-composer-dags.sh
@@ -1,0 +1,84 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+DAG_GCS_PREFIX=""
+BUNDLE_DIR=""
+MANIFEST_PATH=""
+TEMP_WORK_DIR=""
+# shellcheck disable=SC1091
+source "${ROOT_DIR}/scripts/cli-common.sh"
+
+usage() {
+  echo "Usage: $0 --dag-gcs-prefix gs://bucket/path [--bundle-dir path] [--manifest-path path]" >&2
+}
+
+cleanup() {
+  if [[ -n "$TEMP_WORK_DIR" && -d "$TEMP_WORK_DIR" ]]; then
+    rm -rf "$TEMP_WORK_DIR"
+  fi
+}
+
+trap cleanup EXIT
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --dag-gcs-prefix)
+      shift
+      DAG_GCS_PREFIX="$(require_cli_option_value "--dag-gcs-prefix" "${1:-}" usage)"
+      ;;
+    --bundle-dir)
+      shift
+      BUNDLE_DIR="$(require_cli_option_value "--bundle-dir" "${1:-}" usage)"
+      ;;
+    --manifest-path)
+      shift
+      MANIFEST_PATH="$(require_cli_option_value "--manifest-path" "${1:-}" usage)"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 1
+      ;;
+  esac
+
+  shift
+done
+
+if [[ -z "$DAG_GCS_PREFIX" ]]; then
+  usage
+  exit 1
+fi
+
+require_command gcloud
+require_command python3
+
+DAG_GCS_PREFIX="$(printf '%s' "$DAG_GCS_PREFIX" | tr -d '\r')"
+DAG_GCS_PREFIX="${DAG_GCS_PREFIX%/}"
+
+if [[ -z "$BUNDLE_DIR" ]]; then
+  TEMP_WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/foehncast-composer-dags.XXXXXX")"
+  BUNDLE_DIR="${TEMP_WORK_DIR}/bundle"
+fi
+
+if [[ -z "$MANIFEST_PATH" ]]; then
+  MANIFEST_PATH="${BUNDLE_DIR}.manifest.json"
+fi
+
+mkdir -p "$(dirname "$MANIFEST_PATH")"
+
+env PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}" \
+  python3 -m foehncast.composer_bundle build \
+  --project-root "$ROOT_DIR" \
+  --output-dir "$BUNDLE_DIR" \
+  --manifest-path "$MANIFEST_PATH" >/dev/null
+
+gcloud storage rsync --recursive "$BUNDLE_DIR" "$DAG_GCS_PREFIX"
+
+printf 'Composer DAG bundle published to %s\n' "$DAG_GCS_PREFIX"
+printf 'Bundle directory: %s\n' "$BUNDLE_DIR"
+printf 'Manifest: %s\n' "$MANIFEST_PATH"

--- a/scripts/terraform-platform-state.sh
+++ b/scripts/terraform-platform-state.sh
@@ -288,6 +288,7 @@ load_terraform_platform_state() {
   FOEHNCAST_TF_MLFLOW_TRACKING_URI="$(terraform_output_or_tfvars_value "$terraform_dir" mlflow_tracking_uri mlflow_tracking_uri)"
   FOEHNCAST_TF_PROVISION_CLOUD_COMPOSER_ENVIRONMENT="$(terraform_output_or_tfvars_value "$terraform_dir" provision_cloud_composer_environment provision_cloud_composer_environment)"
   FOEHNCAST_TF_CLOUD_COMPOSER_ENVIRONMENT_NAME="$(terraform_output_or_tfvars_value "$terraform_dir" configured_cloud_composer_environment_name cloud_composer_environment_name)"
+  FOEHNCAST_TF_CLOUD_COMPOSER_DAG_GCS_PREFIX="$(trimmed_terraform_output_value "$terraform_dir" cloud_composer_dag_gcs_prefix)"
   FOEHNCAST_TF_CLOUD_RUN_SERVICE="$(optional_terraform_output_value "$terraform_dir" cloud_run_service_name)"
   FOEHNCAST_TF_PROVISION_ONLINE_COMPOSE_HOST="$(terraform_output_or_tfvars_value "$terraform_dir" provision_online_compose_host provision_online_compose_host)"
   FOEHNCAST_TF_ONLINE_COMPOSE_HOST_NAME="$(terraform_output_or_tfvars_value "$terraform_dir" online_compose_host_name online_compose_host_name)"
@@ -324,6 +325,7 @@ terraform_repo_variable_names() {
     GCP_MLFLOW_TRACKING_URI \
     GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT \
     GCP_CLOUD_COMPOSER_ENVIRONMENT_NAME \
+    GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX \
     GCP_PROVISION_ONLINE_COMPOSE_HOST \
     GCP_ONLINE_COMPOSE_HOST_NAME \
     GCP_ONLINE_COMPOSE_HOST_ZONE \
@@ -368,6 +370,10 @@ terraform_repo_variable_pairs() {
 
   if [[ -n "$FOEHNCAST_TF_MLFLOW_TRACKING_URI" ]]; then
     printf 'GCP_MLFLOW_TRACKING_URI\t%s\n' "$FOEHNCAST_TF_MLFLOW_TRACKING_URI"
+  fi
+
+  if terraform_platform_value_present "$FOEHNCAST_TF_CLOUD_COMPOSER_DAG_GCS_PREFIX"; then
+    printf 'GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX\t%s\n' "$FOEHNCAST_TF_CLOUD_COMPOSER_DAG_GCS_PREFIX"
   fi
 
   if [[ -n "$FOEHNCAST_TF_CLOUD_RUN_SERVICE" ]]; then

--- a/src/foehncast/composer_bundle.py
+++ b/src/foehncast/composer_bundle.py
@@ -1,0 +1,159 @@
+"""Build the repo-managed DAG and source bundle for Cloud Composer."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+import argparse
+import json
+from pathlib import Path
+import shutil
+from typing import Any
+
+
+def _resolved_project_root(project_root: str | Path | None = None) -> Path:
+    if project_root is None:
+        return Path(__file__).resolve().parents[2]
+    return Path(project_root).expanduser().resolve()
+
+
+def composer_bundle_mappings(
+    project_root: str | Path | None = None,
+) -> list[dict[str, str]]:
+    """Return the reviewed source-to-target mappings for the Composer bundle."""
+    root = _resolved_project_root(project_root)
+    dag_dir = root / "dags"
+    dag_paths = sorted(path for path in dag_dir.glob("*.py") if path.is_file())
+    if not dag_paths:
+        raise FileNotFoundError(f"No DAG entrypoints found under {dag_dir}.")
+
+    mappings = [
+        {
+            "source": str(path.relative_to(root)),
+            "target": path.name,
+            "type": "file",
+        }
+        for path in dag_paths
+    ]
+    mappings.extend(
+        [
+            {
+                "source": "src/foehncast",
+                "target": "foehncast",
+                "type": "directory",
+            },
+            {"source": "config.yaml", "target": "config.yaml", "type": "file"},
+            {
+                "source": "pyproject.toml",
+                "target": "pyproject.toml",
+                "type": "file",
+            },
+            {
+                "source": "feature_repo",
+                "target": "feature_repo",
+                "type": "directory",
+            },
+        ]
+    )
+
+    for mapping in mappings:
+        source_path = root / mapping["source"]
+        if not source_path.exists():
+            raise FileNotFoundError(
+                f"Required Composer bundle path not found: {source_path}"
+            )
+
+    return mappings
+
+
+def build_composer_bundle(
+    output_dir: str | Path,
+    *,
+    project_root: str | Path | None = None,
+) -> dict[str, Any]:
+    """Copy the reviewed DAG bundle into the requested output directory."""
+    root = _resolved_project_root(project_root)
+    output_path = Path(output_dir).expanduser().resolve()
+
+    if output_path.exists():
+        if output_path.is_dir():
+            shutil.rmtree(output_path)
+        else:
+            output_path.unlink()
+    output_path.mkdir(parents=True, exist_ok=True)
+
+    ignore_patterns = shutil.ignore_patterns("__pycache__", "*.pyc")
+    mappings = composer_bundle_mappings(root)
+    for mapping in mappings:
+        source_path = root / mapping["source"]
+        target_path = output_path / mapping["target"]
+        if mapping["type"] == "directory":
+            shutil.copytree(
+                source_path,
+                target_path,
+                dirs_exist_ok=True,
+                ignore=ignore_patterns,
+            )
+            continue
+
+        target_path.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source_path, target_path)
+
+    return {
+        "project_root": str(root),
+        "output_dir": str(output_path),
+        "entries": mappings,
+    }
+
+
+def write_composer_bundle_manifest(
+    manifest: dict[str, Any],
+    manifest_path: str | Path,
+) -> Path:
+    """Persist a stable JSON manifest for the Composer DAG bundle."""
+    path = Path(manifest_path).expanduser().resolve()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="python -m foehncast.composer_bundle")
+    subparsers = parser.add_subparsers(dest="command", required=True)
+
+    build_parser = subparsers.add_parser("build")
+    build_parser.add_argument("--project-root", default="")
+    build_parser.add_argument("--output-dir", required=True)
+    build_parser.add_argument("--manifest-path", default="")
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    if args.command == "build":
+        manifest = build_composer_bundle(
+            args.output_dir,
+            project_root=args.project_root or None,
+        )
+        if args.manifest_path:
+            write_composer_bundle_manifest(manifest, args.manifest_path)
+        print(json.dumps(manifest, indent=2, sort_keys=True))
+        return 0
+
+    parser.error(f"Unsupported command: {args.command}")
+    return 2
+
+
+if __name__ == "__main__":  # pragma: no cover - module entry point
+    raise SystemExit(main())
+
+
+__all__ = [
+    "build_composer_bundle",
+    "composer_bundle_mappings",
+    "write_composer_bundle_manifest",
+]

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -175,8 +175,11 @@ The repository uses two image-publication workflows that share one hosted build 
 
 - `.github/workflows/publish-app-image.yml` submits the app image build to Cloud Build and publishes the reviewed image to Artifact Registry for the Cloud Run path
 - `.github/workflows/publish-runtime-images.yml` submits the Airflow and MLflow image builds to Cloud Build and publishes the reviewed images to Artifact Registry for the retained operator host
+- `.github/workflows/publish-composer-dags.yml` syncs the reviewed DAG and source bundle into the provisioned Composer DAG bucket
 
 Artifact Registry is the canonical hosted image registry in this contract. GHCR convenience artifacts, if published separately, are not the default hosted deployment path.
+
+The Composer DAG bundle path narrows the VM-checkout dependency for DAG delivery, but the reviewed runtime release entry without VM SSH and Composer-specific dependency installation still belong to later orchestration issues.
 
 Set these GitHub repository variables:
 
@@ -200,6 +203,7 @@ Set these GitHub repository variables:
 - `GCP_MLFLOW_TRACKING_URI` when Cloud Run is enabled
 - `GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT`
 - `GCP_CLOUD_COMPOSER_ENVIRONMENT_NAME`
+- `GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX` when Composer is enabled
 - `GCP_PROVISION_ONLINE_COMPOSE_HOST`
 - `GCP_ONLINE_COMPOSE_HOST_NAME`
 - `GCP_ONLINE_COMPOSE_HOST_ZONE`

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -38,6 +38,7 @@ REPO_VARIABLE_OUTPUTS: list[tuple[str, str]] = [
         "provision_cloud_composer_environment",
     ),
     ("GCP_CLOUD_COMPOSER_ENVIRONMENT_NAME", "cloud_composer_environment_name"),
+    ("GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX", "cloud_composer_dag_gcs_prefix"),
     ("GCP_PROVISION_ONLINE_COMPOSE_HOST", "provision_online_compose_host"),
     ("GCP_ONLINE_COMPOSE_HOST_NAME", "online_compose_host_name"),
     ("GCP_ONLINE_COMPOSE_HOST_ZONE", "online_compose_host_zone"),
@@ -776,6 +777,15 @@ def test_orchestration_docs_describe_current_host_path_and_target_composer_readi
         "a reviewed DAG delivery path that does not depend on a VM checkout"
         in workflow_doc
     )
+    assert ".github/workflows/publish-composer-dags.yml" in workflow_doc
+    assert (
+        "GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket."
+        in workflow_doc
+    )
+    assert (
+        "reviewed runtime release entry still need separate cutover work"
+        in workflow_doc
+    )
     assert (
         "a managed secret and runtime-config path for hosted orchestration"
         in workflow_doc
@@ -794,6 +804,10 @@ def test_orchestration_docs_describe_current_host_path_and_target_composer_readi
         in cloud_mapping
     )
     assert (
+        "A reviewed DAG and source bundle can now sync to the provisioned Composer DAG bucket."
+        in cloud_mapping
+    )
+    assert (
         "a reviewed runtime release entry that reaches the managed Airflow surface directly"
         in cloud_mapping
     )
@@ -806,8 +820,10 @@ def test_orchestration_docs_describe_current_host_path_and_target_composer_readi
         "Terraform can provision an optional Cloud Composer environment today."
         in terraform_readme
     )
+    assert ".github/workflows/publish-composer-dags.yml" in terraform_readme
     assert "reviewed runtime release entry without VM SSH" in terraform_readme
     assert "GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT" in terraform_readme
+    assert "GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX" in terraform_readme
 
 
 def test_promote_candidate_workflow_redirects_to_runtime_trigger_contract() -> None:
@@ -998,6 +1014,90 @@ def test_trigger_runtime_release_script_uses_local_airflow_contract() -> None:
     )
     assert "runtime-release-latest.json" in script
     assert "verify-report" in script
+
+
+def test_publish_composer_dags_script_builds_bundle_and_syncs_to_gcs_prefix() -> None:
+    script = _read_text("scripts/publish-composer-dags.sh")
+
+    assert (
+        "Usage: $0 --dag-gcs-prefix gs://bucket/path [--bundle-dir path] [--manifest-path path]"
+        in script
+    )
+    assert 'source "${ROOT_DIR}/scripts/cli-common.sh"' in script
+    assert "require_command gcloud" in script
+    assert "require_command python3" in script
+    assert 'mktemp -d "${TMPDIR:-/tmp}/foehncast-composer-dags.XXXXXX"' in script
+    assert 'PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"' in script
+    assert "python3 -m foehncast.composer_bundle build" in script
+    assert "gcloud storage rsync --recursive" in script
+    assert "Composer DAG bundle published to" in script
+
+
+def test_publish_composer_dags_workflow_uses_repo_backed_composer_contract() -> None:
+    workflow = _workflow_yaml(".github/workflows/publish-composer-dags.yml")
+    workflow_text = _read_text(".github/workflows/publish-composer-dags.yml")
+    push_paths = workflow["on"]["push"]["paths"]
+    config_job = workflow["jobs"]["config"]
+    dispatch_inputs = workflow["on"]["workflow_dispatch"]["inputs"]
+
+    assert workflow["permissions"] == {"contents": "read", "id-token": "write"}
+    assert ".github/actions/load-gcp-repo-config/action.yml" in push_paths
+    assert "dags/**" in push_paths
+    assert "src/**" in push_paths
+    assert "feature_repo/**" in push_paths
+    assert "scripts/publish-composer-dags.sh" in push_paths
+    assert dispatch_inputs["cloud_composer_dag_gcs_prefix"]["type"] == "string"
+
+    assert (
+        config_job["outputs"]["cloud_composer_environment_name"]
+        == "${{ steps.repo_config.outputs.cloud_composer_environment_name }}"
+    )
+    assert (
+        config_job["outputs"]["dag_gcs_prefix"]
+        == "${{ steps.derived.outputs.dag_gcs_prefix }}"
+    )
+    assert (
+        config_job["outputs"]["publish_ready"]
+        == "${{ steps.derived.outputs.publish_ready }}"
+    )
+
+    repo_config_step = _workflow_step(workflow, "config", "repo_config")
+    assert repo_config_step["uses"] == "./.github/actions/load-gcp-repo-config"
+
+    derived_step = _workflow_step(workflow, "config", "derived")
+    assert (
+        derived_step["env"]["REPO_DAG_GCS_PREFIX"]
+        == "${{ steps.repo_config.outputs.cloud_composer_dag_gcs_prefix }}"
+    )
+    assert (
+        derived_step["env"]["PROVISION_CLOUD_COMPOSER_ENVIRONMENT"]
+        == "${{ steps.repo_config.outputs.provision_cloud_composer_environment }}"
+    )
+    assert "publish_ready=false" in derived_step["run"]
+    assert 'echo "publish_ready=$publish_ready"' in derived_step["run"]
+
+    auth_step = _workflow_step(workflow, "publish", "Authenticate to Google Cloud")
+    assert auth_step["uses"] == "google-github-actions/auth@v2"
+
+    setup_step = _workflow_step(workflow, "publish", "Set up gcloud")
+    assert setup_step["uses"] == "google-github-actions/setup-gcloud@v2"
+    assert setup_step["with"]["project_id"] == "${{ needs.config.outputs.project_id }}"
+
+    publish_step = _workflow_step(workflow, "publish", "Publish Composer DAG bundle")
+    assert "bash ./scripts/publish-composer-dags.sh" in publish_step["run"]
+    assert '--dag-gcs-prefix "$DAG_GCS_PREFIX"' in publish_step["run"]
+    assert "composer-dag-bundle-manifest.json" in publish_step["run"]
+
+    summary_step = _workflow_step(workflow, "publish", "Summarize bundle")
+    assert "## Published Composer DAG bundle" in summary_step["run"]
+    assert "composer-dag-bundle-manifest.json" in summary_step["run"]
+
+    skipped_step = _workflow_step(workflow, "skipped", "Explain skipped publish")
+    assert "GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX" in skipped_step["run"]
+    assert "Runtime release still uses the retained-host handoff" in skipped_step["run"]
+
+    assert "gcloud compute ssh" not in workflow_text
+    assert "trigger-runtime-release.sh" not in workflow_text
 
 
 def test_publish_runtime_images_excludes_local_only_development_env() -> None:
@@ -2056,6 +2156,15 @@ def test_cloud_scripts_share_github_repo_helpers() -> None:
     assert "resolve_repo()" not in configure
     assert "gh auth status" not in configure
     assert "require_github_auth" in configure
+    assert "cloud_composer_dag_gcs_prefix_synced=false" in configure
+    assert (
+        'delete_variable "$REPOSITORY_PATH" GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX'
+        in configure
+    )
+    assert (
+        'echo "Skipping GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX because Terraform has not provisioned a Cloud Composer DAG bucket prefix yet."'
+        in configure
+    )
     assert (
         'TARGET_REPO="$(require_cli_option_value "--repo" "${1:-}" usage)"' in configure
     )

--- a/tests/test_composer_bundle.py
+++ b/tests/test_composer_bundle.py
@@ -1,0 +1,86 @@
+"""Tests for the Cloud Composer DAG bundle builder."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+import foehncast.composer_bundle as composer_bundle
+
+
+def _write(path: Path, content: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+
+
+def test_build_composer_bundle_flattens_dag_entrypoints_and_copies_sources(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "dags" / "feature_dag.py", "print('feature')\n")
+    _write(tmp_path / "dags" / "training_dag.py", "print('training')\n")
+    _write(tmp_path / "src" / "foehncast" / "__init__.py", "")
+    _write(tmp_path / "src" / "foehncast" / "paths.py", "PROJECT = 'ok'\n")
+    _write(tmp_path / "config.yaml", "storage: {}\n")
+    _write(tmp_path / "pyproject.toml", "[project]\nname = 'foehncast'\n")
+    _write(tmp_path / "feature_repo" / "feature_store.yaml", "project: foehncast\n")
+    _write(tmp_path / "feature_repo" / "features.py", "ENTITIES = []\n")
+
+    manifest = composer_bundle.build_composer_bundle(
+        tmp_path / "bundle",
+        project_root=tmp_path,
+    )
+
+    assert (tmp_path / "bundle" / "feature_dag.py").is_file()
+    assert (tmp_path / "bundle" / "training_dag.py").is_file()
+    assert not (tmp_path / "bundle" / "dags").exists()
+    assert (tmp_path / "bundle" / "foehncast" / "paths.py").is_file()
+    assert (tmp_path / "bundle" / "feature_repo" / "features.py").is_file()
+    assert (tmp_path / "bundle" / "config.yaml").is_file()
+    assert (tmp_path / "bundle" / "pyproject.toml").is_file()
+
+    assert {entry["target"] for entry in manifest["entries"]} == {
+        "feature_dag.py",
+        "training_dag.py",
+        "foehncast",
+        "feature_repo",
+        "config.yaml",
+        "pyproject.toml",
+    }
+
+
+def test_build_composer_bundle_requires_checked_in_project_contract_files(
+    tmp_path: Path,
+) -> None:
+    _write(tmp_path / "dags" / "feature_dag.py", "print('feature')\n")
+    _write(tmp_path / "src" / "foehncast" / "__init__.py", "")
+    _write(tmp_path / "config.yaml", "storage: {}\n")
+    _write(tmp_path / "feature_repo" / "feature_store.yaml", "project: foehncast\n")
+
+    with pytest.raises(FileNotFoundError, match="pyproject.toml"):
+        composer_bundle.build_composer_bundle(
+            tmp_path / "bundle", project_root=tmp_path
+        )
+
+
+def test_write_composer_bundle_manifest_persists_stable_json(tmp_path: Path) -> None:
+    manifest = {
+        "project_root": "/tmp/foehncast",
+        "output_dir": "/tmp/foehncast/bundle",
+        "entries": [
+            {
+                "source": "dags/feature_dag.py",
+                "target": "feature_dag.py",
+                "type": "file",
+            }
+        ],
+    }
+
+    manifest_path = composer_bundle.write_composer_bundle_manifest(
+        manifest,
+        tmp_path / "bundle-manifest.json",
+    )
+
+    persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
+    assert persisted == manifest


### PR DESCRIPTION
- What changed: added a reviewed Composer DAG bundle path by syncing the Composer DAG bucket prefix through repo variables, adding a bundle builder plus publish script, and introducing a GitHub workflow that publishes the DAG and source bundle to the provisioned Composer bucket.
- Why: Cloud Composer provisioning alone does not remove the retained-host checkout dependency; hosted DAG delivery needed its own explicit contract before a later runtime-release cutover.
- Verification: `pytest tests/test_composer_bundle.py tests/test_cloud_operator_contract.py`; `PYTHONPATH=$PWD/src mkdocs build -f docs/mkdocs.yml --strict`
- Closes: #234
