### PR TITLE
feature(terraform): seed Composer PyPI baseline

### DIFF
--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -174,7 +174,7 @@ The intended hosted direction keeps Cloud Run as the public API, moves hosted im
 
 Cloud Composer is the target managed orchestration direction, and Terraform can now provision a Cloud Composer environment for readiness work.
 
-A reviewed DAG and source bundle can now sync to the provisioned Composer DAG bucket. That narrows the packaging gap, but Python dependency delivery, secret and runtime-config injection, and a reviewed runtime release entry that reaches the managed Airflow surface directly still need to stop depending on the retained operator host. The retained host remains the active orchestration authority until those boundaries move. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed active-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
+A reviewed DAG and source bundle can now sync to the provisioned Composer DAG bucket. Terraform also seeds the reviewed PyPI baseline required by the checked-in DAG bundle and merges extra `cloud_composer_pypi_packages` overrides on top. Secret and runtime-config injection, and a reviewed runtime release entry that reaches the managed Airflow surface directly, still need to stop depending on the retained operator host. The retained host remains the active orchestration authority until those boundaries move. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed active-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
 
 ## Active And Target Hosted Mapping
 

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -89,7 +89,7 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 
 The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as minimum and maximum instance count, container port, CPU, and memory stay repo-variable-backed instead of becoming manual workflow inputs.
 
-GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket. Dependency packaging, runtime secret delivery, and the reviewed runtime release entry still need separate cutover work.
+GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket. Composer now gets a reviewed PyPI baseline for the checked-in DAG bundle, but runtime secret delivery and the reviewed runtime release entry still need separate cutover work.
 
 Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables stay structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. Both hosted lanes still read the same Terraform-managed storage, Feast, and MLflow contract. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
 
@@ -162,12 +162,12 @@ Cloud Composer is now provisionable as a managed-Airflow readiness surface, but 
 | Requirement | Current repo shape | What later Composer work must replace or define |
 |------|--------------------|-----------------------------------------------|
 | DAG packaging | DAGs currently arrive through the retained host checkout and compose-mounted repo path | a reviewed DAG delivery path that does not depend on a VM checkout |
-| Python dependencies | Airflow dependencies currently live in the retained-host container image path | a hosted Airflow dependency bundle compatible with Composer |
+| Python dependencies | Terraform now seeds a reviewed Composer PyPI baseline for the checked-in DAG bundle | extend or replace that baseline when later Composer work needs private indexes, non-PyPI or system-level dependencies, or broader DAG coverage |
 | Secrets and runtime config | the retained host reads runtime configuration from the VM-local environment and service identity | a managed secret and runtime-config path for hosted orchestration |
 | Network and API reachability | the current trigger contract reaches Airflow through VM SSH and host-local API access | a reviewed runtime-release entry path that reaches Composer without VM SSH |
 | Operator access model | retries, backfills, and recovery currently assume SSH to the retained host | a clear managed operator access model for Composer-owned orchestration |
 
-GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket. This creates a reviewed DAG delivery path that does not depend on a VM checkout for the checked-in DAG and source bundle. It intentionally publishes the DAG entrypoints, the `foehncast` Python package, `config.yaml`, `pyproject.toml`, and `feature_repo`, but it does not yet solve Composer-specific dependency installation, secret injection, or the reviewed runtime release entry without VM SSH.
+GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket. This creates a reviewed DAG delivery path that does not depend on a VM checkout for the checked-in DAG and source bundle. It intentionally publishes the DAG entrypoints, the `foehncast` Python package, `config.yaml`, `pyproject.toml`, and `feature_repo`, and Terraform now seeds the reviewed Composer PyPI package baseline needed by that checked-in DAG bundle. The baseline still allows extra `cloud_composer_pypi_packages` overrides for follow-up slices, but it does not yet solve secret injection or the reviewed runtime release entry without VM SSH.
 
 The runtime release acknowledgement path is now portable as well: the same DAG can keep writing the reviewed summary to the retained-host default path today, or to a durable storage target such as `gs://...` when the managed orchestration path is ready to own that evidence directly.
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -49,6 +49,7 @@ Terraform can provision:
 
 The Cloud Run service remains inference-only. The full online stack is the compose-host path. Cloud Composer is provisionable as a managed orchestration target, but the retained host remains the active orchestration and recovery surface until a later cutover replaces the VM handoff.
 When Composer is enabled, Terraform also seeds `FOEHNCAST_RUNTIME_RELEASE_REPORT_PATH` to a durable `gs://<artifact-bucket>/airflow/reports/runtime-release-latest.json` target so the future managed runtime handoff does not depend on a writable VM checkout for its acknowledgement record.
+Terraform also seeds a reviewed Composer PyPI package baseline for the checked-in DAG bundle and merges any extra `cloud_composer_pypi_packages` entries on top of that baseline.
 
 ## Deployment Scope Rule
 
@@ -134,16 +135,16 @@ The retained host is still part of the shared environment, but several VM-specif
 
 Terraform can provision an optional Cloud Composer environment today. The current online compose host remains the operational orchestration surface.
 
-Before a later Composer cutover, this repo needs explicit contract surfaces for:
+Before a later Composer cutover, this repo still needs explicit contract surfaces for:
 
-- DAG packaging outside a VM checkout
-- a Python dependency bundle for hosted Airflow
 - secrets and runtime-config delivery for managed orchestration
 - network and API reachability for managed Airflow
 - reviewed runtime release entry without VM SSH
 - operator access rules for retries, backfills, and recovery
 
-These are readiness requirements, not resources this directory manages yet. The durable runtime release summary target is the one exception already wired into the Composer env contract, because later managed handoff work needs a storage-backed acknowledgement path before it can remove the retained-host report assumption.
+The repo now covers two Composer readiness seams directly: the reviewed DAG and source bundle sync path, and the reviewed Composer PyPI package baseline for the checked-in DAG bundle. Terraform merges later `cloud_composer_pypi_packages` overrides on top of that baseline so follow-up slices can extend the package set without replacing the known-good contract.
+
+These are readiness requirements, not resources this directory manages yet. The durable runtime release summary target is the one exception already wired into the Composer env contract, because later managed handoff work needs a storage-backed acknowledgement path before it can remove the retained-host report assumption. Private package indexes, non-PyPI or system-level dependencies, secret injection, and the reviewed runtime release entry still remain separate cutover work.
 
 ## What The Hosted Paths Expose
 
@@ -180,7 +181,7 @@ The repository uses two image-publication workflows that share one hosted build 
 
 Artifact Registry is the canonical hosted image registry in this contract. GHCR convenience artifacts, if published separately, are not the default hosted deployment path.
 
-The Composer DAG bundle path narrows the VM-checkout dependency for DAG delivery, but the reviewed runtime release entry without VM SSH and Composer-specific dependency installation still belong to later orchestration issues.
+The Composer DAG bundle path plus the reviewed Composer PyPI baseline narrow the VM-checkout and dependency-installation gaps, but the reviewed runtime release entry without VM SSH and managed secret or runtime-config delivery still belong to later orchestration issues.
 
 Set these GitHub repository variables:
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -92,6 +92,22 @@ locals {
     },
     var.cloud_composer_env_vars,
   )
+  cloud_composer_pypi_packages = merge(
+    {
+      evidently             = ">=0.7.21"
+      feast                 = "[gcp]>=0.63.0"
+      google-cloud-bigquery = ">=3.30.0"
+      google-cloud-storage  = ">=2.19.0"
+      matplotlib            = ">=3.8"
+      mlflow                = ">=3.0"
+      pandas                = ">=2.0"
+      pyarrow               = ">=14.0"
+      pyyaml                = ">=6.0"
+      requests              = ">=2.31"
+      scikit-learn          = ">=1.5"
+    },
+    var.cloud_composer_pypi_packages,
+  )
 
   forecast_feature_schema = [
     {
@@ -795,7 +811,7 @@ resource "google_composer_environment" "cloud_composer" {
       }
 
       env_variables = local.cloud_composer_env_vars
-      pypi_packages = var.cloud_composer_pypi_packages
+      pypi_packages = local.cloud_composer_pypi_packages
     }
 
     node_config {

--- a/terraform/terraform.tfvars.example
+++ b/terraform/terraform.tfvars.example
@@ -20,6 +20,7 @@ mlflow_tracking_uri            = "https://mlflow.example.com"
 cloud_run_env_vars             = {}
 provision_cloud_composer_environment = false
 cloud_composer_environment_name = "foehncast-composer"
+cloud_composer_pypi_packages = {}
 provision_online_compose_host  = true
 online_compose_host_name       = "foehncast-online"
 online_compose_host_zone       = "europe-west6-b"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -154,7 +154,7 @@ variable "cloud_composer_env_vars" {
 }
 
 variable "cloud_composer_pypi_packages" {
-  description = "Additional PyPI packages for the Cloud Composer environment."
+  description = "Additional or overriding PyPI packages merged on top of the repo-reviewed Cloud Composer baseline."
   type        = map(string)
   default     = {}
 }

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -120,6 +120,20 @@ FEAST_CLOUD_ENV_KEYS = {
     "FOEHNCAST_FEAST_DATASTORE_DATABASE",
 }
 
+COMPOSER_BASELINE_PYPI_PACKAGES = {
+    "evidently": ">=0.7.21",
+    "feast": "[gcp]>=0.63.0",
+    "google-cloud-bigquery": ">=3.30.0",
+    "google-cloud-storage": ">=2.19.0",
+    "matplotlib": ">=3.8",
+    "mlflow": ">=3.0",
+    "pandas": ">=2.0",
+    "pyarrow": ">=14.0",
+    "pyyaml": ">=6.0",
+    "requests": ">=2.31",
+    "scikit-learn": ">=1.5",
+}
+
 
 def _function_body(relative_path: str, function_name: str) -> str:
     match = re.search(
@@ -468,6 +482,31 @@ def test_terraform_online_compose_public_ports_default_to_private_control_plane(
     assert "default     = []" in variables
 
 
+def test_terraform_seeds_reviewed_composer_pypi_baseline() -> None:
+    terraform = _read_text("terraform/main.tf")
+
+    assert "cloud_composer_pypi_packages = merge(" in terraform
+    assert "pypi_packages = local.cloud_composer_pypi_packages" in terraform
+    assert "var.cloud_composer_pypi_packages" in terraform
+
+    for package_name, constraint in COMPOSER_BASELINE_PYPI_PACKAGES.items():
+        assert re.search(
+            rf'^\s+{re.escape(package_name)}\s+=\s+"{re.escape(constraint)}"$',
+            terraform,
+            flags=re.MULTILINE,
+        )
+
+
+def test_terraform_describes_composer_pypi_override_contract() -> None:
+    variables = _read_text("terraform/variables.tf")
+
+    assert 'variable "cloud_composer_pypi_packages"' in variables
+    assert (
+        "Additional or overriding PyPI packages merged on top of the repo-reviewed Cloud Composer baseline."
+        in variables
+    )
+
+
 def test_terraform_tfvars_example_promotes_cloud_run_primary_path() -> None:
     tfvars = _read_text("terraform/terraform.tfvars.example")
 
@@ -482,8 +521,34 @@ def test_terraform_tfvars_example_promotes_cloud_run_primary_path() -> None:
         tfvars,
         flags=re.MULTILINE,
     )
+    assert re.search(
+        r"^cloud_composer_pypi_packages\s+=\s+\{\}$",
+        tfvars,
+        flags=re.MULTILINE,
+    )
     assert "provision_online_compose_host  = true" in tfvars
     assert "online_compose_public_ports    = []" in tfvars
+
+
+def test_composer_readiness_docs_describe_reviewed_pypi_baseline() -> None:
+    terraform_readme = _read_text("terraform/README.md")
+    workflow_doc = _read_text("docs/site/system/delivery-and-operator-workflow.md")
+    cloud_mapping_doc = _read_text("docs/site/system/cloud-mapping.md")
+
+    assert "reviewed Composer PyPI package baseline" in terraform_readme
+    assert "cloud_composer_pypi_packages" in terraform_readme
+    assert (
+        "Composer now gets a reviewed PyPI baseline for the checked-in DAG bundle"
+        in workflow_doc
+    )
+    assert (
+        "Terraform now seeds a reviewed Composer PyPI baseline for the checked-in DAG bundle"
+        in workflow_doc
+    )
+    assert (
+        "Terraform also seeds the reviewed PyPI baseline required by the checked-in DAG bundle"
+        in cloud_mapping_doc
+    )
 
 
 def test_remote_terraform_workflow_verifies_hosted_runtimes_after_apply() -> None:


### PR DESCRIPTION
## What changed
- seed a reviewed Cloud Composer PyPI package baseline for the checked-in DAG bundle and merge operator overrides on top of it in Terraform
- document the managed-orchestration dependency contract in the Terraform and system docs
- add regression coverage for the Composer PyPI baseline, override surface, and updated readiness wording

## Why
- the Composer DAG bundle now ships the checked-in DAG entrypoints and source tree, so the managed environment needs a reviewed Python package contract to parse and run that bundle without depending on the retained host image path

## Verification
- `uv run pytest tests/test_cloud_operator_contract.py`
- `uv run ruff check tests/test_cloud_operator_contract.py`
- `terraform -chdir=terraform fmt -check`
- `terraform -chdir=terraform init -backend=false`
- `terraform -chdir=terraform validate`
- `uv run mkdocs build --strict -f docs/mkdocs.yml`

## Closes
- Closes #238
