### PR TITLE
feat(orchestration): add explicit Composer runtime handoff

### DIFF
--- a/.github/actions/load-gcp-repo-config/action.yml
+++ b/.github/actions/load-gcp-repo-config/action.yml
@@ -71,6 +71,9 @@ outputs:
   cloud_composer_dag_gcs_prefix:
     description: Cloud Composer DAG bucket prefix repository variable
     value: ${{ steps.repo_config.outputs.cloud_composer_dag_gcs_prefix }}
+  cloud_composer_airflow_uri:
+    description: Cloud Composer Airflow URI repository variable
+    value: ${{ steps.repo_config.outputs.cloud_composer_airflow_uri }}
   provision_online_compose_host:
     description: Online compose host provisioning repository variable
     value: ${{ steps.repo_config.outputs.provision_online_compose_host }}
@@ -139,6 +142,7 @@ runs:
           echo "provision_cloud_composer_environment=$(read_repo_var GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT)"
           echo "cloud_composer_environment_name=$(read_repo_var GCP_CLOUD_COMPOSER_ENVIRONMENT_NAME)"
           echo "cloud_composer_dag_gcs_prefix=$(read_repo_var GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX)"
+          echo "cloud_composer_airflow_uri=$(read_repo_var GCP_CLOUD_COMPOSER_AIRFLOW_URI)"
           echo "provision_online_compose_host=$(read_repo_var GCP_PROVISION_ONLINE_COMPOSE_HOST)"
           echo "online_compose_host_name=$(read_repo_var GCP_ONLINE_COMPOSE_HOST_NAME)"
           echo "online_compose_host_zone=$(read_repo_var GCP_ONLINE_COMPOSE_HOST_ZONE)"

--- a/.github/workflows/trigger-runtime-release.yml
+++ b/.github/workflows/trigger-runtime-release.yml
@@ -12,6 +12,14 @@ on:
           - deploy_candidate
           - promote_candidate
           - rollback_live
+      airflow_target:
+        description: Reviewed Airflow receiver for the runtime release handoff
+        required: true
+        default: retained_host
+        type: choice
+        options:
+          - retained_host
+          - composer_airflow
       image_uri:
         description: Immutable image URI for deploy_candidate requests
         required: false
@@ -55,10 +63,13 @@ jobs:
     outputs:
       owner_allowed: ${{ steps.flags.outputs.owner_allowed }}
       project_id: ${{ steps.repo_config.outputs.project_id }}
+      artifact_bucket_name: ${{ steps.repo_config.outputs.artifact_bucket_name }}
       workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
       service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
       online_compose_host_name: ${{ steps.repo_config.outputs.online_compose_host_name }}
       online_compose_host_zone: ${{ steps.repo_config.outputs.online_compose_host_zone }}
+      cloud_composer_airflow_uri: ${{ steps.repo_config.outputs.cloud_composer_airflow_uri }}
+      airflow_target: ${{ steps.derived.outputs.airflow_target }}
       action: ${{ steps.derived.outputs.action }}
       image_uri: ${{ steps.derived.outputs.image_uri }}
       candidate_revision_tag: ${{ steps.derived.outputs.candidate_revision_tag }}
@@ -94,6 +105,7 @@ jobs:
       - id: derived
         env:
           ACTION_INPUT: ${{ github.event.inputs.action }}
+          AIRFLOW_TARGET_INPUT: ${{ github.event.inputs.airflow_target }}
           IMAGE_URI_INPUT: ${{ github.event.inputs.image_uri }}
           CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
           CANDIDATE_ALIAS_INPUT: ${{ github.event.inputs.candidate_alias }}
@@ -102,6 +114,9 @@ jobs:
           ROLLBACK_MODEL_VERSION_INPUT: ${{ github.event.inputs.rollback_model_version }}
           ROLLBACK_REVISION_TAG_INPUT: ${{ github.event.inputs.rollback_revision_tag }}
           PROJECT_ID: ${{ steps.repo_config.outputs.project_id }}
+          ARTIFACT_BUCKET_NAME: ${{ steps.repo_config.outputs.artifact_bucket_name }}
+          PROVISION_CLOUD_COMPOSER_ENVIRONMENT: ${{ steps.repo_config.outputs.provision_cloud_composer_environment }}
+          CLOUD_COMPOSER_AIRFLOW_URI: ${{ steps.repo_config.outputs.cloud_composer_airflow_uri }}
           PROVISION_ONLINE_COMPOSE_HOST: ${{ steps.repo_config.outputs.provision_online_compose_host }}
           ONLINE_COMPOSE_HOST_NAME: ${{ steps.repo_config.outputs.online_compose_host_name }}
           ONLINE_COMPOSE_HOST_ZONE: ${{ steps.repo_config.outputs.online_compose_host_zone }}
@@ -111,11 +126,22 @@ jobs:
           set -euo pipefail
 
           action="$(printf '%s' "${ACTION_INPUT:-deploy_candidate}" | tr '[:upper:]' '[:lower:]')"
+          airflow_target="$(printf '%s' "${AIRFLOW_TARGET_INPUT:-retained_host}" | tr '[:upper:]' '[:lower:]')"
+
           case "$action" in
             deploy_candidate|promote_candidate|rollback_live)
               ;;
             *)
               echo "Unsupported action '$action'." >&2
+              exit 1
+              ;;
+          esac
+
+          case "$airflow_target" in
+            retained_host|composer_airflow)
+              ;;
+            *)
+              echo "Unsupported airflow target '$airflow_target'." >&2
               exit 1
               ;;
           esac
@@ -150,13 +176,25 @@ jobs:
           fi
 
           trigger_ready=false
-          if [[ "$PROVISION_ONLINE_COMPOSE_HOST" == 'true' \
-            && -n "$PROJECT_ID" \
-            && -n "$ONLINE_COMPOSE_HOST_NAME" \
-            && -n "$ONLINE_COMPOSE_HOST_ZONE" \
+          if [[ -n "$PROJECT_ID" \
             && -n "$WORKLOAD_IDENTITY_PROVIDER" \
             && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
-            trigger_ready=true
+            case "$airflow_target" in
+              retained_host)
+                if [[ "$PROVISION_ONLINE_COMPOSE_HOST" == 'true' \
+                  && -n "$ONLINE_COMPOSE_HOST_NAME" \
+                  && -n "$ONLINE_COMPOSE_HOST_ZONE" ]]; then
+                  trigger_ready=true
+                fi
+                ;;
+              composer_airflow)
+                if [[ "$PROVISION_CLOUD_COMPOSER_ENVIRONMENT" == 'true' \
+                  && -n "$CLOUD_COMPOSER_AIRFLOW_URI" \
+                  && -n "$ARTIFACT_BUCKET_NAME" ]]; then
+                  trigger_ready=true
+                fi
+                ;;
+            esac
           fi
 
           case "$action" in
@@ -174,6 +212,7 @@ jobs:
 
           {
             echo "action=$action"
+            echo "airflow_target=$airflow_target"
             echo "image_uri=$image_uri"
             echo "candidate_revision_tag=$candidate_revision_tag"
             echo "candidate_alias=$candidate_alias"
@@ -190,8 +229,11 @@ jobs:
     runs-on: ubuntu-latest
     env:
       PROJECT_ID: ${{ needs.config.outputs.project_id }}
+      ARTIFACT_BUCKET_NAME: ${{ needs.config.outputs.artifact_bucket_name }}
       HOST_NAME: ${{ needs.config.outputs.online_compose_host_name }}
       HOST_ZONE: ${{ needs.config.outputs.online_compose_host_zone }}
+      AIRFLOW_TARGET: ${{ needs.config.outputs.airflow_target }}
+      CLOUD_COMPOSER_AIRFLOW_URI: ${{ needs.config.outputs.cloud_composer_airflow_uri }}
       ACTION: ${{ needs.config.outputs.action }}
       IMAGE_URI: ${{ needs.config.outputs.image_uri }}
       CANDIDATE_REVISION_TAG: ${{ needs.config.outputs.candidate_revision_tag }}
@@ -210,12 +252,21 @@ jobs:
 
       - uses: google-github-actions/setup-gcloud@v2
 
+      - name: Set up uv
+        if: ${{ env.AIRFLOW_TARGET == 'composer_airflow' }}
+        uses: astral-sh/setup-uv@v8.1.0
+
+      - name: Install Composer trigger dependencies
+        if: ${{ env.AIRFLOW_TARGET == 'composer_airflow' }}
+        run: uv sync --frozen
+
       - name: Build runtime release request
         run: |
           set -euo pipefail
           python -c 'from datetime import UTC, datetime; import json, os, pathlib; run_url = "/".join([os.environ["GITHUB_SERVER_URL"], os.environ["GITHUB_REPOSITORY"], "actions", "runs", os.environ["GITHUB_RUN_ID"]]); payload = {"action": os.environ["ACTION"], "request_source": "github-actions", "requested_at": datetime.now(tz=UTC).isoformat(), "github_repository": os.environ["GITHUB_REPOSITORY"], "github_workflow": os.environ["GITHUB_WORKFLOW"], "github_run_id": os.environ["GITHUB_RUN_ID"], "github_run_url": run_url, "github_sha": os.environ["GITHUB_SHA"], "image_uri": os.environ.get("IMAGE_URI", ""), "candidate_revision_tag": os.environ.get("CANDIDATE_REVISION_TAG", "candidate"), "candidate_alias": os.environ.get("CANDIDATE_ALIAS", "candidate"), "target_alias": os.environ.get("TARGET_ALIAS", "champion"), "rollback_revision": os.environ.get("ROLLBACK_REVISION", ""), "rollback_model_version": os.environ.get("ROLLBACK_MODEL_VERSION", ""), "rollback_revision_tag": os.environ.get("ROLLBACK_REVISION_TAG", "rollback")}; pathlib.Path("runtime-release-request.json").write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n")'
 
       - name: Refresh operator host checkout
+        if: ${{ env.AIRFLOW_TARGET == 'retained_host' }}
         run: |
           set -euo pipefail
           gcloud compute ssh "$HOST_NAME" \
@@ -224,6 +275,7 @@ jobs:
             --command "sudo systemctl start --wait foehncast-online-compose-sync.service"
 
       - name: Copy runtime release request
+        if: ${{ env.AIRFLOW_TARGET == 'retained_host' }}
         run: |
           set -euo pipefail
           gcloud compute scp \
@@ -237,10 +289,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          report="$(gcloud compute ssh "$HOST_NAME" \
-            --project "$PROJECT_ID" \
-            --zone "$HOST_ZONE" \
-            --command "cd /opt/foehncast && ./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json")"
+          selected_receiver="retained-host Airflow adapter"
+          selected_auth_path="GitHub OIDC plus SSH to retained host"
+
+          if [[ "$AIRFLOW_TARGET" == "composer_airflow" ]]; then
+            selected_receiver="Composer Airflow API"
+            selected_auth_path="GitHub OIDC plus Google access token to Composer Airflow"
+            export FOEHNCAST_AIRFLOW_AUTH_TOKEN="$(gcloud auth print-access-token)"
+            report="$(FOEHNCAST_RUNTIME_RELEASE_REPORT_PATH="gs://${ARTIFACT_BUCKET_NAME}/airflow/reports/runtime-release-latest.json" \
+              uv run ./scripts/trigger-runtime-release.sh \
+                --request-file runtime-release-request.json \
+                --airflow-trigger-mode airflow_api \
+                --airflow-api-base-url "${CLOUD_COMPOSER_AIRFLOW_URI%/}/api/v1" \
+                --airflow-api-health-endpoint /health)"
+          else
+            report="$(gcloud compute ssh "$HOST_NAME" \
+              --project "$PROJECT_ID" \
+              --zone "$HOST_ZONE" \
+              --command "cd /opt/foehncast && ./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json")"
+          fi
 
           printf '%s\n' "$report"
 
@@ -256,10 +323,15 @@ jobs:
             echo "## Runtime release handoff"
             echo
             echo "- Action: $ACTION"
-            echo "- Operator host: $HOST_NAME"
+            echo "- Selected receiver: $selected_receiver"
+            echo "- Fallback receiver: retained-host Airflow adapter"
+            echo "- Auth path: $selected_auth_path"
+            if [[ "$AIRFLOW_TARGET" == "composer_airflow" ]]; then
+              echo "- Composer access assumption: the GitHub service account already maps to an Airflow user or role"
+            else
+              echo "- Operator host: $HOST_NAME"
+            fi
             echo "- Airflow DAG: runtime_release"
-            echo "- Current receiver: retained-host Airflow adapter"
-            echo "- Target receiver: Cloud Composer without VM SSH"
             echo "- DAG run: $dag_run_id"
             echo "- Summary path: $report_path"
             echo
@@ -272,20 +344,29 @@ jobs:
     needs: config
     if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready != 'true' }}
     runs-on: ubuntu-latest
+    env:
+      AIRFLOW_TARGET: ${{ needs.config.outputs.airflow_target }}
     steps:
       - name: Explain skipped runtime release handoff
         run: |
           {
             echo "## Runtime release handoff skipped"
             echo
-            echo "The explicit runtime trigger contract needs all of these inputs before it can run:"
-            echo "This is the current retained-host entry contract. The target managed receiver is Cloud Composer without VM SSH."
+            echo "The selected runtime trigger contract needs all of these inputs before it can run:"
             echo "- GCP_PROJECT_ID"
             echo "- GCP_WORKLOAD_IDENTITY_PROVIDER"
             echo "- GCP_SERVICE_ACCOUNT_EMAIL"
-            echo "- GCP_PROVISION_ONLINE_COMPOSE_HOST=true"
-            echo "- GCP_ONLINE_COMPOSE_HOST_NAME"
-            echo "- GCP_ONLINE_COMPOSE_HOST_ZONE"
+            if [[ "$AIRFLOW_TARGET" == "composer_airflow" ]]; then
+              echo "- GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT=true"
+              echo "- GCP_CLOUD_COMPOSER_AIRFLOW_URI"
+              echo "- GCP_ARTIFACT_BUCKET_NAME"
+              echo
+              echo "Composer handoff also assumes the GitHub service account already maps to an Airflow user or role."
+            else
+              echo "- GCP_PROVISION_ONLINE_COMPOSE_HOST=true"
+              echo "- GCP_ONLINE_COMPOSE_HOST_NAME"
+              echo "- GCP_ONLINE_COMPOSE_HOST_ZONE"
+            fi
             echo
             echo "Action-specific coordinates must also be present for the chosen request."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -176,6 +176,8 @@ Cloud Composer is the target managed orchestration direction, and Terraform can 
 
 A reviewed DAG and source bundle can now sync to the provisioned Composer DAG bucket. Terraform also seeds the reviewed PyPI baseline required by the checked-in DAG bundle and merges extra `cloud_composer_pypi_packages` overrides on top. Secret and runtime-config injection, and a reviewed runtime release entry that reaches the managed Airflow surface directly, still need to stop depending on the retained operator host. The retained host remains the active orchestration authority until those boundaries move. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed active-versus-target delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
 
+The runtime trigger now exposes an explicit receiver selection contract: the retained host stays the default handoff, and Composer Airflow can be selected deliberately once the Composer URI and access path are ready.
+
 ## Active And Target Hosted Mapping
 
 | Concern | Active hosted path | Target hosted direction |

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -84,12 +84,14 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 | `terraform/terraform.tfvars` | interactive bootstrap input, not the day-2 source of truth |
 | runtime image workflows | submit reviewed hosted image builds to Cloud Build and publish images to Artifact Registry |
 | `.github/workflows/publish-composer-dags.yml` | publish the reviewed DAG and source bundle to the provisioned Composer DAG bucket |
-| `.github/workflows/trigger-runtime-release.yml` | send one explicit reviewed runtime release request into hosted Airflow while the retained host still owns that handoff |
+| `.github/workflows/trigger-runtime-release.yml` | send one explicit reviewed runtime release request into the selected Airflow receiver while the retained host remains the default handoff |
 | `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up after a remote apply and curated BigQuery rows exist |
 
 The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as minimum and maximum instance count, container port, CPU, and memory stay repo-variable-backed instead of becoming manual workflow inputs.
 
 GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket. Composer now gets a reviewed PyPI baseline for the checked-in DAG bundle, but runtime secret delivery and the reviewed runtime release entry still need separate cutover work.
+
+The runtime trigger now has an explicit reviewed receiver selection contract as well: `retained_host` stays the default reviewed receiver while the Composer Airflow URI and access path are being prepared, and operators can choose `composer_airflow` deliberately when those prerequisites are ready.
 
 Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables stay structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. Both hosted lanes still read the same Terraform-managed storage, Feast, and MLflow contract. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
 
@@ -135,17 +137,20 @@ GitHub now has exactly one reviewed handoff into runtime execution.
 
 <div class="mermaid">
 flowchart LR
-    GHW["fab:fa-github Runtime release workflow"] --> SSH["OIDC + SSH to retained host"]
+    GHW["fab:fa-github Runtime release workflow"] --> TARGET["reviewed receiver selection"]
+    TARGET --> SSH["OIDC + SSH to retained host"]
+    TARGET --> API["OIDC + access token to Composer Airflow API"]
     SSH --> SCRIPT["trigger-runtime-release.sh"]
+    API --> SCRIPT
     SCRIPT --> DAG["runtime_release DAG"]
     DAG --> REPORT["runtime-release-latest.json"]
     REPORT --> SUMMARY["GitHub workflow summary"]
 </div>
 
 - signal: `.github/workflows/trigger-runtime-release.yml` sends one JSON request with a single action and the associated release coordinates
-- receiver: `./scripts/trigger-runtime-release.sh` runs on the retained operator host and triggers the hosted Airflow `runtime_release` DAG locally
-- auth path: GitHub Actions uses OIDC into the deployer service account and Compute Engine SSH; GitHub does not store Airflow credentials or call a public Airflow endpoint
-- observable outcome: the workflow waits for the `runtime_release` DAG to succeed and captures the configured runtime release summary target; on the retained host the default remains `airflow/reports/runtime-release-latest.json`
+- receiver: Trigger Runtime Release keeps `retained_host` as the default reviewed receiver and can intentionally choose `composer_airflow` once the Composer Airflow URI and access path are ready
+- auth path: the retained-host path uses GitHub OIDC plus Compute Engine SSH; the Composer path uses GitHub OIDC plus a Google access token for the Composer Airflow API and assumes the GitHub service account already maps to an Airflow user or role
+- observable outcome: the workflow waits for the `runtime_release` DAG to succeed and captures the configured runtime release summary target; on the retained host the default remains `airflow/reports/runtime-release-latest.json`, while the Composer path reads the durable `gs://...` report contract derived from the artifact bucket
 
 Supported actions:
 
@@ -153,7 +158,7 @@ Supported actions:
 - `promote_candidate`
 - `rollback_live`
 
-This keeps the handoff explicit while deeper runtime automation still lives behind the Airflow side of the boundary. It is the active contract, not the intended long-term hosted entry path. The target managed direction is the same reviewed request reaching Composer without a retained-host refresh step.
+This keeps the handoff explicit while deeper runtime automation still lives behind the Airflow side of the boundary. It is the active contract, not the intended long-term hosted entry path. The default still points at the retained host; Composer handoff is opt-in until the access path is ready. The target managed direction is the same reviewed request reaching Composer without a retained-host refresh step.
 
 ## Composer Readiness Requirements
 
@@ -178,7 +183,7 @@ Operators should retry work on the same plane that owns it instead of jumping be
 | Situation | Where to act | Normal procedure | Minimum evidence |
 |------|---------------|------------------|------------------|
 | Terraform or image publication fails before any runtime request is sent | GitHub Actions | fix the reviewed delivery input, then rerun the failed GitHub workflow | GitHub workflow URL plus the updated workflow summary |
-| candidate deploy, promotion, or rollback handoff needs another attempt | GitHub Actions through the runtime trigger contract | rerun `.github/workflows/trigger-runtime-release.yml` with the same reviewed release coordinates so the retained operator host refreshes and the hosted Airflow `runtime_release` DAG records a new acknowledgement | GitHub workflow URL plus the configured runtime release summary target |
+| candidate deploy, promotion, or rollback handoff needs another attempt | GitHub Actions through the runtime trigger contract | rerun `.github/workflows/trigger-runtime-release.yml` with the same reviewed release coordinates and the same selected receiver so the retained operator host or the Composer API handoff records a new acknowledgement | GitHub workflow URL plus the configured runtime release summary target |
 | a feature slice failed or needs replay for one logical date | hosted Airflow on the retained operator host | SSH to the host, verify Airflow health, trigger `feature_pipeline` with an explicit logical date, and wait for the DAG to succeed | logical date, feature DAG run id, and `airflow/reports/feature-pipeline-<dataset>-latest.json` |
 | a replayed feature slice should refresh training state too | hosted Airflow on the retained operator host | let the feature replay publish the training-request asset and wait for the asset-triggered `training_pipeline` run instead of treating training as a separate first step | training DAG run id plus `airflow/reports/training-pipeline-<dataset>-latest.json` |
 | training must be rerun without replaying feature ingestion | hosted Airflow on the retained operator host | use a manual `training_pipeline` run only when the curated feature slice already exists and the operator is intentionally choosing the requested stage in DAG config | training DAG run id, requested stage, model version, and training summary JSON |

--- a/scripts/airflow-api-common.sh
+++ b/scripts/airflow-api-common.sh
@@ -9,11 +9,17 @@ airflow_api_verify_health() {
   local timeout_message="$2"
   local max_attempts="${3:-60}"
   local sleep_seconds="${4:-2}"
+  local auth_token="${5:-}"
   local payload=""
   local attempt
+  local -a curl_args=(-fsS)
+
+  if [[ -n "$auth_token" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${auth_token}")
+  fi
 
   for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-    if payload="$(curl --retry 1 --retry-all-errors --retry-delay 0 -fsS "$health_url" 2>/dev/null)"; then
+    if payload="$(curl --retry 1 --retry-all-errors --retry-delay 0 "${curl_args[@]}" "$health_url" 2>/dev/null)"; then
       if printf '%s' "$payload" | airflow_api_helper_run health; then
         return 0
       fi
@@ -36,14 +42,23 @@ airflow_api_wait_for_dag_run_state() {
   local timeout_message="$4"
   local max_attempts="${5:-120}"
   local sleep_seconds="${6:-2}"
-  shift 6
-  local helper_args=("$@")
+  local auth_token="${7:-}"
+  local -a helper_args=()
   local payload=""
   local status
   local attempt
+  local -a curl_args=(-fsS)
+
+  if (( $# > 7 )); then
+    helper_args=("${@:8}")
+  fi
+
+  if [[ -n "$auth_token" ]]; then
+    curl_args+=(-H "Authorization: Bearer ${auth_token}")
+  fi
 
   for ((attempt = 1; attempt <= max_attempts; attempt++)); do
-    if payload="$(curl --retry 1 --retry-all-errors --retry-delay 0 -fsS "${airflow_api_base_url}/dags/${dag_id}/dagRuns?limit=20&order_by=-start_date" 2>/dev/null)"; then
+    if payload="$(curl --retry 1 --retry-all-errors --retry-delay 0 "${curl_args[@]}" "${airflow_api_base_url}/dags/${dag_id}/dagRuns?limit=20&order_by=-start_date" 2>/dev/null)"; then
       if printf '%s' "$payload" | airflow_api_helper_run dag-run --expected-state "$expected_state" "${helper_args[@]}"; then
         return 0
       else

--- a/scripts/bootstrap-local.sh
+++ b/scripts/bootstrap-local.sh
@@ -280,7 +280,9 @@ verify_airflow_api_health() {
   airflow_api_verify_health \
     "$AIRFLOW_HEALTH_URL" \
     "Timed out waiting for Airflow health endpoint to report all required components healthy." \
-    "$@"
+    "${1:-60}" \
+    "${2:-2}" \
+    ""
 }
 
 stop_ci_smoke_airflow_orchestration_services() {
@@ -324,6 +326,7 @@ wait_for_airflow_dag_run_state() {
     "Timed out waiting for Airflow DAG '$dag_id' to reach state '$expected_state'." \
     "$max_attempts" \
     "$sleep_seconds" \
+    "" \
     "${helper_args[@]}"
 }
 

--- a/scripts/configure-github-actions.sh
+++ b/scripts/configure-github-actions.sh
@@ -96,6 +96,7 @@ fi
 cloud_run_synced=false
 mlflow_tracking_uri_synced=false
 cloud_composer_dag_gcs_prefix_synced=false
+cloud_composer_airflow_uri_synced=false
 while IFS=$'\t' read -r variable_name variable_value; do
   set_variable "$REPOSITORY_PATH" "$variable_name" "$variable_value"
 
@@ -109,6 +110,10 @@ while IFS=$'\t' read -r variable_name variable_value; do
 
   if [[ "$variable_name" == "GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX" ]]; then
     cloud_composer_dag_gcs_prefix_synced=true
+  fi
+
+  if [[ "$variable_name" == "GCP_CLOUD_COMPOSER_AIRFLOW_URI" ]]; then
+    cloud_composer_airflow_uri_synced=true
   fi
 done < <(terraform_repo_variable_pairs "$TERRAFORM_DIR")
 
@@ -125,6 +130,11 @@ fi
 if [[ "$cloud_composer_dag_gcs_prefix_synced" != "true" ]]; then
   delete_variable "$REPOSITORY_PATH" GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX
   echo "Skipping GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX because Terraform has not provisioned a Cloud Composer DAG bucket prefix yet."
+fi
+
+if [[ "$cloud_composer_airflow_uri_synced" != "true" ]]; then
+  delete_variable "$REPOSITORY_PATH" GCP_CLOUD_COMPOSER_AIRFLOW_URI
+  echo "Skipping GCP_CLOUD_COMPOSER_AIRFLOW_URI because Terraform has not provisioned a Cloud Composer Airflow URI yet."
 fi
 
 echo "GitHub Actions variables are configured for ${REPOSITORY_PATH}."

--- a/scripts/terraform-platform-state.sh
+++ b/scripts/terraform-platform-state.sh
@@ -289,6 +289,7 @@ load_terraform_platform_state() {
   FOEHNCAST_TF_PROVISION_CLOUD_COMPOSER_ENVIRONMENT="$(terraform_output_or_tfvars_value "$terraform_dir" provision_cloud_composer_environment provision_cloud_composer_environment)"
   FOEHNCAST_TF_CLOUD_COMPOSER_ENVIRONMENT_NAME="$(terraform_output_or_tfvars_value "$terraform_dir" configured_cloud_composer_environment_name cloud_composer_environment_name)"
   FOEHNCAST_TF_CLOUD_COMPOSER_DAG_GCS_PREFIX="$(trimmed_terraform_output_value "$terraform_dir" cloud_composer_dag_gcs_prefix)"
+  FOEHNCAST_TF_CLOUD_COMPOSER_AIRFLOW_URI="$(optional_terraform_output_value "$terraform_dir" cloud_composer_airflow_uri)"
   FOEHNCAST_TF_CLOUD_RUN_SERVICE="$(optional_terraform_output_value "$terraform_dir" cloud_run_service_name)"
   FOEHNCAST_TF_PROVISION_ONLINE_COMPOSE_HOST="$(terraform_output_or_tfvars_value "$terraform_dir" provision_online_compose_host provision_online_compose_host)"
   FOEHNCAST_TF_ONLINE_COMPOSE_HOST_NAME="$(terraform_output_or_tfvars_value "$terraform_dir" online_compose_host_name online_compose_host_name)"
@@ -326,6 +327,7 @@ terraform_repo_variable_names() {
     GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT \
     GCP_CLOUD_COMPOSER_ENVIRONMENT_NAME \
     GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX \
+    GCP_CLOUD_COMPOSER_AIRFLOW_URI \
     GCP_PROVISION_ONLINE_COMPOSE_HOST \
     GCP_ONLINE_COMPOSE_HOST_NAME \
     GCP_ONLINE_COMPOSE_HOST_ZONE \
@@ -374,6 +376,10 @@ terraform_repo_variable_pairs() {
 
   if terraform_platform_value_present "$FOEHNCAST_TF_CLOUD_COMPOSER_DAG_GCS_PREFIX"; then
     printf 'GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX\t%s\n' "$FOEHNCAST_TF_CLOUD_COMPOSER_DAG_GCS_PREFIX"
+  fi
+
+  if terraform_platform_value_present "$FOEHNCAST_TF_CLOUD_COMPOSER_AIRFLOW_URI"; then
+    printf 'GCP_CLOUD_COMPOSER_AIRFLOW_URI\t%s\n' "$FOEHNCAST_TF_CLOUD_COMPOSER_AIRFLOW_URI"
   fi
 
   if [[ -n "$FOEHNCAST_TF_CLOUD_RUN_SERVICE" ]]; then

--- a/scripts/trigger-runtime-release.sh
+++ b/scripts/trigger-runtime-release.sh
@@ -5,14 +5,17 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 REQUEST_FILE=""
 DAG_ID="runtime_release"
-AIRFLOW_API_BASE_URL="http://127.0.0.1:8080/api/v2"
+AIRFLOW_TRIGGER_MODE="${FOEHNCAST_AIRFLOW_TRIGGER_MODE:-local_cli}"
+AIRFLOW_API_BASE_URL="${FOEHNCAST_AIRFLOW_API_BASE_URL:-http://127.0.0.1:8080/api/v2}"
+AIRFLOW_API_HEALTH_ENDPOINT="${FOEHNCAST_AIRFLOW_API_HEALTH_ENDPOINT:-/monitor/health}"
+AIRFLOW_API_AUTH_TOKEN="${FOEHNCAST_AIRFLOW_AUTH_TOKEN:-}"
 # shellcheck disable=SC1091
 source "${ROOT_DIR}/scripts/cli-common.sh"
 # shellcheck disable=SC1091
 source "${ROOT_DIR}/scripts/airflow-api-common.sh"
 
 usage() {
-  echo "Usage: $0 --request-file path" >&2
+  echo "Usage: $0 --request-file path [--airflow-trigger-mode local_cli|airflow_api] [--airflow-api-base-url url] [--airflow-api-health-endpoint path]" >&2
 }
 
 run_airflow_api_helper() {
@@ -23,11 +26,21 @@ run_runtime_release_helper() {
   env PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}" python3 -m foehncast.runtime_release "$@"
 }
 
+normalized_airflow_trigger_mode() {
+  printf '%s' "$1" | tr '[:upper:]' '[:lower:]'
+}
+
+airflow_api_health_url() {
+  printf '%s%s\n' "${AIRFLOW_API_BASE_URL%/}" "$AIRFLOW_API_HEALTH_ENDPOINT"
+}
+
 verify_airflow_api_health() {
   airflow_api_verify_health \
-    "${AIRFLOW_API_BASE_URL}/monitor/health" \
+    "$(airflow_api_health_url)" \
     "Timed out waiting for Airflow API health." \
-    "$@"
+    "${1:-90}" \
+    "${2:-2}" \
+    "$AIRFLOW_API_AUTH_TOKEN"
 }
 
 wait_for_airflow_dag_run_state() {
@@ -43,6 +56,7 @@ wait_for_airflow_dag_run_state() {
     "Timed out waiting for Airflow DAG '${dag_id}' run '${dag_run_id}' to reach state '${expected_state}'." \
     "$max_attempts" \
     "$sleep_seconds" \
+    "$AIRFLOW_API_AUTH_TOKEN" \
     --expected-run-id "$dag_run_id"
 }
 
@@ -50,11 +64,73 @@ normalize_request_payload() {
   run_runtime_release_helper normalize-request --request-file "$REQUEST_FILE"
 }
 
+build_airflow_api_dag_run_payload() {
+  local dag_run_id="$1"
+  local logical_date="$2"
+  local normalized_request="$3"
+
+  python3 -c 'import json, sys; print(json.dumps({"dag_run_id": sys.argv[1], "logical_date": sys.argv[2], "conf": json.loads(sys.argv[3])}, sort_keys=True))' \
+    "$dag_run_id" \
+    "$logical_date" \
+    "$normalized_request"
+}
+
+trigger_airflow_dag_run_via_api() {
+  local normalized_request="$1"
+  local dag_run_id="$2"
+  local logical_date="$3"
+  local request_url payload
+  local -a curl_args=(
+    --retry 1
+    --retry-all-errors
+    --retry-delay 0
+    -fsS
+    -X POST
+    -H "Accept: application/json"
+    -H "Content-Type: application/json"
+    -H "Authorization: Bearer ${AIRFLOW_API_AUTH_TOKEN}"
+  )
+
+  request_url="${AIRFLOW_API_BASE_URL%/}/dags/${DAG_ID}/dagRuns"
+  payload="$(build_airflow_api_dag_run_payload "$dag_run_id" "$logical_date" "$normalized_request")"
+
+  curl "${curl_args[@]}" "$request_url" --data "$payload" >/dev/null
+}
+
+trigger_airflow_dag_run_via_local_cli() {
+  local normalized_request="$1"
+  local dag_run_id="$2"
+  local logical_date="$3"
+  local compose_args=(
+    -f "$ROOT_DIR/docker-compose.yml"
+    -f "$ROOT_DIR/docker-compose.cloud.yml"
+    --env-file "$ROOT_DIR/.env"
+  )
+
+  docker compose "${compose_args[@]}" exec -T airflow-webserver \
+    airflow dags trigger "$DAG_ID" \
+    --logical-date "$logical_date" \
+    --run-id "$dag_run_id" \
+    --conf "$normalized_request" >/dev/null
+}
+
 while [[ $# -gt 0 ]]; do
   case "$1" in
     --request-file)
       shift
       REQUEST_FILE="$(require_cli_option_value "--request-file" "${1:-}" usage)"
+      ;;
+    --airflow-trigger-mode)
+      shift
+      AIRFLOW_TRIGGER_MODE="$(require_cli_option_value "--airflow-trigger-mode" "${1:-}" usage)"
+      ;;
+    --airflow-api-base-url)
+      shift
+      AIRFLOW_API_BASE_URL="$(require_cli_option_value "--airflow-api-base-url" "${1:-}" usage)"
+      ;;
+    --airflow-api-health-endpoint)
+      shift
+      AIRFLOW_API_HEALTH_ENDPOINT="$(require_cli_option_value "--airflow-api-health-endpoint" "${1:-}" usage)"
       ;;
     -h|--help)
       usage
@@ -69,6 +145,25 @@ while [[ $# -gt 0 ]]; do
   shift
 done
 
+AIRFLOW_TRIGGER_MODE="$(normalized_airflow_trigger_mode "$AIRFLOW_TRIGGER_MODE")"
+case "$AIRFLOW_TRIGGER_MODE" in
+  local_cli|airflow_api)
+    ;;
+  *)
+    echo "Unsupported airflow trigger mode '$AIRFLOW_TRIGGER_MODE'." >&2
+    exit 1
+    ;;
+esac
+
+if [[ "${AIRFLOW_API_HEALTH_ENDPOINT}" != /* ]]; then
+  AIRFLOW_API_HEALTH_ENDPOINT="/${AIRFLOW_API_HEALTH_ENDPOINT}"
+fi
+
+if [[ "$AIRFLOW_TRIGGER_MODE" == "airflow_api" && -z "$AIRFLOW_API_AUTH_TOKEN" ]]; then
+  echo "Set FOEHNCAST_AIRFLOW_AUTH_TOKEN when --airflow-trigger-mode airflow_api is selected." >&2
+  exit 1
+fi
+
 if [[ -z "$REQUEST_FILE" || ! -f "$REQUEST_FILE" ]]; then
   usage
   exit 1
@@ -77,19 +172,14 @@ fi
 normalized_request="$(normalize_request_payload)"
 dag_run_id="runtime_release__$(date -u +"%Y-%m-%dT%H-%M-%SZ")"
 logical_date="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-compose_args=(
-  -f "$ROOT_DIR/docker-compose.yml"
-  -f "$ROOT_DIR/docker-compose.cloud.yml"
-  --env-file "$ROOT_DIR/.env"
-)
 
 verify_airflow_api_health 90 2 >&2
 
-docker compose "${compose_args[@]}" exec -T airflow-webserver \
-  airflow dags trigger "$DAG_ID" \
-  --logical-date "$logical_date" \
-  --run-id "$dag_run_id" \
-  --conf "$normalized_request" >/dev/null
+if [[ "$AIRFLOW_TRIGGER_MODE" == "airflow_api" ]]; then
+  trigger_airflow_dag_run_via_api "$normalized_request" "$dag_run_id" "$logical_date"
+else
+  trigger_airflow_dag_run_via_local_cli "$normalized_request" "$dag_run_id" "$logical_date"
+fi
 
 wait_for_airflow_dag_run_state "$DAG_ID" "$dag_run_id" success 120 2 >&2
 

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -144,6 +144,8 @@ Before a later Composer cutover, this repo still needs explicit contract surface
 
 The repo now covers two Composer readiness seams directly: the reviewed DAG and source bundle sync path, and the reviewed Composer PyPI package baseline for the checked-in DAG bundle. Terraform merges later `cloud_composer_pypi_packages` overrides on top of that baseline so follow-up slices can extend the package set without replacing the known-good contract.
 
+The repo also exposes the Composer Airflow URI through the GitHub delivery contract, so Trigger Runtime Release can select Composer explicitly while the retained host stays the default fallback until the managed access path is ready.
+
 These are readiness requirements, not resources this directory manages yet. The durable runtime release summary target is the one exception already wired into the Composer env contract, because later managed handoff work needs a storage-backed acknowledgement path before it can remove the retained-host report assumption. Private package indexes, non-PyPI or system-level dependencies, secret injection, and the reviewed runtime release entry still remain separate cutover work.
 
 ## What The Hosted Paths Expose
@@ -206,6 +208,7 @@ Set these GitHub repository variables:
 - `GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT`
 - `GCP_CLOUD_COMPOSER_ENVIRONMENT_NAME`
 - `GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX` when Composer is enabled
+- `GCP_CLOUD_COMPOSER_AIRFLOW_URI` when Composer is enabled
 - `GCP_PROVISION_ONLINE_COMPOSE_HOST`
 - `GCP_ONLINE_COMPOSE_HOST_NAME`
 - `GCP_ONLINE_COMPOSE_HOST_ZONE`

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -39,6 +39,7 @@ REPO_VARIABLE_OUTPUTS: list[tuple[str, str]] = [
     ),
     ("GCP_CLOUD_COMPOSER_ENVIRONMENT_NAME", "cloud_composer_environment_name"),
     ("GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX", "cloud_composer_dag_gcs_prefix"),
+    ("GCP_CLOUD_COMPOSER_AIRFLOW_URI", "cloud_composer_airflow_uri"),
     ("GCP_PROVISION_ONLINE_COMPOSE_HOST", "provision_online_compose_host"),
     ("GCP_ONLINE_COMPOSE_HOST_NAME", "online_compose_host_name"),
     ("GCP_ONLINE_COMPOSE_HOST_ZONE", "online_compose_host_zone"),
@@ -720,7 +721,7 @@ def test_publish_app_image_uses_cloud_build_artifact_registry_contract() -> None
     assert "docker/metadata-action" not in workflow_text
 
 
-def test_trigger_runtime_release_workflow_uses_current_retained_host_handoff_contract() -> (
+def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_contract() -> (
     None
 ):
     workflow = _workflow_yaml(".github/workflows/trigger-runtime-release.yml")
@@ -735,6 +736,12 @@ def test_trigger_runtime_release_workflow_uses_current_retained_host_handoff_con
         "promote_candidate",
         "rollback_live",
     ]
+    assert dispatch_inputs["airflow_target"]["default"] == "retained_host"
+    assert dispatch_inputs["airflow_target"]["type"] == "choice"
+    assert dispatch_inputs["airflow_target"]["options"] == [
+        "retained_host",
+        "composer_airflow",
+    ]
     assert dispatch_inputs["candidate_revision_tag"]["default"] == "candidate"
     assert dispatch_inputs["candidate_alias"]["default"] == "candidate"
     assert dispatch_inputs["target_alias"]["default"] == "champion"
@@ -743,10 +750,13 @@ def test_trigger_runtime_release_workflow_uses_current_retained_host_handoff_con
     assert set(config_job["outputs"]) == {
         "owner_allowed",
         "project_id",
+        "artifact_bucket_name",
         "workload_identity_provider",
         "service_account_email",
         "online_compose_host_name",
         "online_compose_host_zone",
+        "cloud_composer_airflow_uri",
+        "airflow_target",
         "action",
         "image_uri",
         "candidate_revision_tag",
@@ -764,17 +774,39 @@ def test_trigger_runtime_release_workflow_uses_current_retained_host_handoff_con
     derived_step = _workflow_step(workflow, "config", "derived")
     assert derived_step["env"]["ACTION_INPUT"] == "${{ github.event.inputs.action }}"
     assert (
+        derived_step["env"]["AIRFLOW_TARGET_INPUT"]
+        == "${{ github.event.inputs.airflow_target }}"
+    )
+    assert (
+        derived_step["env"]["ARTIFACT_BUCKET_NAME"]
+        == "${{ steps.repo_config.outputs.artifact_bucket_name }}"
+    )
+    assert (
+        derived_step["env"]["PROVISION_CLOUD_COMPOSER_ENVIRONMENT"]
+        == "${{ steps.repo_config.outputs.provision_cloud_composer_environment }}"
+    )
+    assert (
+        derived_step["env"]["CLOUD_COMPOSER_AIRFLOW_URI"]
+        == "${{ steps.repo_config.outputs.cloud_composer_airflow_uri }}"
+    )
+    assert (
         derived_step["env"]["PROVISION_ONLINE_COMPOSE_HOST"]
         == "${{ steps.repo_config.outputs.provision_online_compose_host }}"
     )
     assert "deploy_candidate|promote_candidate|rollback_live" in derived_step["run"]
+    assert "retained_host|composer_airflow" in derived_step["run"]
     assert "trigger_ready=false" in derived_step["run"]
+    assert 'echo "airflow_target=$airflow_target"' in derived_step["run"]
     assert 'echo "trigger_ready=$trigger_ready"' in derived_step["run"]
 
     trigger_job = workflow["jobs"]["trigger"]
     assert (
         trigger_job["if"]
         == "${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready == 'true' }}"
+    )
+    assert (
+        trigger_job["env"]["ARTIFACT_BUCKET_NAME"]
+        == "${{ needs.config.outputs.artifact_bucket_name }}"
     )
     assert (
         trigger_job["env"]["HOST_NAME"]
@@ -784,42 +816,86 @@ def test_trigger_runtime_release_workflow_uses_current_retained_host_handoff_con
         trigger_job["env"]["HOST_ZONE"]
         == "${{ needs.config.outputs.online_compose_host_zone }}"
     )
+    assert (
+        trigger_job["env"]["AIRFLOW_TARGET"]
+        == "${{ needs.config.outputs.airflow_target }}"
+    )
+    assert (
+        trigger_job["env"]["CLOUD_COMPOSER_AIRFLOW_URI"]
+        == "${{ needs.config.outputs.cloud_composer_airflow_uri }}"
+    )
+
+    setup_uv_step = _workflow_step(workflow, "trigger", "Set up uv")
+    assert setup_uv_step["if"] == "${{ env.AIRFLOW_TARGET == 'composer_airflow' }}"
+    assert setup_uv_step["uses"] == "astral-sh/setup-uv@v8.1.0"
+
+    composer_deps_step = _workflow_step(
+        workflow,
+        "trigger",
+        "Install Composer trigger dependencies",
+    )
+    assert composer_deps_step["if"] == "${{ env.AIRFLOW_TARGET == 'composer_airflow' }}"
+    assert "uv sync --frozen" in composer_deps_step["run"]
 
     payload_step = _workflow_step(workflow, "trigger", "Build runtime release request")
     assert "runtime-release-request.json" in payload_step["run"]
     assert "github_run_url" in payload_step["run"]
 
     refresh_step = _workflow_step(workflow, "trigger", "Refresh operator host checkout")
+    assert refresh_step["if"] == "${{ env.AIRFLOW_TARGET == 'retained_host' }}"
     assert "gcloud compute ssh" in refresh_step["run"]
     assert "foehncast-online-compose-sync.service" in refresh_step["run"]
     assert "--wait" in refresh_step["run"]
 
     copy_step = _workflow_step(workflow, "trigger", "Copy runtime release request")
+    assert copy_step["if"] == "${{ env.AIRFLOW_TARGET == 'retained_host' }}"
     assert "gcloud compute scp" in copy_step["run"]
     assert "/tmp/runtime-release-request.json" in copy_step["run"]
 
     handoff_step = _workflow_step(
         workflow, "trigger", "Trigger runtime release handoff"
     )
+    assert "uv run ./scripts/trigger-runtime-release.sh" in handoff_step["run"]
+    assert "gcloud auth print-access-token" in handoff_step["run"]
+    assert "--airflow-trigger-mode airflow_api" in handoff_step["run"]
+    assert "--airflow-api-base-url" in handoff_step["run"]
+    assert "--airflow-api-health-endpoint /health" in handoff_step["run"]
+    assert "FOEHNCAST_RUNTIME_RELEASE_REPORT_PATH" in handoff_step["run"]
     assert (
         "./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json"
         in handoff_step["run"]
     )
+    assert 'selected_receiver="retained-host Airflow adapter"' in handoff_step["run"]
+    assert 'selected_receiver="Composer Airflow API"' in handoff_step["run"]
     assert 'echo "- Airflow DAG: runtime_release"' in handoff_step["run"]
+    assert 'echo "- Selected receiver: $selected_receiver"' in handoff_step["run"]
     assert (
-        'echo "- Current receiver: retained-host Airflow adapter"'
+        'echo "- Fallback receiver: retained-host Airflow adapter"'
         in handoff_step["run"]
     )
     assert (
-        'echo "- Target receiver: Cloud Composer without VM SSH"' in handoff_step["run"]
+        "GitHub OIDC plus Google access token to Composer Airflow"
+        in handoff_step["run"]
+    )
+    assert (
+        "Composer access assumption: the GitHub service account already maps to an Airflow user or role"
+        in handoff_step["run"]
     )
     assert 'echo "## Runtime release handoff"' in handoff_step["run"]
 
     skipped_step = _workflow_step(
         workflow, "skipped", "Explain skipped runtime release handoff"
     )
-    assert "This is the current retained-host entry contract." in skipped_step["run"]
-    assert "Cloud Composer without VM SSH" in skipped_step["run"]
+    assert (
+        "The selected runtime trigger contract needs all of these inputs before it can run:"
+        in skipped_step["run"]
+    )
+    assert "GCP_PROVISION_ONLINE_COMPOSE_HOST=true" in skipped_step["run"]
+    assert "GCP_CLOUD_COMPOSER_AIRFLOW_URI" in skipped_step["run"]
+    assert (
+        "Composer handoff also assumes the GitHub service account already maps to an Airflow user or role."
+        in skipped_step["run"]
+    )
 
 
 def test_orchestration_docs_describe_current_host_path_and_target_composer_readiness() -> (
@@ -847,6 +923,8 @@ def test_orchestration_docs_describe_current_host_path_and_target_composer_readi
         "GitHub can now publish the repo-managed DAG and source bundle into the provisioned Composer DAG bucket."
         in workflow_doc
     )
+    assert "explicit reviewed receiver selection contract" in workflow_doc
+    assert "retained_host` stays the default reviewed receiver" in workflow_doc
     assert "configured runtime release summary target" in workflow_doc
     assert (
         "reviewed runtime release entry still need separate cutover work"
@@ -874,6 +952,7 @@ def test_orchestration_docs_describe_current_host_path_and_target_composer_readi
         "A reviewed DAG and source bundle can now sync to the provisioned Composer DAG bucket."
         in cloud_mapping
     )
+    assert "explicit receiver selection contract" in cloud_mapping
     assert (
         "a reviewed runtime release entry that reaches the managed Airflow surface directly"
         in cloud_mapping
@@ -892,6 +971,7 @@ def test_orchestration_docs_describe_current_host_path_and_target_composer_readi
     assert "reviewed runtime release entry without VM SSH" in terraform_readme
     assert "GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT" in terraform_readme
     assert "GCP_CLOUD_COMPOSER_DAG_GCS_PREFIX" in terraform_readme
+    assert "GCP_CLOUD_COMPOSER_AIRFLOW_URI" in terraform_readme
 
 
 def test_promote_candidate_workflow_redirects_to_runtime_trigger_contract() -> None:
@@ -1049,17 +1129,33 @@ def test_rollback_live_release_workflow_redirects_to_runtime_trigger_contract() 
     )
 
 
-def test_trigger_runtime_release_script_uses_local_airflow_contract() -> None:
+def test_trigger_runtime_release_script_supports_local_and_api_airflow_contracts() -> (
+    None
+):
     script = _read_text("scripts/trigger-runtime-release.sh")
     cli_common = _read_text("scripts/cli-common.sh")
     helper = _read_text("scripts/airflow-api-common.sh")
 
     assert "require_cli_option_value()" in cli_common
-    assert "Usage: $0 --request-file path" in script
-    assert 'AIRFLOW_API_BASE_URL="http://127.0.0.1:8080/api/v2"' in script
+    assert (
+        "Usage: $0 --request-file path [--airflow-trigger-mode local_cli|airflow_api] [--airflow-api-base-url url] [--airflow-api-health-endpoint path]"
+        in script
+    )
+    assert (
+        'AIRFLOW_TRIGGER_MODE="${FOEHNCAST_AIRFLOW_TRIGGER_MODE:-local_cli}"' in script
+    )
+    assert (
+        'AIRFLOW_API_BASE_URL="${FOEHNCAST_AIRFLOW_API_BASE_URL:-http://127.0.0.1:8080/api/v2}"'
+        in script
+    )
+    assert (
+        'AIRFLOW_API_HEALTH_ENDPOINT="${FOEHNCAST_AIRFLOW_API_HEALTH_ENDPOINT:-/monitor/health}"'
+        in script
+    )
+    assert 'AIRFLOW_API_AUTH_TOKEN="${FOEHNCAST_AIRFLOW_AUTH_TOKEN:-}"' in script
     assert 'source "${ROOT_DIR}/scripts/cli-common.sh"' in script
     assert 'source "${ROOT_DIR}/scripts/airflow-api-common.sh"' in script
-    assert "${AIRFLOW_API_BASE_URL}/monitor/health" in script
+    assert '"$(airflow_api_health_url)"' in script
     assert "python3 -m foehncast.airflow_api" in helper
     assert (
         "${airflow_api_base_url}/dags/${dag_id}/dagRuns?limit=20&order_by=-start_date"
@@ -1068,12 +1164,21 @@ def test_trigger_runtime_release_script_uses_local_airflow_contract() -> None:
     assert "run_airflow_api_helper" in script
     assert "airflow_api_verify_health \\" in script
     assert "airflow_api_wait_for_dag_run_state \\" in script
+    assert "trigger_airflow_dag_run_via_api" in script
+    assert "trigger_airflow_dag_run_via_local_cli" in script
+    assert "--airflow-trigger-mode" in script
+    assert "--airflow-api-base-url" in script
+    assert "--airflow-api-health-endpoint" in script
     assert "python3 -m foehncast.runtime_release" in script
     assert "run_runtime_release_helper" in script
     assert 'PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"' in helper
     assert "normalize-request" in script
     assert (
         'REQUEST_FILE="$(require_cli_option_value "--request-file" "${1:-}" usage)"'
+        in script
+    )
+    assert (
+        'AIRFLOW_TRIGGER_MODE="$(normalized_airflow_trigger_mode "$AIRFLOW_TRIGGER_MODE")"'
         in script
     )
     assert 'airflow dags trigger "$DAG_ID"' in script
@@ -2280,6 +2385,10 @@ def test_local_and_runtime_release_scripts_share_airflow_shell_helper() -> None:
     assert "airflow_api_wait_for_dag_run_state()" in helper
     assert 'PYTHONPATH="$ROOT_DIR/src${PYTHONPATH:+:$PYTHONPATH}"' in helper
     assert "python3 -m foehncast.airflow_api" in helper
+    assert "Authorization: Bearer ${auth_token}" in helper
+    assert "eval " not in helper
+    assert "_AIRFLOW_API_AUTH_TOKEN" not in helper
+    assert "_AIRFLOW_API_VERSION" not in helper
 
     assert 'source "${ROOT_DIR}/scripts/airflow-api-common.sh"' in bootstrap
     assert 'source "${ROOT_DIR}/scripts/airflow-api-common.sh"' in trigger


### PR DESCRIPTION
## Summary
- expose the Composer Airflow URI through the repo-variable sync and GitHub repo-config contract
- add an explicit retained_host or composer_airflow runtime handoff selection while keeping retained-host as the default fallback
- replace the unsafe shell helper auth wiring with explicit parameters and lock the new handoff contract in tests and docs

## Testing
- pytest tests/test_cloud_operator_contract.py tests/test_airflow_api.py

Closes #240
