### PR TITLE
chore: remove redundant docker-compose.cloud.yml overlay

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,6 @@ jobs:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0
       - run: docker compose -f docker-compose.yml config
-      - run: docker compose -f docker-compose.yml -f docker-compose.cloud.yml config
       - run: docker compose -f docker-compose.yml build model-registry app
           airflow-webserver
       - run: make smoke-local-evaluator

--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
     paths:
       - terraform/**
-      - docker-compose.cloud.yml
       - .github/workflows/terraform.yml
   workflow_dispatch:
     inputs:

--- a/containers/README.md
+++ b/containers/README.md
@@ -36,7 +36,6 @@ flowchart TD
 | Surface | Role |
 |---------|------|
 | `docker-compose.yml` | shared service baseline for local runs |
-| `docker-compose.cloud.yml` | online-host overrides for the full hosted stack |
 | `docker-compose.gcp.yml` | local override when Docker services need mounted ADC for BigQuery checks |
 | `docker-compose.objectstore.yml` | local runtime extensions for MinIO-backed storage and the Feast Datastore emulator |
 | `.env` | shared runtime configuration file initialized by the bootstrap scripts |

--- a/docker-compose.cloud.yml
+++ b/docker-compose.cloud.yml
@@ -1,4 +1,0 @@
-services:
-  development_env:
-    profiles:
-      - local-only

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -194,7 +194,7 @@ Example feature replay on the retained host:
 
 ```bash
 cd /opt/foehncast
-docker compose -f docker-compose.yml -f docker-compose.cloud.yml --env-file .env exec -T airflow-webserver \
+docker compose -f docker-compose.yml --env-file .env exec -T airflow-webserver \
     airflow dags trigger feature_pipeline \
     --logical-date "2026-05-14T00:00:00Z" \
     --run-id "manual_backfill__2026-05-14T00-00-00Z"

--- a/terraform/templates/online-compose-host.sh.tftpl
+++ b/terraform/templates/online-compose-host.sh.tftpl
@@ -114,7 +114,6 @@ app_health_url="http://127.0.0.1:8000/health"
 online_features_url="http://127.0.0.1:8000/features/online"
 compose_args=(
   -f /opt/foehncast/docker-compose.yml
-  -f /opt/foehncast/docker-compose.cloud.yml
   --env-file /opt/foehncast/.env
 )
 
@@ -222,7 +221,7 @@ gcloud auth configure-docker "${artifact_registry_host}" --quiet >/dev/null 2>&1
 
 vacuum_host_logs
 docker compose "$${compose_args[@]}" pull model-registry app airflow-init airflow-webserver airflow-dag-processor airflow-scheduler airflow-triggerer
-docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env up -d --no-build
+docker compose -f /opt/foehncast/docker-compose.yml --env-file /opt/foehncast/.env up -d --no-build
 
 echo "Waiting for Airflow API server health..."
 verify_airflow_api_health 90 2

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -1798,14 +1798,14 @@ def test_online_compose_startup_template_installs_periodic_repo_sync_timer() -> 
     assert "Persistent=true" in template
     assert "compose_args=(" in template
     assert "-f /opt/foehncast/docker-compose.yml" in template
-    assert "-f /opt/foehncast/docker-compose.cloud.yml" in template
+    assert "docker-compose.cloud.yml" not in template
     assert "--env-file /opt/foehncast/.env" in template
     assert (
         'docker compose "$${compose_args[@]}" pull model-registry app airflow-init airflow-webserver airflow-dag-processor airflow-scheduler airflow-triggerer'
         in template
     )
     assert (
-        "docker compose -f /opt/foehncast/docker-compose.yml -f /opt/foehncast/docker-compose.cloud.yml --env-file /opt/foehncast/.env up -d --no-build"
+        "docker compose -f /opt/foehncast/docker-compose.yml --env-file /opt/foehncast/.env up -d --no-build"
         in template
     )
     assert "--build" not in template


### PR DESCRIPTION
The `development_env` service already defines `profiles: [local-only]` in its base compose file, making `docker-compose.cloud.yml` redundant. This PR removes the file and updates all 7 references across CI, Terraform templates, tests, and docs.

**Changes:**
- Delete `docker-compose.cloud.yml`
- Remove the redundant `config` check from `.github/workflows/ci.yml`
- Remove from Terraform workflow path triggers
- Simplify `online-compose-host.sh.tftpl` compose args to use base file only
- Add negative assertion in `test_cloud_operator_contract.py` guarding against re-introduction
- Update `containers/README.md` and operator workflow docs

Closes #248