### PR TITLE
refactor(monitoring): rename online-compose sync to hosted sync

### DIFF
--- a/src/foehncast/inference_pipeline/serve.py
+++ b/src/foehncast/inference_pipeline/serve.py
@@ -26,8 +26,8 @@ from foehncast.monitoring.pipeline_prometheus import (
     render_feature_pipeline_prometheus_metrics,
     render_training_pipeline_prometheus_metrics,
 )
-from foehncast.monitoring.online_compose_sync_prometheus import (
-    render_online_compose_sync_prometheus_metrics,
+from foehncast.monitoring.hosted_sync_prometheus import (
+    render_hosted_sync_prometheus_metrics,
 )
 from foehncast.monitoring.prediction_monitoring_prometheus import (
     record_prediction_monitoring_execution,
@@ -114,7 +114,7 @@ def _metrics_payload() -> bytes:
         render_feature_pipeline_prometheus_metrics()
         + render_training_pipeline_prometheus_metrics()
         + render_prediction_log_prometheus_metrics()
-        + render_online_compose_sync_prometheus_metrics()
+        + render_hosted_sync_prometheus_metrics()
         # Ephemeral metrics: rendered from in-memory counters and reset on restart.
         + render_prediction_monitoring_prometheus_metrics()
     )

--- a/src/foehncast/monitoring/__init__.py
+++ b/src/foehncast/monitoring/__init__.py
@@ -7,10 +7,10 @@ from foehncast.monitoring.drift import (
     detect_prediction_drift,
     push_drift_metrics,
 )
-from foehncast.monitoring.online_compose_sync_prometheus import (
-    build_online_compose_sync_prometheus_registry,
-    read_online_compose_sync_status,
-    render_online_compose_sync_prometheus_metrics,
+from foehncast.monitoring.hosted_sync_prometheus import (
+    build_hosted_sync_prometheus_registry,
+    read_hosted_sync_status,
+    render_hosted_sync_prometheus_metrics,
 )
 from foehncast.monitoring.pipeline_metrics import (
     FEATURE_PIPELINE_METRIC_CONTRACT,
@@ -50,7 +50,7 @@ __all__ = [
     "TRAINING_PIPELINE_METRIC_CONTRACT",
     "append_prediction_log",
     "build_prediction_log_prometheus_registry",
-    "build_online_compose_sync_prometheus_registry",
+    "build_hosted_sync_prometheus_registry",
     "detect_data_drift",
     "detect_prediction_drift",
     "emit_prediction_drift_metrics",
@@ -61,7 +61,7 @@ __all__ = [
     "feature_pipeline_summary_path",
     "prediction_event_log_path",
     "push_drift_metrics",
-    "read_online_compose_sync_status",
+    "read_hosted_sync_status",
     "read_prediction_event_log",
     "read_prediction_history",
     "read_prediction_log",
@@ -69,7 +69,7 @@ __all__ = [
     "read_feature_pipeline_run_summary",
     "read_training_pipeline_run_summary_history",
     "read_training_pipeline_run_summary",
-    "render_online_compose_sync_prometheus_metrics",
+    "render_hosted_sync_prometheus_metrics",
     "render_prediction_log_prometheus_metrics",
     "training_pipeline_stage_overview",
     "training_pipeline_summary_history_paths",

--- a/src/foehncast/monitoring/hosted_sync_prometheus.py
+++ b/src/foehncast/monitoring/hosted_sync_prometheus.py
@@ -1,4 +1,4 @@
-"""Prometheus export helpers for the hosted online-compose sync status file."""
+"""Prometheus export helpers for the hosted sync status file."""
 
 from __future__ import annotations
 
@@ -12,27 +12,25 @@ from foehncast.monitoring._common import timestamp_seconds
 from foehncast.paths import project_root
 
 
-def _default_online_compose_sync_status_path() -> Path:
+def _default_hosted_sync_status_path() -> Path:
     return project_root() / ".state" / "online-compose-sync" / "last-success.json"
 
 
-def read_online_compose_sync_status(
+def read_hosted_sync_status(
     status_path: Path | None = None,
 ) -> dict[str, Any] | None:
-    """Load the latest hosted compose sync status if the file exists."""
+    """Load the latest hosted sync status if the file exists."""
     resolved_path = (
-        _default_online_compose_sync_status_path()
-        if status_path is None
-        else status_path
+        _default_hosted_sync_status_path() if status_path is None else status_path
     )
     return read_json_file_if_exists(resolved_path)
 
 
-def build_online_compose_sync_prometheus_registry(
+def build_hosted_sync_prometheus_registry(
     status: dict[str, Any] | None = None,
 ) -> CollectorRegistry:
-    """Render the hosted compose sync status file into a scrapeable registry."""
-    resolved_status = read_online_compose_sync_status() if status is None else status
+    """Render the hosted sync status file into a scrapeable registry."""
+    resolved_status = read_hosted_sync_status() if status is None else status
     registry = CollectorRegistry()
 
     status_file_present = Gauge(
@@ -62,16 +60,16 @@ def build_online_compose_sync_prometheus_registry(
     return registry
 
 
-def render_online_compose_sync_prometheus_metrics(
+def render_hosted_sync_prometheus_metrics(
     status: dict[str, Any] | None = None,
 ) -> bytes:
-    """Return Prometheus exposition text for the hosted compose sync status."""
-    registry = build_online_compose_sync_prometheus_registry(status=status)
+    """Return Prometheus exposition text for the hosted sync status."""
+    registry = build_hosted_sync_prometheus_registry(status=status)
     return generate_latest(registry)
 
 
 __all__ = [
-    "build_online_compose_sync_prometheus_registry",
-    "read_online_compose_sync_status",
-    "render_online_compose_sync_prometheus_metrics",
+    "build_hosted_sync_prometheus_registry",
+    "read_hosted_sync_status",
+    "render_hosted_sync_prometheus_metrics",
 ]

--- a/tests/test_hosted_sync_prometheus.py
+++ b/tests/test_hosted_sync_prometheus.py
@@ -1,4 +1,4 @@
-"""Tests for Prometheus export of hosted online-compose sync state."""
+"""Tests for Prometheus export of hosted sync state."""
 
 from __future__ import annotations
 
@@ -7,22 +7,20 @@ from pathlib import Path
 
 import pytest
 
-from foehncast.monitoring import online_compose_sync_prometheus
+from foehncast.monitoring import hosted_sync_prometheus
 from tests.prometheus_assertions import metric_value
 
 
-def test_render_online_compose_sync_prometheus_metrics_reports_last_success() -> None:
-    payload = (
-        online_compose_sync_prometheus.render_online_compose_sync_prometheus_metrics(
-            {
-                "state": "succeeded",
-                "git_ref": "main",
-                "last_successful_sync_at": "2026-05-11T18:50:00Z",
-                "last_successful_commit": "abc123",
-                "compose_deploy_mode": "pull",
-            }
-        ).decode("utf-8")
-    )
+def test_render_hosted_sync_prometheus_metrics_reports_last_success() -> None:
+    payload = hosted_sync_prometheus.render_hosted_sync_prometheus_metrics(
+        {
+            "state": "succeeded",
+            "git_ref": "main",
+            "last_successful_sync_at": "2026-05-11T18:50:00Z",
+            "last_successful_commit": "abc123",
+            "compose_deploy_mode": "pull",
+        }
+    ).decode("utf-8")
 
     assert "foehncast_online_compose_sync_status_file_present 1.0" in payload
     assert metric_value(
@@ -31,27 +29,25 @@ def test_render_online_compose_sync_prometheus_metrics_reports_last_success() ->
     ) == pytest.approx(1778525400.0)
 
 
-def test_render_online_compose_sync_prometheus_metrics_handles_missing_status(
+def test_render_hosted_sync_prometheus_metrics_handles_missing_status(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setattr(
-        online_compose_sync_prometheus,
-        "_default_online_compose_sync_status_path",
+        hosted_sync_prometheus,
+        "_default_hosted_sync_status_path",
         lambda: tmp_path / "last-success.json",
     )
 
-    payload = (
-        online_compose_sync_prometheus.render_online_compose_sync_prometheus_metrics(
-            None
-        ).decode("utf-8")
+    payload = hosted_sync_prometheus.render_hosted_sync_prometheus_metrics(None).decode(
+        "utf-8"
     )
 
     assert "foehncast_online_compose_sync_status_file_present 0.0" in payload
     assert "foehncast_online_compose_sync_last_success_timestamp_seconds" in payload
 
 
-def test_read_online_compose_sync_status_loads_json(tmp_path: Path) -> None:
+def test_read_hosted_sync_status_loads_json(tmp_path: Path) -> None:
     status_path = tmp_path / "last-success.json"
     status_path.write_text(
         json.dumps(
@@ -65,9 +61,7 @@ def test_read_online_compose_sync_status_loads_json(tmp_path: Path) -> None:
         )
     )
 
-    assert online_compose_sync_prometheus.read_online_compose_sync_status(
-        status_path
-    ) == {
+    assert hosted_sync_prometheus.read_hosted_sync_status(status_path) == {
         "state": "succeeded",
         "git_ref": "main",
         "last_successful_sync_at": "2026-05-11T18:50:00Z",

--- a/tests/test_predict.py
+++ b/tests/test_predict.py
@@ -553,7 +553,7 @@ def test_metrics_endpoint_returns_prometheus_payload(
     )
     monkeypatch.setattr(
         serve,
-        "render_online_compose_sync_prometheus_metrics",
+        "render_hosted_sync_prometheus_metrics",
         lambda: hosted_sync_payload,
     )
     client = TestClient(serve.app)


### PR DESCRIPTION
Rename the Python module and function API from `online_compose_sync` to `hosted_sync`, reflecting that the hosted sync concept is not tied to the online-compose host specifically.

**Renamed:**
- `online_compose_sync_prometheus.py` → `hosted_sync_prometheus.py`
- `read_online_compose_sync_status` → `read_hosted_sync_status`
- `build_online_compose_sync_prometheus_registry` → `build_hosted_sync_prometheus_registry`
- `render_online_compose_sync_prometheus_metrics` → `render_hosted_sync_prometheus_metrics`
- `test_online_compose_sync_prometheus.py` → `test_hosted_sync_prometheus.py`

**Kept stable:**
- Prometheus metric names (`foehncast_online_compose_sync_*`) — avoids breaking dashboards and alert rules
- State directory path (`.state/online-compose-sync/`) — avoids breaking bootstrap scripts and Terraform templates

Closes #247