### PR TITLE
chore(monitoring): add inference latency and request rate Grafana panels

### DIFF
--- a/grafana_work/dashboards/foehncast-overview.json
+++ b/grafana_work/dashboards/foehncast-overview.json
@@ -1064,6 +1064,121 @@
       ],
       "title": "Pipeline Freshness",
       "type": "timeseries"
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 106
+      },
+      "id": 31,
+      "title": "Inference Operations",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 107
+      },
+      "id": 32,
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, endpoint) (rate(foehncast_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{endpoint}}",
+          "refId": "A"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, endpoint) (rate(foehncast_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{endpoint}}",
+          "refId": "B"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, endpoint) (rate(foehncast_http_request_duration_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{endpoint}}",
+          "refId": "C"
+        }
+      ],
+      "title": "Request Latency (p50 / p95 / p99)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 107
+      },
+      "id": 33,
+      "targets": [
+        {
+          "expr": "sum by (endpoint) (rate(foehncast_http_requests_total[5m]))",
+          "legendFormat": "{{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Request Rate by Endpoint",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "reqps"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 115
+      },
+      "id": 34,
+      "targets": [
+        {
+          "expr": "sum by (endpoint, status) (rate(foehncast_http_requests_total{status=~\"4..|5..\"}[5m]))",
+          "legendFormat": "{{status}} {{endpoint}}",
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Error Rate (4xx / 5xx)",
+      "type": "timeseries"
     }
   ],
   "refresh": "15s",

--- a/src/foehncast/inference_pipeline/serve.py
+++ b/src/foehncast/inference_pipeline/serve.py
@@ -29,6 +29,10 @@ from foehncast.monitoring.pipeline_prometheus import (
 from foehncast.monitoring.hosted_sync_prometheus import (
     render_hosted_sync_prometheus_metrics,
 )
+from foehncast.monitoring.inference_prometheus import (
+    InferenceMetricsMiddleware,
+    render_inference_prometheus_metrics,
+)
 from foehncast.monitoring.prediction_monitoring_prometheus import (
     record_prediction_monitoring_execution,
     record_prediction_monitoring_schedule,
@@ -117,12 +121,14 @@ def _metrics_payload() -> bytes:
         + render_hosted_sync_prometheus_metrics()
         # Ephemeral metrics: rendered from in-memory counters and reset on restart.
         + render_prediction_monitoring_prometheus_metrics()
+        + render_inference_prometheus_metrics()
     )
 
 
 def create_app() -> FastAPI:
     """Build the serving application for health and inference endpoints."""
     app = FastAPI(title="FoehnCast API", version="0.1.0")
+    app.add_middleware(InferenceMetricsMiddleware)
 
     @app.get("/health")
     def health() -> dict[str, str]:

--- a/src/foehncast/monitoring/inference_prometheus.py
+++ b/src/foehncast/monitoring/inference_prometheus.py
@@ -1,0 +1,65 @@
+"""HTTP request metrics for the inference API."""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Callable, Awaitable
+
+from prometheus_client import CollectorRegistry, Counter, Histogram, generate_latest
+from starlette.middleware.base import BaseHTTPMiddleware
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+_registry = CollectorRegistry()
+
+request_duration = Histogram(
+    "foehncast_http_request_duration_seconds",
+    "HTTP request duration in seconds",
+    ["method", "endpoint", "status"],
+    buckets=(0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+    registry=_registry,
+)
+
+request_total = Counter(
+    "foehncast_http_requests_total",
+    "Total HTTP requests",
+    ["method", "endpoint", "status"],
+    registry=_registry,
+)
+
+
+def _normalize_path(path: str) -> str:
+    """Collapse path to the route pattern to avoid cardinality explosion."""
+    known = {
+        "/health",
+        "/spots",
+        "/predict",
+        "/rank",
+        "/features/online",
+        "/features/online/demo",
+        "/metrics",
+    }
+    return path if path in known else "other"
+
+
+class InferenceMetricsMiddleware(BaseHTTPMiddleware):
+    async def dispatch(
+        self,
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        start = time.perf_counter()
+        response = await call_next(request)
+        duration = time.perf_counter() - start
+
+        endpoint = _normalize_path(request.url.path)
+        status = str(response.status_code)
+        request_duration.labels(request.method, endpoint, status).observe(duration)
+        request_total.labels(request.method, endpoint, status).inc()
+
+        return response
+
+
+def render_inference_prometheus_metrics() -> bytes:
+    return generate_latest(_registry)

--- a/tests/test_monitoring_stack.py
+++ b/tests/test_monitoring_stack.py
@@ -93,6 +93,20 @@ def test_grafana_provisioning_points_to_prometheus_dashboard_dir() -> None:
     assert any(
         panel["title"] == "Training Stage State" for panel in dashboard["panels"]
     )
+    assert any(
+        panel["title"] == "Inference Operations" and panel["type"] == "row"
+        for panel in dashboard["panels"]
+    )
+    assert any(
+        panel["title"] == "Request Latency (p50 / p95 / p99)"
+        for panel in dashboard["panels"]
+    )
+    assert any(
+        panel["title"] == "Request Rate by Endpoint" for panel in dashboard["panels"]
+    )
+    assert any(
+        panel["title"] == "HTTP Error Rate (4xx / 5xx)" for panel in dashboard["panels"]
+    )
 
 
 def test_grafana_alerting_provisions_background_monitoring_rules() -> None:


### PR DESCRIPTION
### What Changed

- Add `InferenceMetricsMiddleware` using `prometheus_client` to track HTTP request duration (histogram with p50/p95/p99 buckets) and request count (counter) with method, endpoint, and status labels
- Wire middleware into the FastAPI app and include rendered metrics in the `/metrics` endpoint
- Add an "Inference Operations" row to the Grafana dashboard with three panels:
  - **Request Latency (p50/p95/p99)** by endpoint
  - **Request Rate** by endpoint
  - **HTTP Error Rate (4xx/5xx)** by endpoint
- Update `test_monitoring_stack.py` to verify the new row and panel structure

### Why

The dashboard covered feature pipeline, training pipeline, and prediction monitoring well but lacked inference-level operational panels for request latency and throughput.

### Verification

- `tests/test_monitoring_stack.py` passes (17 tests)
- `tests/test_dashboard.py` passes (5 tests)
- Dashboard JSON validates and contains 34 panels (was 30)

### Closes

- Closes #254