### PR TITLE
feat(build): add Cloud Build config for app image

### DIFF
--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -124,21 +124,17 @@ jobs:
       - id: submit
         name: Submit Cloud Build
         env:
-          BUILD_CONTEXT: .
-          DOCKERFILE: containers/app/Dockerfile
           LATEST_TAG: ${{ steps.image.outputs.latest_tag }}
         run: |
           set -euo pipefail
 
           substitutions=(
-            "_BUILD_CONTEXT=${BUILD_CONTEXT}"
-            "_DOCKERFILE=${DOCKERFILE}"
             "_IMAGE_REPOSITORY=${IMAGE_REPOSITORY}"
             "_COMMIT_SHA=${GITHUB_SHA}"
             "_FLOATING_TAG=${LATEST_TAG}"
           )
           IFS=,
-          build_id="$(gcloud builds submit . --project "${PROJECT_ID}" --config cloudbuild/runtime-image.yaml --substitutions "${substitutions[*]}" --format='value(id)')"
+          build_id="$(gcloud builds submit . --project "${PROJECT_ID}" --config cloudbuild/app.yaml --substitutions "${substitutions[*]}" --format='value(id)')"
           unset IFS
           echo "build_id=${build_id}" >> "$GITHUB_OUTPUT"
 

--- a/cloudbuild/app.yaml
+++ b/cloudbuild/app.yaml
@@ -1,0 +1,46 @@
+# Cloud Build config for the FoehnCast app image.
+#
+# Trigger contract: GitHub Actions submits this build after merge to main.
+# The workflow authenticates via OIDC, resolves the image repository from
+# Terraform-managed GitHub repository variables, and passes substitutions
+# for the commit SHA and floating tag.
+#
+# Manual submission (for testing):
+#   gcloud builds submit . \
+#     --config=cloudbuild/app.yaml \
+#     --substitutions=_IMAGE_REPOSITORY=REGION-docker.pkg.dev/PROJECT/REPO/foehncast-app,_COMMIT_SHA=$(git rev-parse HEAD)
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -ceu
+      - |
+        tags=(-t "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}")
+        if [[ -n "${_FLOATING_TAG}" ]]; then
+          tags+=(-t "${_FLOATING_TAG}")
+        fi
+
+        docker build \
+          --platform linux/amd64 \
+          -f containers/app/Dockerfile \
+          "${tags[@]}" \
+          .
+
+        docker push "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}"
+
+        if [[ -n "${_FLOATING_TAG}" ]]; then
+          docker push "${_FLOATING_TAG}"
+        fi
+
+options:
+  dynamicSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY
+
+images:
+  - "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}"
+
+substitutions:
+  _IMAGE_REPOSITORY: europe-west6-docker.pkg.dev/example-project/foehncast-docker/foehncast-app
+  _COMMIT_SHA: dev
+  _FLOATING_TAG: ""


### PR DESCRIPTION
### What Changed

- Add `cloudbuild/app.yaml` with dedicated Cloud Build config for the app image
- Build targets `--platform linux/amd64` with `containers/app/Dockerfile`
- Tags: immutable `sha-$COMMIT_SHA` plus optional floating tag
- Update `publish-app-image.yml` to use the dedicated config and drop redundant substitutions

### Trigger Contract

GitHub Actions submits this build after merge to main. The workflow authenticates via OIDC, resolves the image repository from Terraform-managed repository variables, and passes commit SHA and floating tag substitutions.

### Closes

- Closes #249