### PR TITLE
feat(build): add Cloud Build configs for airflow and mlflow images

### DIFF
--- a/.github/workflows/publish-runtime-images.yml
+++ b/.github/workflows/publish-runtime-images.yml
@@ -86,11 +86,9 @@ jobs:
       matrix:
         include:
           - image_name: foehncast-airflow
-            context: .
-            dockerfile: containers/airflow/Dockerfile
+            cloudbuild_config: cloudbuild/airflow.yaml
           - image_name: foehncast-mlflow
-            context: containers/mlflow
-            dockerfile: containers/mlflow/Dockerfile
+            cloudbuild_config: cloudbuild/mlflow.yaml
     steps:
       - uses: actions/checkout@v6.0.2
 
@@ -129,22 +127,19 @@ jobs:
         name: Submit Cloud Build
         env:
           PROJECT_ID: ${{ needs.config.outputs.project_id }}
-          BUILD_CONTEXT: ${{ matrix.context }}
-          DOCKERFILE: ${{ matrix.dockerfile }}
+          CLOUDBUILD_CONFIG: ${{ matrix.cloudbuild_config }}
           IMAGE_REPOSITORY: ${{ steps.image.outputs.image_repository }}
           LATEST_TAG: ${{ steps.image.outputs.latest_tag }}
         run: |
           set -euo pipefail
 
           substitutions=(
-            "_BUILD_CONTEXT=${BUILD_CONTEXT}"
-            "_DOCKERFILE=${DOCKERFILE}"
             "_IMAGE_REPOSITORY=${IMAGE_REPOSITORY}"
             "_COMMIT_SHA=${GITHUB_SHA}"
             "_FLOATING_TAG=${LATEST_TAG}"
           )
           IFS=,
-          build_id="$(gcloud builds submit . --project "${PROJECT_ID}" --config cloudbuild/runtime-image.yaml --substitutions "${substitutions[*]}" --format='value(id)')"
+          build_id="$(gcloud builds submit . --project "${PROJECT_ID}" --config "${CLOUDBUILD_CONFIG}" --substitutions "${substitutions[*]}" --format='value(id)')"
           unset IFS
           echo "build_id=${build_id}" >> "$GITHUB_OUTPUT"
 

--- a/cloudbuild/airflow.yaml
+++ b/cloudbuild/airflow.yaml
@@ -1,0 +1,45 @@
+# Cloud Build config for the FoehnCast Airflow image.
+#
+# Trigger contract: GitHub Actions submits this build after merge to main.
+# The build context is the repo root because the Airflow Dockerfile copies
+# pyproject.toml, uv.lock, and src/ from the workspace root.
+#
+# Manual submission (for testing):
+#   gcloud builds submit . \
+#     --config=cloudbuild/airflow.yaml \
+#     --substitutions=_IMAGE_REPOSITORY=REGION-docker.pkg.dev/PROJECT/REPO/foehncast-airflow,_COMMIT_SHA=$(git rev-parse HEAD)
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -ceu
+      - |
+        tags=(-t "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}")
+        if [[ -n "${_FLOATING_TAG}" ]]; then
+          tags+=(-t "${_FLOATING_TAG}")
+        fi
+
+        docker build \
+          --platform linux/amd64 \
+          -f containers/airflow/Dockerfile \
+          "${tags[@]}" \
+          .
+
+        docker push "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}"
+
+        if [[ -n "${_FLOATING_TAG}" ]]; then
+          docker push "${_FLOATING_TAG}"
+        fi
+
+options:
+  dynamicSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY
+
+images:
+  - "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}"
+
+substitutions:
+  _IMAGE_REPOSITORY: europe-west6-docker.pkg.dev/example-project/foehncast-docker/foehncast-airflow
+  _COMMIT_SHA: dev
+  _FLOATING_TAG: ""

--- a/cloudbuild/mlflow.yaml
+++ b/cloudbuild/mlflow.yaml
@@ -1,0 +1,45 @@
+# Cloud Build config for the FoehnCast MLflow image.
+#
+# Trigger contract: GitHub Actions submits this build after merge to main.
+# The build context is containers/mlflow/ because the MLflow Dockerfile
+# only needs files from that directory.
+#
+# Manual submission (for testing):
+#   gcloud builds submit containers/mlflow \
+#     --config=cloudbuild/mlflow.yaml \
+#     --substitutions=_IMAGE_REPOSITORY=REGION-docker.pkg.dev/PROJECT/REPO/foehncast-mlflow,_COMMIT_SHA=$(git rev-parse HEAD)
+
+steps:
+  - name: gcr.io/cloud-builders/docker
+    entrypoint: bash
+    args:
+      - -ceu
+      - |
+        tags=(-t "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}")
+        if [[ -n "${_FLOATING_TAG}" ]]; then
+          tags+=(-t "${_FLOATING_TAG}")
+        fi
+
+        docker build \
+          --platform linux/amd64 \
+          -f containers/mlflow/Dockerfile \
+          "${tags[@]}" \
+          containers/mlflow
+
+        docker push "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}"
+
+        if [[ -n "${_FLOATING_TAG}" ]]; then
+          docker push "${_FLOATING_TAG}"
+        fi
+
+options:
+  dynamicSubstitutions: true
+  logging: CLOUD_LOGGING_ONLY
+
+images:
+  - "${_IMAGE_REPOSITORY}:sha-${_COMMIT_SHA}"
+
+substitutions:
+  _IMAGE_REPOSITORY: europe-west6-docker.pkg.dev/example-project/foehncast-docker/foehncast-mlflow
+  _COMMIT_SHA: dev
+  _FLOATING_TAG: ""


### PR DESCRIPTION
### What Changed

- Add `cloudbuild/airflow.yaml` — dedicated Cloud Build config for the Airflow image
- Add `cloudbuild/mlflow.yaml` — dedicated Cloud Build config for the MLflow image
- Both target `--platform linux/amd64` with SHA-based immutable tags
- Update `publish-runtime-images.yml` to reference per-image configs and drop redundant substitutions

### Build Contexts

| Image | Config | Dockerfile | Context |
|-------|--------|-----------|---------|
| foehncast-airflow | cloudbuild/airflow.yaml | containers/airflow/Dockerfile | . (root, needs pyproject.toml + src/) |
| foehncast-mlflow | cloudbuild/mlflow.yaml | containers/mlflow/Dockerfile | containers/mlflow |

### Closes

- Closes #250