### PR TITLE
feat(infra): add dedicated Cloud Build service account and IAM bindings

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -545,6 +545,37 @@ resource "google_artifact_registry_repository_iam_member" "cloud_build_writer" {
   member     = "serviceAccount:${data.google_project.current.number}@cloudbuild.gserviceaccount.com"
 }
 
+# ---------------------------------------------------------------------------
+# Dedicated Cloud Build service account (least-privilege alternative to the
+# default Cloud Build SA).  Builds are submitted by GitHub Actions via the
+# github_deployer SA; the build itself runs as this SA when
+# --service-account is passed to `gcloud builds submit`.
+# ---------------------------------------------------------------------------
+
+resource "google_service_account" "cloud_build" {
+  account_id   = "foehncast-cloud-build"
+  display_name = "FoehnCast Cloud Build"
+}
+
+resource "google_artifact_registry_repository_iam_member" "cloud_build_sa_writer" {
+  location   = google_artifact_registry_repository.containers.location
+  repository = google_artifact_registry_repository.containers.name
+  role       = "roles/artifactregistry.writer"
+  member     = "serviceAccount:${google_service_account.cloud_build.email}"
+}
+
+resource "google_project_iam_member" "cloud_build_sa_log_writer" {
+  project = var.project_id
+  role    = "roles/logging.logWriter"
+  member  = "serviceAccount:${google_service_account.cloud_build.email}"
+}
+
+resource "google_service_account_iam_member" "github_deployer_impersonate_cloud_build" {
+  service_account_id = google_service_account.cloud_build.name
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${google_service_account.github_deployer.email}"
+}
+
 resource "google_artifact_registry_repository_iam_member" "cloud_run_reader" {
   location   = google_artifact_registry_repository.containers.location
   repository = google_artifact_registry_repository.containers.name

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -73,6 +73,11 @@ output "cloud_run_runtime_service_account" {
   value       = try(google_service_account.cloud_run_runtime.email, "foehncast-cloud-run@${var.project_id}.iam.gserviceaccount.com")
 }
 
+output "cloud_build_service_account" {
+  description = "Dedicated service account for Cloud Build image builds."
+  value       = google_service_account.cloud_build.email
+}
+
 output "online_compose_runtime_service_account" {
   description = "Service account intended for the online compose host runtime when that target is enabled."
   value       = var.provision_online_compose_host ? try(google_service_account.online_compose_runtime[0].email, "foehncast-online-compose@${var.project_id}.iam.gserviceaccount.com") : null


### PR DESCRIPTION
### What Changed

- Add `foehncast-cloud-build` service account for least-privilege Cloud Build execution
- Grant `roles/artifactregistry.writer` on the container registry
- Grant `roles/logging.logWriter` for build logs
- Allow `github_deployer` to impersonate via `roles/iam.serviceAccountUser`
- Export `cloud_build_service_account` output

### Submission Pattern

The project uses **GitHub Actions → `gcloud builds submit`** (not Cloud Build triggers). Builds are submitted by the `github_deployer` SA authenticated via OIDC. The dedicated Cloud Build SA can be used with `--service-account` for least-privilege execution.

### Validation

- `terraform validate`: success
- `terraform fmt -check`: clean
- All resources are additive (no destroys)

### Closes

- Closes #251