### PR TITLE
chore(composer): add DAG validation tests and runbook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -5,6 +5,7 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-yaml
+        args: ['--unsafe']
       - id: check-added-large-files
         args: ['--maxkb=500']
       - id: check-merge-conflict

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -37,8 +37,9 @@ markdown_extensions:
   - tables
   - pymdownx.emoji:
       # yaml-language-server-disable Unresolved tag
-      emoji_index: !!python/name:material.extensions.emoji.twemoji
-      # yaml-language-server-disable Unresolved tag
+      emoji_index:
+        !!python/name:material.extensions.emoji.twemoji # yaml-language-server-disable Unresolved tag
+
       emoji_generator: !!python/name:material.extensions.emoji.to_svg
   - pymdownx.details
   - pymdownx.highlight:
@@ -73,3 +74,4 @@ nav:
       - Seasonality: system/seasonality.md
   - Operations:
       - Monitoring: system/monitoring.md
+      - Composer DAG Validation: system/composer-dag-validation.md

--- a/docs/site/system/composer-dag-validation.md
+++ b/docs/site/system/composer-dag-validation.md
@@ -1,0 +1,88 @@
+# Composer DAG Validation
+
+How to validate FoehnCast DAGs in a Cloud Composer environment.
+
+## Prerequisites
+
+- Terraform has provisioned the Composer environment (`provision_cloud_composer_environment = true`)
+- `gcloud` is authenticated with a principal that has Composer access
+- The Composer environment is healthy and the Airflow web UI is reachable
+
+## 1. Build and Upload DAGs
+
+```bash
+# Resolve the Composer DAG bucket from Terraform outputs
+DAG_GCS_PREFIX="$(cd terraform && terraform output -raw cloud_composer_dag_gcs_prefix)"
+
+# Build and publish the DAG bundle
+./scripts/publish-composer-dags.sh --dag-gcs-prefix "$DAG_GCS_PREFIX"
+```
+
+This builds the Composer bundle (DAG files, `foehncast/` source, `config.yaml`,
+`pyproject.toml`, `feature_repo/`) and syncs it to the Composer DAG bucket via
+`gcloud storage rsync`.
+
+## 2. Verify DAG Import
+
+After upload, check the Airflow web UI or CLI for import errors:
+
+```bash
+COMPOSER_ENV="$(cd terraform && terraform output -raw cloud_composer_environment_name)"
+REGION="$(cd terraform && terraform output -raw region)"
+
+gcloud composer environments run "$COMPOSER_ENV" \
+  --location "$REGION" \
+  dags list
+```
+
+Expected DAGs:
+
+| DAG ID | Schedule | Description |
+|--------|----------|-------------|
+| `feature_pipeline` | `0 */6 * * *` | Ingest, engineer, validate, store features; trigger retraining |
+| `training_pipeline` | Asset-triggered | Train, evaluate, register model |
+| `runtime_release` | Manual | Record runtime release handoff |
+
+## 3. Trigger Feature Pipeline DAG
+
+```bash
+gcloud composer environments run "$COMPOSER_ENV" \
+  --location "$REGION" \
+  dags trigger -- feature_pipeline
+```
+
+Monitor the run in the Airflow UI or via:
+
+```bash
+gcloud composer environments run "$COMPOSER_ENV" \
+  --location "$REGION" \
+  dags list-runs -- -d feature_pipeline
+```
+
+## 4. Verify Connectivity
+
+The feature pipeline DAG exercises these connections:
+
+| Service | Verification |
+|---------|-------------|
+| BigQuery | Feature store read/write in `store_features` task |
+| GCS | Artifact storage via MLflow or direct GCS writes |
+| Datastore | Feast online store materialization |
+
+Check task logs in the Airflow UI for connection errors. Common issues:
+
+- **Missing PyPI packages**: Composer environment must have the packages listed
+  in `terraform/main.tf` under `cloud_composer_env_config.software_config.pypi_packages`
+- **IAM permissions**: The Composer SA (`foehncast-composer`) needs BigQuery,
+  GCS, and Datastore access
+- **Network connectivity**: Composer uses a private network; ensure VPC peering
+  or firewall rules allow access to required services
+
+## 5. Document Issues
+
+If any tasks fail, file follow-up issues with:
+
+- The failing task ID and error message
+- Whether the failure is a packaging issue (missing module/config) or a
+  connectivity issue (IAM/network)
+- The Composer environment version and Airflow image version

--- a/tests/test_composer_bundle.py
+++ b/tests/test_composer_bundle.py
@@ -9,6 +9,8 @@ import pytest
 
 import foehncast.composer_bundle as composer_bundle
 
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+
 
 def _write(path: Path, content: str) -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -84,3 +86,44 @@ def test_write_composer_bundle_manifest_persists_stable_json(tmp_path: Path) -> 
 
     persisted = json.loads(manifest_path.read_text(encoding="utf-8"))
     assert persisted == manifest
+
+
+# ---------------------------------------------------------------------------
+# Integration: validate the real project DAG bundle
+# ---------------------------------------------------------------------------
+
+
+def test_real_project_bundle_includes_all_dags_and_source(tmp_path: Path) -> None:
+    """Build the bundle from the real project root and verify structure."""
+    manifest = composer_bundle.build_composer_bundle(
+        tmp_path / "bundle",
+        project_root=_PROJECT_ROOT,
+    )
+    bundle = tmp_path / "bundle"
+
+    dag_dir = _PROJECT_ROOT / "dags"
+    expected_dags = sorted(p.name for p in dag_dir.glob("*.py") if p.is_file())
+    assert expected_dags, "Expected at least one DAG file"
+
+    for dag_name in expected_dags:
+        assert (bundle / dag_name).is_file(), f"Missing DAG: {dag_name}"
+
+    assert (bundle / "foehncast" / "__init__.py").is_file()
+    assert (bundle / "config.yaml").is_file()
+    assert (bundle / "pyproject.toml").is_file()
+    assert (bundle / "feature_repo").is_dir()
+
+    assert not (bundle / "dags").exists(), "DAGs should be flattened, not nested"
+    assert not list(bundle.rglob("__pycache__")), "No __pycache__ in bundle"
+
+    targets = {e["target"] for e in manifest["entries"]}
+    for dag_name in expected_dags:
+        assert dag_name in targets
+
+
+def test_real_project_bundle_mappings_resolve() -> None:
+    """All source paths in the bundle mappings exist in the real project."""
+    mappings = composer_bundle.composer_bundle_mappings(_PROJECT_ROOT)
+    for m in mappings:
+        source = _PROJECT_ROOT / m["source"]
+        assert source.exists(), f"Missing: {source}"


### PR DESCRIPTION
### What Changed

- Add integration tests in `test_composer_bundle.py` that build the bundle from the real project root:
  - Verify all DAGs are flattened (not nested under `dags/`)
  - Verify source package, config, pyproject.toml, and feature_repo are included
  - Verify no `__pycache__` leaks into the bundle
  - Verify all bundle mappings resolve to existing source paths
- Add `docs/site/system/composer-dag-validation.md` runbook covering:
  - DAG upload via `publish-composer-dags.sh`
  - Import verification via `gcloud composer`
  - Manual DAG trigger and monitoring
  - Connectivity verification (BigQuery, GCS, Datastore)
  - Issue documentation template
- Fix `check-yaml` pre-commit hook to allow Python constructors used by mkdocs-material

### Tests

5 tests pass in `test_composer_bundle.py` (3 existing + 2 new)

### Closes

- Closes #253