### PR TITLE
chore(workflow): replace SSH handoff with Composer Airflow API

### DIFF
--- a/.github/workflows/trigger-runtime-release.yml
+++ b/.github/workflows/trigger-runtime-release.yml
@@ -13,13 +13,11 @@ on:
           - promote_candidate
           - rollback_live
       airflow_target:
-        description: Reviewed Airflow receiver selection for the runtime release handoff
+        description: Airflow receiver for the runtime release handoff
         required: true
-        default: auto
+        default: composer_airflow
         type: choice
         options:
-          - auto
-          - retained_host
           - composer_airflow
       image_uri:
         description: Immutable image URI for deploy_candidate requests
@@ -67,10 +65,7 @@ jobs:
       artifact_bucket_name: ${{ steps.repo_config.outputs.artifact_bucket_name }}
       workload_identity_provider: ${{ steps.repo_config.outputs.workload_identity_provider }}
       service_account_email: ${{ steps.repo_config.outputs.service_account_email }}
-      online_compose_host_name: ${{ steps.repo_config.outputs.online_compose_host_name }}
-      online_compose_host_zone: ${{ steps.repo_config.outputs.online_compose_host_zone }}
       cloud_composer_airflow_uri: ${{ steps.repo_config.outputs.cloud_composer_airflow_uri }}
-      requested_airflow_target: ${{ steps.derived.outputs.requested_airflow_target }}
       airflow_target: ${{ steps.derived.outputs.airflow_target }}
       action: ${{ steps.derived.outputs.action }}
       image_uri: ${{ steps.derived.outputs.image_uri }}
@@ -107,7 +102,6 @@ jobs:
       - id: derived
         env:
           ACTION_INPUT: ${{ github.event.inputs.action }}
-          AIRFLOW_TARGET_INPUT: ${{ github.event.inputs.airflow_target }}
           IMAGE_URI_INPUT: ${{ github.event.inputs.image_uri }}
           CANDIDATE_REVISION_TAG_INPUT: ${{ github.event.inputs.candidate_revision_tag }}
           CANDIDATE_ALIAS_INPUT: ${{ github.event.inputs.candidate_alias }}
@@ -120,32 +114,19 @@ jobs:
           PROVISION_CLOUD_COMPOSER_ENVIRONMENT: ${{ steps.repo_config.outputs.provision_cloud_composer_environment }}
           CLOUD_COMPOSER_AIRFLOW_ACCESS_READY: ${{ steps.repo_config.outputs.cloud_composer_airflow_access_ready }}
           CLOUD_COMPOSER_AIRFLOW_URI: ${{ steps.repo_config.outputs.cloud_composer_airflow_uri }}
-          PROVISION_ONLINE_COMPOSE_HOST: ${{ steps.repo_config.outputs.provision_online_compose_host }}
-          ONLINE_COMPOSE_HOST_NAME: ${{ steps.repo_config.outputs.online_compose_host_name }}
-          ONLINE_COMPOSE_HOST_ZONE: ${{ steps.repo_config.outputs.online_compose_host_zone }}
           WORKLOAD_IDENTITY_PROVIDER: ${{ steps.repo_config.outputs.workload_identity_provider }}
           SERVICE_ACCOUNT_EMAIL: ${{ steps.repo_config.outputs.service_account_email }}
         run: |
           set -euo pipefail
 
           action="$(printf '%s' "${ACTION_INPUT:-deploy_candidate}" | tr '[:upper:]' '[:lower:]')"
-          requested_airflow_target="$(printf '%s' "${AIRFLOW_TARGET_INPUT:-auto}" | tr '[:upper:]' '[:lower:]')"
-          airflow_target="$requested_airflow_target"
+          airflow_target="composer_airflow"
 
           case "$action" in
             deploy_candidate|promote_candidate|rollback_live)
               ;;
             *)
               echo "Unsupported action '$action'." >&2
-              exit 1
-              ;;
-          esac
-
-          case "$requested_airflow_target" in
-            auto|retained_host|composer_airflow)
-              ;;
-            *)
-              echo "Unsupported airflow target '$requested_airflow_target'." >&2
               exit 1
               ;;
           esac
@@ -185,49 +166,14 @@ jobs:
           fi
 
           trigger_ready=false
-          composer_trigger_ready=false
-          retained_host_trigger_ready=false
           if [[ -n "$PROJECT_ID" \
             && -n "$WORKLOAD_IDENTITY_PROVIDER" \
-            && -n "$SERVICE_ACCOUNT_EMAIL" ]]; then
-            if [[ "$PROVISION_CLOUD_COMPOSER_ENVIRONMENT" == 'true' \
-              && -n "$CLOUD_COMPOSER_AIRFLOW_URI" \
-              && -n "$ARTIFACT_BUCKET_NAME" \
-              && "$composer_access_ready" == 'true' ]]; then
-              composer_trigger_ready=true
-            fi
-
-            if [[ "$PROVISION_ONLINE_COMPOSE_HOST" == 'true' \
-              && -n "$ONLINE_COMPOSE_HOST_NAME" \
-              && -n "$ONLINE_COMPOSE_HOST_ZONE" ]]; then
-              retained_host_trigger_ready=true
-            fi
-
-            case "$requested_airflow_target" in
-              auto)
-                if [[ "$composer_trigger_ready" == 'true' ]]; then
-                  airflow_target='composer_airflow'
-                else
-                  airflow_target='retained_host'
-                fi
-                ;;
-              retained_host|composer_airflow)
-                airflow_target="$requested_airflow_target"
-                ;;
-            esac
-
-            case "$airflow_target" in
-              retained_host)
-                if [[ "$retained_host_trigger_ready" == 'true' ]]; then
-                  trigger_ready=true
-                fi
-                ;;
-              composer_airflow)
-                if [[ "$composer_trigger_ready" == 'true' ]]; then
-                  trigger_ready=true
-                fi
-                ;;
-            esac
+            && -n "$SERVICE_ACCOUNT_EMAIL" \
+            && "$PROVISION_CLOUD_COMPOSER_ENVIRONMENT" == 'true' \
+            && -n "$CLOUD_COMPOSER_AIRFLOW_URI" \
+            && -n "$ARTIFACT_BUCKET_NAME" \
+            && "$composer_access_ready" == 'true' ]]; then
+            trigger_ready=true
           fi
 
           case "$action" in
@@ -245,7 +191,6 @@ jobs:
 
           {
             echo "action=$action"
-            echo "requested_airflow_target=$requested_airflow_target"
             echo "airflow_target=$airflow_target"
             echo "image_uri=$image_uri"
             echo "candidate_revision_tag=$candidate_revision_tag"
@@ -264,9 +209,6 @@ jobs:
     env:
       PROJECT_ID: ${{ needs.config.outputs.project_id }}
       ARTIFACT_BUCKET_NAME: ${{ needs.config.outputs.artifact_bucket_name }}
-      HOST_NAME: ${{ needs.config.outputs.online_compose_host_name }}
-      HOST_ZONE: ${{ needs.config.outputs.online_compose_host_zone }}
-      REQUESTED_AIRFLOW_TARGET: ${{ needs.config.outputs.requested_airflow_target }}
       AIRFLOW_TARGET: ${{ needs.config.outputs.airflow_target }}
       CLOUD_COMPOSER_AIRFLOW_URI: ${{ needs.config.outputs.cloud_composer_airflow_uri }}
       ACTION: ${{ needs.config.outputs.action }}
@@ -288,11 +230,9 @@ jobs:
       - uses: google-github-actions/setup-gcloud@v2
 
       - name: Set up uv
-        if: ${{ env.AIRFLOW_TARGET == 'composer_airflow' }}
         uses: astral-sh/setup-uv@v8.1.0
 
       - name: Install Composer trigger dependencies
-        if: ${{ env.AIRFLOW_TARGET == 'composer_airflow' }}
         run: uv sync --frozen
 
       - name: Build runtime release request
@@ -302,48 +242,17 @@ jobs:
             python3 -m foehncast.runtime_release write-request-from-env \
               --output-file runtime-release-request.json
 
-      - name: Refresh operator host checkout
-        if: ${{ env.AIRFLOW_TARGET == 'retained_host' }}
-        run: |
-          set -euo pipefail
-          gcloud compute ssh "$HOST_NAME" \
-            --project "$PROJECT_ID" \
-            --zone "$HOST_ZONE" \
-            --command "sudo systemctl start --wait foehncast-online-compose-sync.service"
-
-      - name: Copy runtime release request
-        if: ${{ env.AIRFLOW_TARGET == 'retained_host' }}
-        run: |
-          set -euo pipefail
-          gcloud compute scp \
-            --project "$PROJECT_ID" \
-            --zone "$HOST_ZONE" \
-            runtime-release-request.json \
-            "$HOST_NAME:/tmp/runtime-release-request.json"
-
       - id: handoff
         name: Trigger runtime release handoff
         run: |
           set -euo pipefail
 
-          selected_receiver="retained-host Airflow API adapter"
-          selected_auth_path="GitHub OIDC plus SSH to retained host and host-local Airflow API"
-
-          if [[ "$AIRFLOW_TARGET" == "composer_airflow" ]]; then
-            selected_receiver="Composer Airflow API"
-            selected_auth_path="GitHub OIDC plus Google access token to Composer Airflow"
-            export FOEHNCAST_AIRFLOW_AUTH_TOKEN="$(gcloud auth print-access-token)"
-            report="$(FOEHNCAST_RUNTIME_RELEASE_REPORT_PATH="gs://${ARTIFACT_BUCKET_NAME}/airflow/reports/runtime-release-latest.json" \
-              uv run ./scripts/trigger-runtime-release.sh \
-                --request-file runtime-release-request.json \
-                --airflow-api-base-url "${CLOUD_COMPOSER_AIRFLOW_URI%/}/api/v1" \
-                --airflow-api-health-endpoint /health)"
-          else
-            report="$(gcloud compute ssh "$HOST_NAME" \
-              --project "$PROJECT_ID" \
-              --zone "$HOST_ZONE" \
-              --command "cd /opt/foehncast && ./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json --airflow-api-base-url http://127.0.0.1:8080/api/v2 --airflow-api-health-endpoint /monitor/health")"
-          fi
+          export FOEHNCAST_AIRFLOW_AUTH_TOKEN="$(gcloud auth print-access-token)"
+          report="$(FOEHNCAST_RUNTIME_RELEASE_REPORT_PATH="gs://${ARTIFACT_BUCKET_NAME}/airflow/reports/runtime-release-latest.json" \
+            uv run ./scripts/trigger-runtime-release.sh \
+              --request-file runtime-release-request.json \
+              --airflow-api-base-url "${CLOUD_COMPOSER_AIRFLOW_URI%/}/api/v1" \
+              --airflow-api-health-endpoint /health)"
 
           printf '%s\n' "$report"
 
@@ -359,18 +268,9 @@ jobs:
             echo "## Runtime release handoff"
             echo
             echo "- Action: $ACTION"
-            echo "- Requested receiver: $REQUESTED_AIRFLOW_TARGET"
-            if [[ "$REQUESTED_AIRFLOW_TARGET" == "auto" ]]; then
-              echo "- Selection rule: prefer Composer Airflow when the managed URI, artifact bucket, and access-ready contract are ready; otherwise fallback to retained-host Airflow API adapter"
-            fi
-            echo "- Selected receiver: $selected_receiver"
-            echo "- Fallback receiver: retained-host Airflow API adapter"
-            echo "- Auth path: $selected_auth_path"
-            if [[ "$AIRFLOW_TARGET" == "composer_airflow" ]]; then
-              echo "- Composer access assumption: the GitHub service account already maps to an Airflow user or role"
-            else
-              echo "- Operator host: $HOST_NAME"
-            fi
+            echo "- Receiver: Composer Airflow API"
+            echo "- Auth path: GitHub OIDC plus Google access token to Composer Airflow"
+            echo "- Composer access assumption: the GitHub service account already maps to an Airflow user or role"
             echo "- Airflow DAG: runtime_release"
             echo "- DAG run: $dag_run_id"
             echo "- Summary path: $report_path"
@@ -384,48 +284,22 @@ jobs:
     needs: config
     if: ${{ needs.config.outputs.owner_allowed == 'true' && needs.config.outputs.trigger_ready != 'true' }}
     runs-on: ubuntu-latest
-    env:
-      REQUESTED_AIRFLOW_TARGET: ${{ needs.config.outputs.requested_airflow_target }}
-      AIRFLOW_TARGET: ${{ needs.config.outputs.airflow_target }}
     steps:
       - name: Explain skipped runtime release handoff
         run: |
           {
             echo "## Runtime release handoff skipped"
             echo
-            echo "- Requested receiver: $REQUESTED_AIRFLOW_TARGET"
-            echo "The selected runtime trigger contract needs all of these inputs before it can run:"
+            echo "The Composer Airflow trigger contract needs all of these inputs before it can run:"
             echo "- GCP_PROJECT_ID"
             echo "- GCP_WORKLOAD_IDENTITY_PROVIDER"
             echo "- GCP_SERVICE_ACCOUNT_EMAIL"
-            if [[ "$REQUESTED_AIRFLOW_TARGET" == "auto" ]]; then
-              echo
-              echo "Automatic receiver selection prefers Composer Airflow when the managed URI, artifact bucket, and access-ready contract are ready, and otherwise falls back to the retained-host Airflow API adapter."
-              echo
-              echo "Composer automatic selection requires:"
-              echo "- GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT=true"
-              echo "- GCP_CLOUD_COMPOSER_AIRFLOW_ACCESS_READY=true"
-              echo "- GCP_CLOUD_COMPOSER_AIRFLOW_URI"
-              echo "- GCP_ARTIFACT_BUCKET_NAME"
-              echo
-              echo "Composer handoff also assumes the GitHub service account already maps to an Airflow user or role."
-              echo
-              echo "Retained-host fallback requires:"
-              echo "- GCP_PROVISION_ONLINE_COMPOSE_HOST=true"
-              echo "- GCP_ONLINE_COMPOSE_HOST_NAME"
-              echo "- GCP_ONLINE_COMPOSE_HOST_ZONE"
-            elif [[ "$AIRFLOW_TARGET" == "composer_airflow" ]]; then
-              echo "- GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT=true"
-              echo "- GCP_CLOUD_COMPOSER_AIRFLOW_ACCESS_READY=true"
-              echo "- GCP_CLOUD_COMPOSER_AIRFLOW_URI"
-              echo "- GCP_ARTIFACT_BUCKET_NAME"
-              echo
-              echo "Composer handoff also assumes the GitHub service account already maps to an Airflow user or role."
-            else
-              echo "- GCP_PROVISION_ONLINE_COMPOSE_HOST=true"
-              echo "- GCP_ONLINE_COMPOSE_HOST_NAME"
-              echo "- GCP_ONLINE_COMPOSE_HOST_ZONE"
-            fi
+            echo "- GCP_PROVISION_CLOUD_COMPOSER_ENVIRONMENT=true"
+            echo "- GCP_CLOUD_COMPOSER_AIRFLOW_ACCESS_READY=true"
+            echo "- GCP_CLOUD_COMPOSER_AIRFLOW_URI"
+            echo "- GCP_ARTIFACT_BUCKET_NAME"
+            echo
+            echo "The handoff also assumes the GitHub service account already maps to an Airflow user or role."
             echo
             echo "Action-specific coordinates must also be present for the chosen request."
           } >> "$GITHUB_STEP_SUMMARY"

--- a/src/foehncast/runtime_release.py
+++ b/src/foehncast/runtime_release.py
@@ -268,9 +268,10 @@ def normalize_runtime_release_request(
         ).lower(),
     }
 
-    if not normalized_request["selected_airflow_target"] and normalized_request[
-        "requested_airflow_target"
-    ] in {"retained_host", "composer_airflow"}:
+    if (
+        not normalized_request["selected_airflow_target"]
+        and normalized_request["requested_airflow_target"] == "composer_airflow"
+    ):
         normalized_request["selected_airflow_target"] = normalized_request[
             "requested_airflow_target"
         ]

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -746,11 +746,9 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
         "promote_candidate",
         "rollback_live",
     ]
-    assert dispatch_inputs["airflow_target"]["default"] == "auto"
+    assert dispatch_inputs["airflow_target"]["default"] == "composer_airflow"
     assert dispatch_inputs["airflow_target"]["type"] == "choice"
     assert dispatch_inputs["airflow_target"]["options"] == [
-        "auto",
-        "retained_host",
         "composer_airflow",
     ]
     assert dispatch_inputs["candidate_revision_tag"]["default"] == "candidate"
@@ -764,10 +762,7 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
         "artifact_bucket_name",
         "workload_identity_provider",
         "service_account_email",
-        "online_compose_host_name",
-        "online_compose_host_zone",
         "cloud_composer_airflow_uri",
-        "requested_airflow_target",
         "airflow_target",
         "action",
         "image_uri",
@@ -786,10 +781,6 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
     derived_step = _workflow_step(workflow, "config", "derived")
     assert derived_step["env"]["ACTION_INPUT"] == "${{ github.event.inputs.action }}"
     assert (
-        derived_step["env"]["AIRFLOW_TARGET_INPUT"]
-        == "${{ github.event.inputs.airflow_target }}"
-    )
-    assert (
         derived_step["env"]["ARTIFACT_BUCKET_NAME"]
         == "${{ steps.repo_config.outputs.artifact_bucket_name }}"
     )
@@ -805,21 +796,13 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
         derived_step["env"]["CLOUD_COMPOSER_AIRFLOW_URI"]
         == "${{ steps.repo_config.outputs.cloud_composer_airflow_uri }}"
     )
-    assert (
-        derived_step["env"]["PROVISION_ONLINE_COMPOSE_HOST"]
-        == "${{ steps.repo_config.outputs.provision_online_compose_host }}"
-    )
+    assert "PROVISION_ONLINE_COMPOSE_HOST" not in derived_step.get("env", {})
     assert "deploy_candidate|promote_candidate|rollback_live" in derived_step["run"]
-    assert "auto|retained_host|composer_airflow" in derived_step["run"]
     assert (
         "composer_access_ready=\"$(printf '%s' \"${CLOUD_COMPOSER_AIRFLOW_ACCESS_READY:-false}\" | tr '[:upper:]' '[:lower:]')\""
         in derived_step["run"]
     )
     assert "trigger_ready=false" in derived_step["run"]
-    assert (
-        'echo "requested_airflow_target=$requested_airflow_target"'
-        in derived_step["run"]
-    )
     assert 'echo "airflow_target=$airflow_target"' in derived_step["run"]
     assert 'echo "trigger_ready=$trigger_ready"' in derived_step["run"]
 
@@ -832,18 +815,9 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
         trigger_job["env"]["ARTIFACT_BUCKET_NAME"]
         == "${{ needs.config.outputs.artifact_bucket_name }}"
     )
-    assert (
-        trigger_job["env"]["HOST_NAME"]
-        == "${{ needs.config.outputs.online_compose_host_name }}"
-    )
-    assert (
-        trigger_job["env"]["HOST_ZONE"]
-        == "${{ needs.config.outputs.online_compose_host_zone }}"
-    )
-    assert (
-        trigger_job["env"]["REQUESTED_AIRFLOW_TARGET"]
-        == "${{ needs.config.outputs.requested_airflow_target }}"
-    )
+    assert "HOST_NAME" not in trigger_job["env"]
+    assert "HOST_ZONE" not in trigger_job["env"]
+    assert "REQUESTED_AIRFLOW_TARGET" not in trigger_job["env"]
     assert (
         trigger_job["env"]["AIRFLOW_TARGET"]
         == "${{ needs.config.outputs.airflow_target }}"
@@ -854,7 +828,7 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
     )
 
     setup_uv_step = _workflow_step(workflow, "trigger", "Set up uv")
-    assert setup_uv_step["if"] == "${{ env.AIRFLOW_TARGET == 'composer_airflow' }}"
+    assert "if" not in setup_uv_step
     assert setup_uv_step["uses"] == "astral-sh/setup-uv@v8.1.0"
 
     composer_deps_step = _workflow_step(
@@ -862,7 +836,7 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
         "trigger",
         "Install Composer trigger dependencies",
     )
-    assert composer_deps_step["if"] == "${{ env.AIRFLOW_TARGET == 'composer_airflow' }}"
+    assert "if" not in composer_deps_step
     assert "uv sync --frozen" in composer_deps_step["run"]
 
     payload_step = _workflow_step(workflow, "trigger", "Build runtime release request")
@@ -877,16 +851,9 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
     )
     assert "--output-file runtime-release-request.json" in payload_step["run"]
 
-    refresh_step = _workflow_step(workflow, "trigger", "Refresh operator host checkout")
-    assert refresh_step["if"] == "${{ env.AIRFLOW_TARGET == 'retained_host' }}"
-    assert "gcloud compute ssh" in refresh_step["run"]
-    assert "foehncast-online-compose-sync.service" in refresh_step["run"]
-    assert "--wait" in refresh_step["run"]
-
-    copy_step = _workflow_step(workflow, "trigger", "Copy runtime release request")
-    assert copy_step["if"] == "${{ env.AIRFLOW_TARGET == 'retained_host' }}"
-    assert "gcloud compute scp" in copy_step["run"]
-    assert "/tmp/runtime-release-request.json" in copy_step["run"]
+    trigger_step_names = [s["name"] for s in trigger_job["steps"] if "name" in s]
+    assert "Refresh operator host checkout" not in trigger_step_names
+    assert "Copy runtime release request" not in trigger_step_names
 
     handoff_step = _workflow_step(
         workflow, "trigger", "Trigger runtime release handoff"
@@ -896,27 +863,10 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
     assert "--airflow-api-base-url" in handoff_step["run"]
     assert "--airflow-api-health-endpoint /health" in handoff_step["run"]
     assert "FOEHNCAST_RUNTIME_RELEASE_REPORT_PATH" in handoff_step["run"]
-    assert (
-        "./scripts/trigger-runtime-release.sh --request-file /tmp/runtime-release-request.json --airflow-api-base-url http://127.0.0.1:8080/api/v2 --airflow-api-health-endpoint /monitor/health"
-        in handoff_step["run"]
-    )
-    assert (
-        'selected_receiver="retained-host Airflow API adapter"' in handoff_step["run"]
-    )
-    assert 'selected_receiver="Composer Airflow API"' in handoff_step["run"]
-    assert (
-        'echo "- Requested receiver: $REQUESTED_AIRFLOW_TARGET"' in handoff_step["run"]
-    )
-    assert (
-        "Selection rule: prefer Composer Airflow when the managed URI, artifact bucket, and access-ready contract are ready; otherwise fallback to retained-host Airflow API adapter"
-        in handoff_step["run"]
-    )
+    assert "retained" not in handoff_step["run"].lower()
+    assert "ssh" not in handoff_step["run"].lower()
+    assert 'echo "- Receiver: Composer Airflow API"' in handoff_step["run"]
     assert 'echo "- Airflow DAG: runtime_release"' in handoff_step["run"]
-    assert 'echo "- Selected receiver: $selected_receiver"' in handoff_step["run"]
-    assert (
-        'echo "- Fallback receiver: retained-host Airflow API adapter"'
-        in handoff_step["run"]
-    )
     assert (
         "GitHub OIDC plus Google access token to Composer Airflow"
         in handoff_step["run"]
@@ -931,22 +881,14 @@ def test_trigger_runtime_release_workflow_supports_selected_airflow_handoff_cont
         workflow, "skipped", "Explain skipped runtime release handoff"
     )
     assert (
-        "The selected runtime trigger contract needs all of these inputs before it can run:"
+        "The Composer Airflow trigger contract needs all of these inputs before it can run:"
         in skipped_step["run"]
     )
-    assert (
-        'echo "- Requested receiver: $REQUESTED_AIRFLOW_TARGET"' in skipped_step["run"]
-    )
-    assert (
-        "Automatic receiver selection prefers Composer Airflow when the managed URI, artifact bucket, and access-ready contract are ready"
-        in skipped_step["run"]
-    )
+    assert "retained" not in skipped_step["run"].lower()
     assert "GCP_CLOUD_COMPOSER_AIRFLOW_ACCESS_READY=true" in skipped_step["run"]
-    assert "Retained-host fallback requires:" in skipped_step["run"]
-    assert "GCP_PROVISION_ONLINE_COMPOSE_HOST=true" in skipped_step["run"]
     assert "GCP_CLOUD_COMPOSER_AIRFLOW_URI" in skipped_step["run"]
     assert (
-        "Composer handoff also assumes the GitHub service account already maps to an Airflow user or role."
+        "the GitHub service account already maps to an Airflow user or role"
         in skipped_step["run"]
     )
 

--- a/tests/test_runtime_release.py
+++ b/tests/test_runtime_release.py
@@ -155,7 +155,7 @@ def test_write_runtime_release_request_file_persists_normalized_payload(
             "GITHUB_WORKFLOW": "Trigger Runtime Release",
             "GITHUB_RUN_ID": "99",
             "GITHUB_SHA": "def456",
-            "REQUESTED_AIRFLOW_TARGET": "retained_host",
+            "REQUESTED_AIRFLOW_TARGET": "composer_airflow",
             "IMAGE_URI": "europe-west6-docker.pkg.dev/demo/foehncast/foehncast-app:sha-123",
         },
         requested_at="2026-05-16T12:05:00+00:00",
@@ -164,8 +164,8 @@ def test_write_runtime_release_request_file_persists_normalized_payload(
     request = json.loads(request_path.read_text(encoding="utf-8"))
     assert request["action"] == "deploy_candidate"
     assert request["requested_at"] == "2026-05-16T12:05:00+00:00"
-    assert request["requested_airflow_target"] == "retained_host"
-    assert request["selected_airflow_target"] == "retained_host"
+    assert request["requested_airflow_target"] == "composer_airflow"
+    assert request["selected_airflow_target"] == "composer_airflow"
     assert request["image_uri"]
 
 


### PR DESCRIPTION
### What Changed

Remove the retained-host SSH handoff path from the runtime release workflow. Composer Airflow API is now the sole handoff target.

**Workflow changes** (`trigger-runtime-release.yml`):
- Remove `auto` and `retained_host` from `airflow_target` input — only `composer_airflow` remains
- Remove SSH steps: `Refresh operator host checkout` (`gcloud compute ssh`) and `Copy runtime release request` (`gcloud compute scp`)
- Remove dual-target readiness logic and `PROVISION_ONLINE_COMPOSE_HOST` env vars
- Remove `HOST_NAME`, `HOST_ZONE`, `REQUESTED_AIRFLOW_TARGET` from trigger job env
- Remove `if` conditionals from uv setup steps (always needed now)
- Simplify handoff step to always use Composer Airflow API with OIDC token
- Simplify skipped job explanation

**Source changes** (`runtime_release.py`):
- Target validation now accepts only `composer_airflow` (was `retained_host | composer_airflow`)

**Test changes**:
- Update `test_runtime_release.py`: test uses `composer_airflow` target
- Update `test_cloud_operator_contract.py`: remove all retained-host assertions, verify SSH steps are absent, verify Composer-only contract

### Stats

4 files changed, 48 insertions(+), 231 deletions(-)

### Closes

- Closes #252