### PR TITLE
chore(monitoring): restructure dashboard with row groupings

### DIFF
--- a/grafana_work/dashboards/foehncast-overview.json
+++ b/grafana_work/dashboards/foehncast-overview.json
@@ -22,6 +22,19 @@
   "links": [],
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 100,
+      "panels": [],
+      "title": "Feature Pipeline",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "prometheus"
@@ -30,7 +43,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 0
+        "y": 1
       },
       "id": 1,
       "targets": [
@@ -52,7 +65,7 @@
         "h": 8,
         "w": 9,
         "x": 6,
-        "y": 0
+        "y": 1
       },
       "id": 2,
       "targets": [
@@ -74,7 +87,7 @@
         "h": 8,
         "w": 9,
         "x": 15,
-        "y": 0
+        "y": 1
       },
       "id": 3,
       "targets": [
@@ -96,7 +109,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 9
       },
       "id": 4,
       "targets": [
@@ -118,7 +131,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 9
       },
       "id": 5,
       "targets": [
@@ -140,7 +153,7 @@
         "h": 6,
         "w": 12,
         "x": 0,
-        "y": 38
+        "y": 17
       },
       "id": 15,
       "targets": [
@@ -162,7 +175,7 @@
         "h": 6,
         "w": 12,
         "x": 12,
-        "y": 38
+        "y": 17
       },
       "id": 16,
       "targets": [
@@ -182,15 +195,77 @@
       },
       "fieldConfig": {
         "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": -1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 23
+      },
+      "id": 20,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_state)",
+          "legendFormat": "{{dataset}} / {{storage_backend}} / {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Feature Stage State",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
           "unit": "s"
         },
         "overrides": []
       },
       "gridPos": {
         "h": 8,
-        "w": 24,
-        "x": 0,
-        "y": 44
+        "w": 12,
+        "x": 12,
+        "y": 23
       },
       "id": 17,
       "targets": [
@@ -233,10 +308,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
+        "h": 6,
         "w": 24,
         "x": 0,
-        "y": 52
+        "y": 31
       },
       "id": 18,
       "targets": [
@@ -250,49 +325,17 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "min": 0,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "green",
-                "value": null
-              },
-              {
-                "color": "red",
-                "value": 900
-              }
-            ]
-          },
-          "unit": "s"
-        },
-        "overrides": []
-      },
+      "collapsed": false,
       "gridPos": {
-        "h": 8,
+        "h": 1,
         "w": 24,
         "x": 0,
-        "y": 60
+        "y": 37
       },
-      "id": 19,
-      "targets": [
-        {
-          "expr": "time() - max by (git_ref, compose_deploy_mode) (foehncast_online_compose_sync_last_success_timestamp_seconds)",
-          "legendFormat": "{{git_ref}} / {{compose_deploy_mode}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Seconds Since Last Hosted Sync",
-      "type": "timeseries"
+      "id": 101,
+      "panels": [],
+      "title": "Drift and Prediction Monitoring",
+      "type": "row"
     },
     {
       "datasource": {
@@ -331,7 +374,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 16
+        "y": 38
       },
       "id": 6,
       "targets": [
@@ -381,7 +424,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 16
+        "y": 38
       },
       "id": 7,
       "targets": [
@@ -403,7 +446,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 16
+        "y": 38
       },
       "id": 8,
       "targets": [
@@ -425,7 +468,7 @@
         "h": 6,
         "w": 8,
         "x": 0,
-        "y": 24
+        "y": 46
       },
       "id": 9,
       "targets": [
@@ -447,7 +490,7 @@
         "h": 6,
         "w": 8,
         "x": 8,
-        "y": 24
+        "y": 46
       },
       "id": 10,
       "targets": [
@@ -469,7 +512,7 @@
         "h": 6,
         "w": 8,
         "x": 16,
-        "y": 24
+        "y": 46
       },
       "id": 11,
       "targets": [
@@ -514,7 +557,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 30
+        "y": 52
       },
       "id": 12,
       "targets": [
@@ -559,7 +602,7 @@
         "h": 8,
         "w": 8,
         "x": 8,
-        "y": 30
+        "y": 52
       },
       "id": 13,
       "targets": [
@@ -581,7 +624,7 @@
         "h": 8,
         "w": 8,
         "x": 16,
-        "y": 30
+        "y": 52
       },
       "id": 14,
       "targets": [
@@ -595,128 +638,17 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "max": 1,
-          "min": -1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
+      "collapsed": false,
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 1,
+        "w": 24,
         "x": 0,
-        "y": 68
+        "y": 60
       },
-      "id": 20,
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true
-      },
-      "targets": [
-        {
-          "expr": "max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_state)",
-          "legendFormat": "{{dataset}} / {{storage_backend}} / {{stage}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Feature Stage State",
-      "type": "bargauge"
-    },
-    {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
-      "fieldConfig": {
-        "defaults": {
-          "color": {
-            "mode": "thresholds"
-          },
-          "max": 1,
-          "min": -1,
-          "thresholds": {
-            "mode": "absolute",
-            "steps": [
-              {
-                "color": "red",
-                "value": null
-              },
-              {
-                "color": "orange",
-                "value": 0
-              },
-              {
-                "color": "green",
-                "value": 1
-              }
-            ]
-          },
-          "unit": "short"
-        },
-        "overrides": []
-      },
-      "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 68
-      },
-      "id": 21,
-      "options": {
-        "displayMode": "gradient",
-        "orientation": "horizontal",
-        "reduceOptions": {
-          "calcs": [
-            "lastNotNull"
-          ],
-          "fields": "",
-          "values": false
-        },
-        "showUnfilled": true
-      },
-      "targets": [
-        {
-          "expr": "max by (dataset, requested_stage, stage) (foehncast_training_pipeline_stage_state)",
-          "legendFormat": "{{dataset}} / {{requested_stage}} / {{stage}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Training Stage State",
-      "type": "bargauge"
+      "id": 102,
+      "panels": [],
+      "title": "Training Pipeline",
+      "type": "row"
     },
     {
       "datasource": {
@@ -727,7 +659,7 @@
         "h": 6,
         "w": 6,
         "x": 0,
-        "y": 76
+        "y": 61
       },
       "id": 22,
       "targets": [
@@ -749,7 +681,7 @@
         "h": 6,
         "w": 9,
         "x": 6,
-        "y": 76
+        "y": 61
       },
       "id": 23,
       "targets": [
@@ -795,7 +727,7 @@
         "h": 6,
         "w": 9,
         "x": 15,
-        "y": 76
+        "y": 61
       },
       "id": 24,
       "options": {
@@ -830,11 +762,73 @@
         "type": "prometheus",
         "uid": "prometheus"
       },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "max": 1,
+          "min": -1,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 0
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "unit": "short"
+        },
+        "overrides": []
+      },
       "gridPos": {
         "h": 8,
-        "w": 8,
+        "w": 12,
         "x": 0,
-        "y": 82
+        "y": 67
+      },
+      "id": 21,
+      "options": {
+        "displayMode": "gradient",
+        "orientation": "horizontal",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showUnfilled": true
+      },
+      "targets": [
+        {
+          "expr": "max by (dataset, requested_stage, stage) (foehncast_training_pipeline_stage_state)",
+          "legendFormat": "{{dataset}} / {{requested_stage}} / {{stage}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Training Stage State",
+      "type": "bargauge"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 67
       },
       "id": 25,
       "options": {
@@ -887,9 +881,9 @@
       },
       "gridPos": {
         "h": 8,
-        "w": 16,
-        "x": 8,
-        "y": 82
+        "w": 12,
+        "x": 0,
+        "y": 75
       },
       "id": 26,
       "targets": [
@@ -900,6 +894,28 @@
         }
       ],
       "title": "Training Stage Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 75
+      },
+      "id": 28,
+      "targets": [
+        {
+          "expr": "max by (dataset, requested_stage, metric_name) (foehncast_training_pipeline_run_metric{metric_name=~\"accuracy|mae|r2|rmse\"})",
+          "legendFormat": "{{dataset}} / {{requested_stage}} / {{metric_name}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Training Metrics",
       "type": "timeseries"
     },
     {
@@ -932,10 +948,10 @@
         "overrides": []
       },
       "gridPos": {
-        "h": 8,
-        "w": 12,
+        "h": 6,
+        "w": 24,
         "x": 0,
-        "y": 90
+        "y": 83
       },
       "id": 27,
       "targets": [
@@ -949,26 +965,17 @@
       "type": "timeseries"
     },
     {
-      "datasource": {
-        "type": "prometheus",
-        "uid": "prometheus"
-      },
+      "collapsed": false,
       "gridPos": {
-        "h": 8,
-        "w": 12,
-        "x": 12,
-        "y": 90
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 89
       },
-      "id": 28,
-      "targets": [
-        {
-          "expr": "max by (dataset, requested_stage, metric_name) (foehncast_training_pipeline_run_metric{metric_name=~\"accuracy|mae|r2|rmse\"})",
-          "legendFormat": "{{dataset}} / {{requested_stage}} / {{metric_name}}",
-          "refId": "A"
-        }
-      ],
-      "title": "Training Metrics",
-      "type": "timeseries"
+      "id": 103,
+      "panels": [],
+      "title": "Pipeline Health and Freshness",
+      "type": "row"
     },
     {
       "datasource": {
@@ -1002,7 +1009,7 @@
         "h": 8,
         "w": 12,
         "x": 0,
-        "y": 98
+        "y": 90
       },
       "id": 29,
       "targets": [
@@ -1047,7 +1054,7 @@
         "h": 8,
         "w": 12,
         "x": 12,
-        "y": 98
+        "y": 90
       },
       "id": 30,
       "targets": [
@@ -1066,6 +1073,51 @@
       "type": "timeseries"
     },
     {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "min": 0,
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 900
+              }
+            ]
+          },
+          "unit": "s"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 98
+      },
+      "id": 19,
+      "targets": [
+        {
+          "expr": "time() - max by (git_ref, compose_deploy_mode) (foehncast_online_compose_sync_last_success_timestamp_seconds)",
+          "legendFormat": "{{git_ref}} / {{compose_deploy_mode}}",
+          "refId": "A"
+        }
+      ],
+      "title": "Seconds Since Last Hosted Sync",
+      "type": "timeseries"
+    },
+    {
       "collapsed": false,
       "gridPos": {
         "h": 1,
@@ -1073,7 +1125,8 @@
         "x": 0,
         "y": 106
       },
-      "id": 31,
+      "id": 104,
+      "panels": [],
       "title": "Inference Operations",
       "type": "row"
     },


### PR DESCRIPTION
Reorganize the 34-panel Grafana dashboard into five labeled row sections:

- **Feature Pipeline** — summary, success, failures, stage state, duration
- **Drift and Prediction Monitoring** — drift shares, prediction log, monitoring health
- **Training Pipeline** — summary, artifacts, stage state, duration, metrics
- **Pipeline Health and Freshness** — training freshness, pipeline freshness, hosted sync
- **Inference Operations** — latency percentiles, request rate, error rate

Panel queries and alert rule panel references are preserved.

Closes #272