### PR TITLE
feat(ui): prepare the rider console for final delivery

### DIFF
--- a/src/foehncast/inference_pipeline/dashboard.py
+++ b/src/foehncast/inference_pipeline/dashboard.py
@@ -109,10 +109,7 @@ def build_ranking_frame(ranked_spots: list[dict[str, Any]]) -> pd.DataFrame:
 def horizon_caption(hours: int) -> str:
     """Describe the currently supported live forecast window."""
     unit = "hour" if hours == 1 else "hours"
-    return (
-        "The live demo follows the current inference contract: "
-        f"{hours} forecast {unit} from the active Open-Meteo pull."
-    )
+    return f"Forecast window: {hours} {unit} from the current Open-Meteo pull."
 
 
 def load_dashboard_data(spot_ids: list[str] | None = None) -> dict[str, Any]:

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -123,4 +123,4 @@ def test_load_dashboard_data_combines_predictions_rankings_and_metadata(
 
 
 def test_horizon_caption_describes_hour_based_contract() -> None:
-    assert "14 forecast hours" in dashboard.horizon_caption(14)
+    assert "14 hours" in dashboard.horizon_caption(14)

--- a/ui/app.py
+++ b/ui/app.py
@@ -1,4 +1,4 @@
-"""Streamlit dashboard for the FoehnCast live demo."""
+"""Streamlit rider console for FoehnCast spot recommendations."""
 
 from __future__ import annotations
 
@@ -15,7 +15,7 @@ from foehncast.inference_pipeline.dashboard import (
 )
 
 st.set_page_config(
-    page_title="FoehnCast Live Demo",
+    page_title="FoehnCast Rider Console",
     layout="wide",
     initial_sidebar_state="expanded",
 )
@@ -247,12 +247,12 @@ def main() -> None:
     st.markdown(
         """
         <section class="hero-shell">
-          <p class="eyebrow">MS3 Live Demo</p>
-          <h1 class="hero-title">FoehnCast Rider Console</h1>
+          <p class="eyebrow">FoehnCast</p>
+          <h1 class="hero-title">Rider Console</h1>
           <p class="hero-lede">
-            One rider profile, six validated Swiss spots, one current serving model. This dashboard
-            reuses the live prediction and ranking modules behind the API so the demo stays on the
-            same inference path the repository already validates.
+            One rider profile, six Swiss spots, one served model. Ranked recommendations
+            combine live Open-Meteo forecasts, engineered wind features, drive-time estimates,
+            and the current champion model through the same inference path the API serves.
           </p>
         </section>
         """,
@@ -264,15 +264,15 @@ def main() -> None:
     default_spot_ids = [spot["id"] for spot in available_spots]
 
     with st.sidebar:
-        st.markdown("### Demo Scope")
+        st.markdown("### Spot Selection")
         selected_spot_ids = st.multiselect(
-            "Spot selector",
+            "Spots",
             options=default_spot_ids,
             default=default_spot_ids,
             format_func=lambda spot_id: _spot_label(spot_lookup, spot_id),
-            help="Choose the configured spots you want in the live ranking run.",
+            help="Choose the configured spots to include in the live ranking.",
         )
-        if st.button("Refresh live forecast", use_container_width=True):
+        if st.button("Refresh forecast", use_container_width=True):
             _live_dashboard_data.clear()
 
     if not selected_spot_ids:
@@ -281,12 +281,12 @@ def main() -> None:
 
     try:
         with st.spinner(
-            "Loading live forecasts, drive times, and ranked recommendations..."
+            "Loading forecasts, drive times, and ranked recommendations..."
         ):
             dashboard_data = _live_dashboard_data(tuple(selected_spot_ids))
     except Exception as exc:
         st.error(
-            "The live demo could not load the current forecast-model stack. "
+            "Could not load the current forecast and model stack. "
             "Check MLflow, network access, and the configured serving model alias."
         )
         st.exception(exc)
@@ -302,7 +302,7 @@ def main() -> None:
     with st.sidebar:
         st.markdown(_profile_card(rider_profile), unsafe_allow_html=True)
         st.caption(
-            "Drive-time ranking uses the configured rider home in config.yaml and live OSRM route estimates."
+            "Drive-time ranking uses the rider home from config.yaml and live OSRM route estimates."
         )
 
     metric_columns = st.columns(4)
@@ -325,14 +325,14 @@ def main() -> None:
     left_column, right_column = st.columns([1.25, 1.0], gap="large")
 
     with left_column:
-        st.subheader("Ranked Spot Recommendations")
+        st.subheader("Ranked Recommendations")
         st.dataframe(
             build_ranking_frame(ranked_spots),
             use_container_width=True,
             hide_index=True,
         )
         st.caption(
-            "Ranking combines peak forecast quality, rideable duration, and ride-to-drive return for the configured rider."
+            "Ranking combines peak forecast quality, rideable duration, and ride-to-drive return."
         )
 
     with right_column:


### PR DESCRIPTION
Closes #274

### What

Transition the Streamlit rider console from MS3 demo branding to the final delivery product surface. The UI role stays the same: a rider-facing evaluation surface that reuses the real inference path, not an operator dashboard.

### Changes

- Replace `MS3 Live Demo` eyebrow with `FoehnCast` product identity
- Rename page title to `FoehnCast Rider Console`
- Refine hero text to describe the product rather than the demo milestone
- Tighten sidebar labels (`Spot Selection`, not `Demo Scope`)
- Shorten captions and error messages to remove demo-centric language
- Simplify `horizon_caption()` to a cleaner format
- Update the horizon caption test to match

### Scope decisions

The rider console remains a local Streamlit surface that imports directly from the inference pipeline modules. It is not served via Docker Compose or exposed publicly. The `/features/online/demo` HTML page and Grafana operator dashboard retain their existing roles alongside it.

389 tests passing.