### PR TITLE
fix(dvc): fix dvc repro errors and add param key contract test

### DIFF
--- a/dvc.lock
+++ b/dvc.lock
@@ -1,0 +1,214 @@
+schema: '2.0'
+stages:
+  curate:
+    cmd: python -m foehncast.dvc_stages curate --dataset train
+    deps:
+    - path: config.yaml
+      hash: md5
+      md5: cce93314edb22eb7d8ebe903134f6bc1
+      size: 6881
+    - path: src/foehncast/dvc_stages.py
+      hash: md5
+      md5: da9f98cfd4870e0e2ea47794b8614bc4
+      size: 6010
+    - path: src/foehncast/feature_pipeline/engineer.py
+      hash: md5
+      md5: 2a15251b4e9b6b5983f1a17fe37742c2
+      size: 6335
+    - path: src/foehncast/feature_pipeline/ingest.py
+      hash: md5
+      md5: 3f7bc457401217f607c5e66abab267bd
+      size: 5487
+    - path: src/foehncast/feature_pipeline/store.py
+      hash: md5
+      md5: ae0e1ce70055a6c6dc514b3cfa00b7b9
+      size: 13428
+    - path: src/foehncast/feature_pipeline/validate.py
+      hash: md5
+      md5: dee15887040f2c5f34d716c411467076
+      size: 3747
+    params:
+      config.yaml:
+        model.features:
+        - wind_speed_10m
+        - wind_speed_80m
+        - wind_gusts_10m
+        - temperature_2m
+        - relative_humidity_2m
+        - hour_of_day_sin
+        - hour_of_day_cos
+        - day_of_year_sin
+        - day_of_year_cos
+        - wind_direction_10m_sin
+        - wind_direction_10m_cos
+        - wind_steadiness
+        - gust_excess_10m
+        - shore_alignment
+        spots:
+        - id: silvaplana
+          name: Silvaplana
+          lat: 46.45
+          lon: 9.79
+          altitude_m: 1800
+          shore_orientation_deg: 225
+          ideal_wind_dir_min: 180
+          ideal_wind_dir_max: 270
+          difficulty: intermediate
+          water_type: lake
+          canton: GR
+        - id: urnersee
+          name: Urnersee
+          lat: 46.93
+          lon: 8.6
+          altitude_m: 434
+          shore_orientation_deg: 180
+          ideal_wind_dir_min: 150
+          ideal_wind_dir_max: 210
+          difficulty: intermediate
+          water_type: lake
+          canton: UR
+        - id: neuchatel
+          name: Lac de Neuchatel
+          lat: 46.85
+          lon: 6.85
+          altitude_m: 429
+          shore_orientation_deg: 270
+          ideal_wind_dir_min: 200
+          ideal_wind_dir_max: 310
+          difficulty: beginner
+          water_type: lake
+          canton: NE
+        - id: bodensee
+          name: Bodensee
+          lat: 47.63
+          lon: 9.37
+          altitude_m: 395
+          shore_orientation_deg: 180
+          ideal_wind_dir_min: 180
+          ideal_wind_dir_max: 300
+          difficulty: beginner
+          water_type: lake
+          canton: TG
+        - id: walensee
+          name: Walensee
+          lat: 47.12
+          lon: 9.22
+          altitude_m: 419
+          shore_orientation_deg: 270
+          ideal_wind_dir_min: 220
+          ideal_wind_dir_max: 320
+          difficulty: intermediate
+          water_type: lake
+          canton: SG
+        - id: thunersee
+          name: Thunersee
+          lat: 46.72
+          lon: 7.72
+          altitude_m: 558
+          shore_orientation_deg: 270
+          ideal_wind_dir_min: 220
+          ideal_wind_dir_max: 330
+          difficulty: advanced
+          water_type: lake
+          canton: BE
+    outs:
+    - path: data/train
+      hash: md5
+      md5: d25a37e5f1bef05ffed930e973561045.dir
+      size: 196480
+      nfiles: 6
+  train:
+    cmd: python -m foehncast.dvc_stages train --dataset train
+    deps:
+    - path: config.yaml
+      hash: md5
+      md5: cce93314edb22eb7d8ebe903134f6bc1
+      size: 6881
+    - path: data/train
+      hash: md5
+      md5: d25a37e5f1bef05ffed930e973561045.dir
+      size: 196480
+      nfiles: 6
+    - path: src/foehncast/dvc_stages.py
+      hash: md5
+      md5: da9f98cfd4870e0e2ea47794b8614bc4
+      size: 6010
+    - path: src/foehncast/training_pipeline/evaluate.py
+      hash: md5
+      md5: 56b6fdacd4fa1e03b964e4f0907bb941
+      size: 3231
+    - path: src/foehncast/training_pipeline/label.py
+      hash: md5
+      md5: 8070226feca8d24598d2b411a6479705
+      size: 3281
+    - path: src/foehncast/training_pipeline/train.py
+      hash: md5
+      md5: 4832c42ad6651faab684afa90ffcd507
+      size: 5735
+    params:
+      config.yaml:
+        model:
+          algorithm: random_forest
+          target: quality_index
+          raw_features:
+          - wind_speed_10m
+          - wind_speed_80m
+          - wind_speed_120m
+          - wind_direction_10m
+          - wind_direction_80m
+          - wind_gusts_10m
+          - temperature_2m
+          - precipitation
+          - relative_humidity_2m
+          - cloud_cover
+          - pressure_msl
+          - cape
+          - lifted_index
+          engineered_features:
+          - hour_of_day_sin
+          - hour_of_day_cos
+          - day_of_year_sin
+          - day_of_year_cos
+          - wind_direction_10m_sin
+          - wind_direction_10m_cos
+          - wind_steadiness
+          - gust_excess_10m
+          - gust_factor
+          - shore_alignment
+          features:
+          - wind_speed_10m
+          - wind_speed_80m
+          - wind_gusts_10m
+          - temperature_2m
+          - relative_humidity_2m
+          - hour_of_day_sin
+          - hour_of_day_cos
+          - day_of_year_sin
+          - day_of_year_cos
+          - wind_direction_10m_sin
+          - wind_direction_10m_cos
+          - wind_steadiness
+          - gust_excess_10m
+          - shore_alignment
+          test_size: 0.2
+          random_state: 42
+        rider:
+          weight_kg: 80
+          home_lat: 47.02
+          home_lon: 8.65
+          home_location: Schwyz
+          quiver_m2:
+          - 5
+          - 7
+          - 8
+          - 10
+          - 12
+    outs:
+    - path: reports/feature_importance.png
+      hash: md5
+      md5: a50fa2f74a1ea58923d10646ae4f057c
+      size: 33934
+    - path: reports/train_metrics.json
+      hash: md5
+      md5: 63d5bd4723c194d2f5ec29ed6492fe4c
+      size: 218

--- a/dvc.yaml
+++ b/dvc.yaml
@@ -28,7 +28,7 @@ stages:
     params:
       - config.yaml:
           - model
-          - rider_profile
+          - rider
     metrics:
       - reports/train_metrics.json:
           cache: false
@@ -36,5 +36,5 @@ stages:
       - reports/feature_importance.png:
           cache: false
 
-params:
+vars:
   - dataset: train

--- a/src/foehncast/dvc_stages.py
+++ b/src/foehncast/dvc_stages.py
@@ -1,8 +1,4 @@
-"""Thin CLI entry points for DVC pipeline stages.
-
-These wrappers call the same pipeline functions that Airflow uses, but write
-outputs to the local filesystem so DVC can track them as stage artefacts.
-"""
+"""CLI entry points for DVC stages (curate + train)."""
 
 from __future__ import annotations
 
@@ -19,7 +15,7 @@ def _project_root() -> Path:
 
 
 def curate(dataset: str) -> None:
-    """Run the feature pipeline for all configured spots and export to local parquet."""
+    """Fetch, engineer and validate features for every spot, write parquet files."""
     from foehncast.config import get_spots
     from foehncast.feature_pipeline.engineer import engineer_features
     from foehncast.feature_pipeline.ingest import fetch_all_spots
@@ -33,7 +29,7 @@ def curate(dataset: str) -> None:
     spot_config = {spot["id"]: spot for spot in spots}
 
     print(f"Fetching forecasts for {len(spot_ids)} spots...")
-    forecast_frames = fetch_all_spots(spot_ids)
+    forecast_frames = fetch_all_spots()
 
     curated_count = 0
     for spot_id, forecast_df in forecast_frames.items():
@@ -46,7 +42,7 @@ def curate(dataset: str) -> None:
             shore_orientation_deg=spot_config[spot_id].get("shore_orientation_deg", 0),
         )
 
-        validation = run_validation(feature_df)
+        validation = run_validation(feature_df, spot_id)
         if not validation.is_valid:
             print(f"  {spot_id}: validation failed, skipping")
             continue
@@ -64,7 +60,7 @@ def curate(dataset: str) -> None:
 
 
 def train(dataset: str) -> None:
-    """Train the model from local curated data and write metrics to reports/."""
+    """Train on curated parquet data and write metrics + plots to reports/."""
     from foehncast.config import get_model_config, get_rider_config
     from foehncast.training_pipeline.evaluate import compute_metrics
     from foehncast.training_pipeline.label import label_dataset
@@ -125,7 +121,7 @@ def train(dataset: str) -> None:
     metrics_path.write_text(json.dumps(metrics, indent=2) + "\n")
     print(f"Metrics written to {metrics_path}")
 
-    # Feature importance plot
+    # feature importance plot
     if hasattr(model, "feature_importances_"):
         import matplotlib
 
@@ -152,16 +148,13 @@ def train(dataset: str) -> None:
 
 
 def main() -> None:
-    parser = argparse.ArgumentParser(
-        prog="python -m foehncast.dvc_stages",
-        description="DVC pipeline stage entry points",
-    )
+    parser = argparse.ArgumentParser(prog="python -m foehncast.dvc_stages")
     subparsers = parser.add_subparsers(dest="stage", required=True)
 
-    curate_parser = subparsers.add_parser("curate", help="Run feature curation")
+    curate_parser = subparsers.add_parser("curate")
     curate_parser.add_argument("--dataset", default="train")
 
-    train_parser = subparsers.add_parser("train", help="Run model training")
+    train_parser = subparsers.add_parser("train")
     train_parser.add_argument("--dataset", default="train")
 
     args = parser.parse_args()

--- a/tests/test_dvc_contract.py
+++ b/tests/test_dvc_contract.py
@@ -1,4 +1,4 @@
-"""Tests for the DVC pipeline definition and stage contract."""
+"""Contract tests for dvc.yaml and the DVC stage entry points."""
 
 from __future__ import annotations
 
@@ -83,7 +83,7 @@ def test_dvc_train_command_uses_dvc_stages_module() -> None:
 
 
 def test_dvc_curate_covers_feature_pipeline_stages() -> None:
-    """The curate stage wraps all four feature-pipeline stages."""
+    """Curate stage depends on ingest, engineer, validate."""
     dvc = _load_dvc_yaml()
     deps = dvc["stages"]["curate"]["deps"]
     dep_text = " ".join(deps)
@@ -93,7 +93,7 @@ def test_dvc_curate_covers_feature_pipeline_stages() -> None:
 
 
 def test_dvc_train_covers_training_pipeline_stages() -> None:
-    """The train stage wraps train + evaluate (register stays in Airflow)."""
+    """Train stage depends on train, evaluate, label."""
     dvc = _load_dvc_yaml()
     deps = dvc["stages"]["train"]["deps"]
     dep_text = " ".join(deps)
@@ -130,3 +130,30 @@ def test_dvc_stages_module_is_importable() -> None:
     assert hasattr(dvc_stages, "curate")
     assert hasattr(dvc_stages, "train")
     assert hasattr(dvc_stages, "main")
+
+
+# ---------------------------------------------------------------------------
+# 6. DVC param keys actually exist in config.yaml
+# ---------------------------------------------------------------------------
+
+
+def test_dvc_params_reference_valid_config_keys() -> None:
+    """Catch typos like rider_profile vs rider in DVC param references."""
+    dvc = _load_dvc_yaml()
+    config = yaml.safe_load((REPO_ROOT / "config.yaml").read_text())
+
+    for stage_name, stage in dvc["stages"].items():
+        for param_entry in stage.get("params", []):
+            if not isinstance(param_entry, dict):
+                continue
+            for _file, keys in param_entry.items():
+                if keys is None:
+                    continue
+                for key in keys:
+                    # walk dotted keys like "model.features"
+                    node = config
+                    for part in key.split("."):
+                        assert isinstance(node, dict) and part in node, (
+                            f"{stage_name}: param '{key}' not in config.yaml"
+                        )
+                        node = node[part]


### PR DESCRIPTION
Fixes four issues that prevented `dvc repro` from completing:

- Top-level `params:` → `vars:` (DVC 3.x syntax)
- `rider_profile` → `rider` (wrong config key name)
- `fetch_all_spots(spot_ids)` → `fetch_all_spots()` (function takes no args)
- `run_validation(feature_df)` → `run_validation(feature_df, spot_id)` (missing arg)

Also adds `dvc.lock` and a contract test that catches param key drift between `dvc.yaml` and `config.yaml`.

Validated: `dvc repro` runs both stages end-to-end, 402 tests green, lint clean.

Closes #284