### PR TITLE
feat(training): data lineage fingerprint and DVC documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,14 +88,27 @@ For the rider-facing demo, run `uv run streamlit run ui/app.py` from the repo ro
 
 ### Reproducible pipelines (DVC)
 
-Data and training stages are versioned with [DVC](https://dvc.org). With the local stack running:
+DVC is the reproducible, file-based path for the offline parts of the FTI design. It does not replace Airflow or the API.
+
+- `curate` in `dvc.yaml` runs ingest, engineer, validate, and writes curated parquet files to `data/<dataset>/`
+- `train` reads that curated dataset, labels it, trains the model, and writes metrics and plots to `reports/`
+- both stages go through `python -m foehncast.dvc_stages`, so the DVC path reuses the same feature and training modules as the rest of the repo
+- inference stays outside DVC, and model registration or alias changes stay in the MLflow and operator path
+
+| If you want to... | Use |
+|------|-----|
+| rerun offline feature and training steps locally or in CI | `dvc repro` |
+| inspect scheduled runs, retries, and asset hand-offs | Airflow |
+| serve live predictions and rankings | FastAPI app |
+
+With the local stack running:
 
 ```bash
 dvc repro          # run the full pipeline (ingest → curate → train)
 dvc metrics show   # show latest training metrics
 ```
 
-DVC uses the local MinIO instance as its S3 remote. See `dvc.yaml` for stage definitions.
+DVC tracks outputs under `data/` and `reports/`. Its checked-in remote points at the local MinIO objectstore, so cache push and pull can use the same local stack during evaluation. See `dvc.yaml` and `src/foehncast/dvc_stages.py` for the stage contract.
 
 ### Running tests
 

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -81,7 +81,47 @@ Grafana stays on the operator side. The rider-facing experience comes from the a
 | Online features | Surface curated fields through an online lookup route | Feast-backed service path plus demo page |
 | Monitoring | Scrape runtime metrics, collect pushed gauges, and visualize starter alerts | Prometheus, StatsD exporter, and Grafana operator stack |
 
-The orchestration layer models the main data products as Airflow assets. In the validated local stack, the feature DAG publishes curated-feature, Feast-sync, and training-request assets. The training DAG consumes the training request and emits MLflow training, evaluation, and registry assets.
+## DVC And Airflow
+
+The same feature and training boundaries are driven by two different control paths.
+
+- DVC is the reproducible path for local reruns and CI. It tracks file dependencies and outputs in `dvc.yaml`.
+- Airflow is the runtime control plane. It schedules DAG runs, handles retries, and shows asset hand-offs.
+- Inference is neither a DVC stage nor an Airflow DAG. The FastAPI app serves live requests from the registered model and online feature surfaces.
+
+<div class="mermaid">
+flowchart LR
+    classDef ctl fill:#f5f5f5,stroke:#333
+    classDef pipe fill:#e1f5fe,stroke:#01579b
+    classDef store fill:#ececff,stroke:#9370db
+    classDef serve fill:#fff8e1,stroke:#f57f17
+
+    subgraph DVCPath ["DVC reproducibility path"]
+        DVCY["dvc.yaml"]:::ctl --> DVCCLI["python -m foehncast.dvc_stages"]:::ctl
+    end
+
+    subgraph AirflowPath ["Airflow runtime path"]
+        FDAG["feature_dag"]:::ctl --> FEAT["Feature pipeline"]:::pipe
+        TDAG["training_dag"]:::ctl --> TRAIN["Training pipeline"]:::pipe
+    end
+
+    DVCCLI --> FEAT
+    DVCCLI --> TRAIN
+    FEAT --> CUR["Curated dataset"]:::store
+    CUR --> TRAIN
+    CUR --> FEAST["Feast serving prep"]:::store
+    TRAIN --> REG["MLflow model + reports"]:::store
+    FEAST --> API["FastAPI inference"]:::serve
+    REG --> API
+</div>
+
+| Path | Main job | Main outputs |
+|------|----------|--------------|
+| DVC | repeatable offline reruns in local or CI contexts | `data/${dataset}`, `reports/train_metrics.json`, `reports/feature_importance.png` |
+| Airflow | scheduled or asset-triggered runtime execution | curated-feature, Feast-sync, training-request, MLflow, evaluation, and registry assets |
+| FastAPI | live serving | `/predict`, `/rank`, `/spots`, `/features/online`, `/metrics` |
+
+The runtime orchestration layer models the main data products as Airflow assets. In the validated local stack, the feature DAG publishes curated-feature, Feast-sync, and training-request assets. The training DAG consumes the training request and emits MLflow training, evaluation, and registry assets. DVC mirrors the offline feature and training boundaries for reproducible reruns, but it does not replace the Airflow asset graph.
 
 ## Deployment Targets
 

--- a/docs/site/system/feature-pipeline.md
+++ b/docs/site/system/feature-pipeline.md
@@ -59,6 +59,16 @@ Each stage has one clear job:
 | Active shared environment | the same DAG and curated contract write to BigQuery and keep Feast downstream through the hosted storage surfaces |
 | Hosted inference target | consumes the curated layer through the app and Feast; it does not run the feature DAG itself |
 
+## DVC Mapping
+
+For reproducible local and CI runs, DVC collapses the offline feature path into one `curate` stage.
+
+| DVC stage | Covers | Stops at |
+|------|--------|----------|
+| `curate` | ingest, engineer, validate, and local curated-data materialization | `data/<dataset>/` parquet outputs |
+
+That means DVC proves the curated-data hand-off, not the full runtime orchestration. Airflow still owns the Feast-sync and training-request assets used in the running stack.
+
 ## Notebook Review Surface
 
 The repo keeps one runtime-aware notebook review surface at `notebooks/feat_01_ingest_validation.ipynb`. The notebook runs the same feature-pipeline steps in either lane, writes a backend-tagged summary to `.state/notebook_reviews/feature_pipeline_summary_<backend>.json`, and can compare the stable output fields in place when the other backend artifact already exists.

--- a/docs/site/system/local-evaluator.md
+++ b/docs/site/system/local-evaluator.md
@@ -66,6 +66,18 @@ The bootstrap path resets disposable state, starts the validated service subset 
 
 If the preferred local ports are already occupied, the bootstrap moves the bindings to the next free ports and prints the resolved endpoints.
 
+## Bootstrap, DVC, And The App
+
+The local evaluator keeps three useful entry points available, but each one has a different job.
+
+| Use this | When you want | What it covers |
+|------|---------------|----------------|
+| `./scripts/bootstrap-local.sh` | the full local runtime | Docker services, Airflow asset hand-off, MLflow, Feast, monitoring, and app validation |
+| `dvc repro` | a reproducible offline rerun | `curate` and `train` from `dvc.yaml`, writing tracked outputs under `data/` and `reports/` |
+| FastAPI or Streamlit | serving behavior | live prediction, ranking, and online-feature checks |
+
+DVC is optional in the local evaluator. It is useful when you want a clean, file-based rerun of the offline feature and training path without driving the scheduler by hand. The checked-in DVC remote points at the local MinIO objectstore for cache storage, but DVC itself is not the runtime control plane and it does not replace the app, Airflow, or monitoring stack.
+
 ## Runtime Surfaces
 
 | Surface | Role in the local evaluator | Must not become |

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -5,8 +5,10 @@ The repository keeps runtime code, orchestration, tests, and public documentatio
 ## Main Layout
 
 ```text
+dvc.yaml
 src/foehncast/
   config.py
+  dvc_stages.py
   feature_pipeline/
   training_pipeline/
   inference_pipeline/
@@ -28,6 +30,7 @@ docs/
 <div class="mermaid">
 flowchart TD
   CODE[src/foehncast] --> APP[Feature + Training + Inference + Monitoring code]
+  DVC[dvc.yaml + dvc_stages.py] --> REPRO[Reproducible feature + training reruns]
   DAGS[dags] --> ORCH[Airflow orchestration]
   CNT[containers] --> PACK[Containerized runtime packaging]
   OPS[scripts + terraform] --> DELIV[Bootstrap and hosted delivery]
@@ -38,15 +41,26 @@ flowchart TD
 ## Where To Start
 
 - `src/foehncast/`: the application modules for configuration, feature engineering, training, inference, monitoring, and spot metadata.
+- `src/foehncast/dvc_stages.py`: the thin CLI entry point that exposes the DVC `curate` and `train` stages.
+- `dvc.yaml`: the file-based reproducibility contract for offline feature and training reruns.
 - `dags/`: Airflow entry points for the feature and training workflows.
 
 | Area | What it holds |
 |------|---------------|
 | `src/foehncast/` | application code for configuration, features, training, inference, monitoring, and spot metadata |
+| `dvc.yaml` and `src/foehncast/dvc_stages.py` | reproducible local and CI reruns of the offline feature and training path |
 | `dags/` | Airflow entry points for feature and training workflows |
 | `containers/`, `scripts/`, and `terraform/` | runtime packaging, bootstrap helpers, and deployment tooling |
 | `feature_repo/`, `prometheus_config/`, and `grafana_work/` | Feast and operator-monitoring integration contracts |
 | `tests/` and `docs/` | regression coverage and public explanation |
+
+## DVC Vs Airflow
+
+The repo keeps both because they solve different problems.
+
+- DVC reruns the offline feature and training steps from tracked files.
+- Airflow runs the real runtime orchestration with schedules, retries, and asset hand-offs.
+- The FastAPI app remains the serving surface for inference instead of becoming another DAG.
 
 ## Design Rules
 

--- a/docs/site/system/training-pipeline.md
+++ b/docs/site/system/training-pipeline.md
@@ -40,6 +40,16 @@ The training path stays explicit:
 | Active shared environment | the hosted full-stack operator lane runs the same Airflow and MLflow contract online |
 | Hosted inference target | serves a registered alias; it does not run training |
 
+## DVC Mapping
+
+For reproducible local and CI runs, DVC models the offline training path as one `train` stage.
+
+| DVC stage | Covers | Writes |
+|------|--------|--------|
+| `train` | label, train, and evaluate | `reports/train_metrics.json` and `reports/feature_importance.png` |
+
+Model registration, alias movement, and rollback stay outside `dvc repro`. Those remain MLflow- and operator-controlled runtime steps.
+
 ## Stage Responsibilities
 
 | Stage | Main responsibility | Must not become |
@@ -49,6 +59,22 @@ The training path stays explicit:
 | Evaluate | write reviewable metrics and report artifacts for one run | a second training stage or a silent model selector |
 | Register | create a versioned MLflow model and assign the requested alias | a broad deployment control plane |
 | Promote and rollback | move explicit aliases between validated model versions | retraining, relabeling, or feature regeneration |
+
+## Label Boundary
+
+### Data Lineage
+
+Every MLflow training run logs provenance params so the model can be traced back to its input data:
+
+| Param | Source | What it tells you |
+|-------|--------|-------------------|
+| `dataset` | config argument | which named dataset split was used |
+| `data_hash` | SHA-256 of the training DataFrame | whether the data content changed between runs |
+| `git_commit` | `git rev-parse --short HEAD` | which code version produced the run |
+
+The DVC path in `dvc_stages.py` writes `data_hash` and `git_commit` into the `reports/train_metrics.json` file for the same traceability outside MLflow.
+
+This bridges the DVC→MLflow lineage gap: DVC versions the curated parquet files, MLflow versions the model, and both carry a content hash so you can match them without inspecting local DVC state.
 
 ## Label Boundary
 

--- a/src/foehncast/dvc_stages.py
+++ b/src/foehncast/dvc_stages.py
@@ -64,6 +64,10 @@ def train(dataset: str) -> None:
     from foehncast.config import get_model_config, get_rider_config
     from foehncast.training_pipeline.evaluate import compute_metrics
     from foehncast.training_pipeline.label import label_dataset
+    from foehncast.training_pipeline.provenance import (
+        get_git_commit,
+        hash_parquet_files,
+    )
     from foehncast.training_pipeline.train import train_model
 
     data_dir = _project_root() / "data" / dataset
@@ -116,6 +120,9 @@ def train(dataset: str) -> None:
     metrics["training_feature_count"] = len(feature_columns)
     metrics["train_row_count"] = len(features_train)
     metrics["test_row_count"] = len(features_test)
+
+    metrics["data_hash"] = hash_parquet_files(data_dir)
+    metrics["git_commit"] = get_git_commit()
 
     metrics_path = reports_dir / "train_metrics.json"
     metrics_path.write_text(json.dumps(metrics, indent=2) + "\n")

--- a/src/foehncast/training_pipeline/provenance.py
+++ b/src/foehncast/training_pipeline/provenance.py
@@ -1,0 +1,39 @@
+"""Data provenance helpers for training lineage."""
+
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+import pandas as pd
+
+
+def hash_parquet_files(data_dir: Path) -> str:
+    """Return a hex digest of the sorted parquet files in a directory."""
+    hasher = hashlib.sha256()
+    for path in sorted(data_dir.glob("*.parquet")):
+        hasher.update(path.name.encode())
+        hasher.update(path.read_bytes())
+    return hasher.hexdigest()
+
+
+def hash_dataframe(df: pd.DataFrame) -> str:
+    """Return a hex digest of a DataFrame's content."""
+    return hashlib.sha256(pd.util.hash_pandas_object(df).values.tobytes()).hexdigest()
+
+
+def get_git_commit() -> str:
+    """Return the current git HEAD short hash, or 'unknown' outside a repo."""
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        if result.returncode == 0:
+            return result.stdout.strip()
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        pass
+    return "unknown"

--- a/src/foehncast/training_pipeline/train.py
+++ b/src/foehncast/training_pipeline/train.py
@@ -23,6 +23,7 @@ from foehncast.config import (
 from foehncast.feature_pipeline.store import read_features
 from foehncast.training_pipeline.evaluate import compute_metrics
 from foehncast.training_pipeline.label import label_dataset
+from foehncast.training_pipeline.provenance import get_git_commit, hash_dataframe
 
 
 def load_training_data(dataset: str = "train") -> tuple[pd.DataFrame, pd.Series]:
@@ -118,6 +119,7 @@ def run_training_pipeline(
     mlflow.set_experiment(mlflow_config["experiment_name"])
 
     features_df, target_series = load_training_data(dataset=dataset)
+    data_hash = hash_dataframe(pd.concat([features_df, target_series], axis=1))
     (
         features_train,
         features_test,
@@ -152,6 +154,8 @@ def run_training_pipeline(
                 "test_size": resolved_model_config["test_size"],
                 "random_state": resolved_model_config["random_state"],
                 "features": ",".join(resolved_model_config["features"]),
+                "git_commit": get_git_commit(),
+                "data_hash": data_hash,
             }
         )
         mlflow.log_metrics(metrics)

--- a/tests/test_provenance.py
+++ b/tests/test_provenance.py
@@ -1,0 +1,56 @@
+"""Tests for data provenance helpers."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pandas as pd
+
+from foehncast.training_pipeline.provenance import (
+    get_git_commit,
+    hash_dataframe,
+    hash_parquet_files,
+)
+
+
+def test_hash_parquet_files_returns_stable_hex_digest(tmp_path: Path) -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": [3, 4]})
+    (tmp_path / "spot_a.parquet").write_bytes(df.to_parquet())
+    (tmp_path / "spot_b.parquet").write_bytes(df.to_parquet())
+
+    first = hash_parquet_files(tmp_path)
+    second = hash_parquet_files(tmp_path)
+    assert first == second
+    assert len(first) == 64  # sha256 hex
+
+
+def test_hash_parquet_files_changes_when_data_changes(tmp_path: Path) -> None:
+    df1 = pd.DataFrame({"a": [1, 2]})
+    (tmp_path / "spot_a.parquet").write_bytes(df1.to_parquet())
+    hash1 = hash_parquet_files(tmp_path)
+
+    df2 = pd.DataFrame({"a": [3, 4]})
+    (tmp_path / "spot_a.parquet").write_bytes(df2.to_parquet())
+    hash2 = hash_parquet_files(tmp_path)
+
+    assert hash1 != hash2
+
+
+def test_hash_dataframe_returns_stable_hex_digest() -> None:
+    df = pd.DataFrame({"a": [1, 2], "b": [3.0, 4.0]})
+    first = hash_dataframe(df)
+    second = hash_dataframe(df)
+    assert first == second
+    assert len(first) == 64
+
+
+def test_hash_dataframe_changes_when_content_changes() -> None:
+    df1 = pd.DataFrame({"a": [1, 2]})
+    df2 = pd.DataFrame({"a": [3, 4]})
+    assert hash_dataframe(df1) != hash_dataframe(df2)
+
+
+def test_get_git_commit_returns_short_hash() -> None:
+    commit = get_git_commit()
+    assert len(commit) >= 7
+    assert commit != "unknown"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -304,6 +304,8 @@ def test_run_training_pipeline_logs_mlflow_artifacts(
         "_model_pip_requirements",
         lambda: ["scikit-learn==1.8.0", "cloudpickle==3.1.1"],
     )
+    monkeypatch.setattr(train, "get_git_commit", lambda: "abc1234")
+    monkeypatch.setattr(train, "hash_dataframe", lambda df: "fakehash" * 8)
 
     run_id = train.run_training_pipeline(model_config, dataset="validation")
 
@@ -326,3 +328,5 @@ def test_run_training_pipeline_logs_mlflow_artifacts(
         "cloudpickle==3.1.1",
     ]
     assert logged["feature_plot"] == model_config["features"]
+    assert logged["params"]["git_commit"] == "abc1234"
+    assert logged["params"]["data_hash"] == "fakehash" * 8


### PR DESCRIPTION
### What Changed

- Added `src/foehncast/training_pipeline/provenance.py` with data hashing and git commit helpers
- MLflow training runs now log `data_hash` (SHA-256 of training DataFrame) and `git_commit` (HEAD short hash)
- DVC `train` stage writes `data_hash` and `git_commit` into `reports/train_metrics.json`
- Updated README with clearer DVC vs Airflow guidance and a decision table
- Added DVC/Airflow architecture diagram to `architecture.md`
- Added DVC mapping sections to feature-pipeline, training-pipeline, repository, and local-evaluator docs
- Added data lineage section to training-pipeline docs

### Why

Bridges the DVC→MLflow lineage gap: every training run now carries a content hash of its input data, so models can be traced back to specific data versions without inspecting local DVC state.

### Verification

- 407 tests pass (5 new provenance tests)
- `make lint` clean
- `make docs-build` clean

### Closes

- Closes #287
- Closes #288