### PR TITLE
docs(monitoring,inference): align docs with implemented monitoring stack

### DIFF
--- a/docs/site/system/inference-pipeline.md
+++ b/docs/site/system/inference-pipeline.md
@@ -1,14 +1,14 @@
 # Inference Pipeline
 
-FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs locally, on Cloud Run, and on the private operator lane. Cloud Run is the shared public API. The operator-lane app stays private and supports internal checks on the hosted operator surface.
+FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs locally, on Cloud Run, and on the private operator lane. Cloud Run is the shared public API. The operator-lane app stays private for internal checks.
 
 This page describes what the running app owns and what stays optional or operator-controlled.
 
 !!! note "Scope"
 
     This page describes the validated inference-path contract.
-    It does not redefine the hosted build or orchestration plan.
-    The serving contract stays stable even as the surrounding hosted control plane moves toward Cloud Build and Cloud Composer.
+    It does not redefine orchestration or the hosted build.
+    The serving contract stays stable regardless of hosted control-plane changes.
 
 ## Inference Shape
 
@@ -56,13 +56,13 @@ flowchart LR
     OUT --> MON
 </div>
 
-The important boundary is that inference stays request-focused:
+Inference stays request-focused:
 
 - the app resolves configured spots and fetches fresh forecast data on demand
 - the serving model is loaded from the registry alias that represents the live contract
 - prediction and ranking reuse the same forecast payload instead of forking into separate pipelines
 - the Feast lookup path stays optional and does not gate the main prediction surface
-- monitoring is triggered from the request path, but the operator metrics surface stays separate
+- monitoring is triggered from the request path but the operator metrics surface stays separate
 
 ## Endpoint Responsibilities
 
@@ -152,18 +152,22 @@ The monitoring hand-off is:
 
 This keeps the inference service responsible for request-side facts while leaving dashboards, alert rules, and long-range operator review to the monitoring stack.
 
-## Serving Targets
+## Runtime Role
 
-The same FastAPI app runs in the local evaluator, on Cloud Run, and on the private operator host. Cloud Run owns the shared public API. The operator host keeps the app available only for private checks next to the other hosted operator services.
+| Runtime mode | Inference role |
+|------|---------------------|
+| Local evaluator | FastAPI app serves predictions from locally-registered MLflow model |
+| Cloud Run | shared public API with the same serving contract |
+| Private operator host | internal checks next to other hosted operator services |
 
 See [Architecture](architecture.md) for the lane summary and [Hosted Full-Stack](hosted-full-stack.md) for the hosted exposure and transition rules.
 
 ## Why This Structure Works
 
-- it keeps live requests narrow enough to verify through simple route and dashboard tests
-- it reuses the shared feature contract instead of inventing a serving-only schema
-- it ties responses back to a concrete registry version without giving the app promotion authority
-- it lets one FastAPI contract run locally, on Cloud Run, and on the hosted operator surface without changing the serving contract
-- it keeps the Feast lookup path useful for integration checks while leaving prediction and ranking available from the core app alone
+- live requests stay narrow enough to verify through simple route and dashboard tests
+- the shared feature contract is reused instead of inventing a serving-only schema
+- responses tie back to a concrete registry version without giving the app promotion authority
+- one FastAPI contract runs locally, on Cloud Run, and on the operator surface without contract changes
+- the Feast lookup path is useful for integration checks while prediction and ranking work from the core app alone
 
 See [Architecture](architecture.md), [Training Pipeline](training-pipeline.md), [Monitoring](monitoring.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding system boundaries.

--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -1,86 +1,167 @@
 # Monitoring
 
-FoehnCast keeps monitoring as an operator surface, not a rider-facing one. The monitoring stack turns pipeline summaries, retained prediction events, drift signals, and hosted sync state into scrapeable metrics and checked-in alert rules.
+FoehnCast keeps monitoring as an operator surface, not a rider-facing one. The monitoring stack turns pipeline summaries, prediction events, drift signals, and serving health into scrapeable metrics and checked-in alert rules.
 
 This page describes what is measured, where the evidence comes from, and how operators verify it.
 
 !!! note "Scope"
 
     This page describes the validated monitoring contract.
-    It focuses on the monitoring evidence and boundaries.
-    It does not redefine the hosted build or orchestration plan.
+    It focuses on monitoring evidence and boundaries.
+    It does not redefine orchestration or the hosted build.
 
 ## Signal Path
 
 <div class="mermaid">
 flowchart LR
-    AIR["Airflow pipeline summaries"] --> APP["App /metrics"]
-    PRED["Prediction requests"] --> LOG["Prediction log and event history"]
-    LOG --> DRIFT["Evidently drift checks"]
-    DRIFT --> STATSD["StatsD exporter"]
-    SYNC["Hosted sync status file"] --> APP
+    subgraph Sources ["Evidence sources"]
+        direction TB
+        AIR["Airflow pipeline summaries"]
+        PRED["Prediction requests"]
+        SYNC["Hosted sync status"]
+    end
+
+    subgraph Processing ["Metric composition"]
+        direction TB
+        APP["App /metrics endpoint"]
+        LOG["Prediction log + event history"]
+        DRIFT["Evidently drift detection"]
+        STATSD["StatsD exporter"]
+    end
+
+    subgraph Operator ["Operator tooling"]
+        direction TB
+        PROM["Prometheus"]
+        GRAFANA["Grafana dashboards"]
+        ALERT["Alert rules"]
+    end
+
+    AIR --> APP
+    PRED --> LOG
+    SYNC --> APP
     LOG --> APP
-    APP --> PROM["Prometheus"]
+    LOG --> DRIFT
+    DRIFT --> STATSD
+    APP --> PROM
     STATSD --> PROM
-    PROM --> GRAFANA["Grafana"]
-    GRAFANA --> DASH["Dashboards and alert rules"]
+    PROM --> GRAFANA
+    PROM --> ALERT
 </div>
 
-The important split is that monitoring consumes persisted or runtime monitoring state after the pipeline and serving paths run. It does not own feature engineering, model scoring, or orchestration itself.
+Monitoring consumes persisted or runtime state after the pipeline and serving paths run. It does not own feature engineering, model scoring, or orchestration.
 
-## Monitoring By Runtime Mode
+## Runtime Role
 
-| Runtime mode | Monitoring contract | Exposure boundary |
-|------|---------------------|-------------------|
-| Local evaluator | app `/metrics`, StatsD drift export, persisted pipeline summaries, and local Grafana dashboards validate the full monitoring path on one machine | local-only |
-| Shared hosted environment | Cloud Run exposes the app-owned `/metrics` contract, while the active operator lane keeps Prometheus, Grafana, hosted sync evidence, and operator review online until the managed hosted control plane absorbs more of that work | operator stack stays private by default |
-| Public docs | rendered metrics snippets, screenshots, checked-in configs, and summary artifacts explain the monitoring contract | no live control planes |
+| Runtime mode | Monitoring contract |
+|------|---------------------|
+| Local evaluator | app `/metrics`, StatsD drift export, persisted pipeline summaries, and local Grafana dashboards validate the full monitoring path on one machine |
+| Shared hosted environment | Cloud Run exposes `/metrics`; the operator lane keeps Prometheus, Grafana, and hosted sync evidence online |
+| Public docs | rendered metrics snippets, checked-in configs, and summary artifacts explain the contract without live control planes |
 
-The public-versus-private surface rule itself is documented in [Interfaces and Surfaces](interfaces-and-surfaces.md). This page stays focused on what monitoring measures and how operators verify it.
+The public-versus-private surface rule is documented in [Interfaces and Surfaces](interfaces-and-surfaces.md).
 
 ## Evidence Sources
 
 | Source | Kind | What it shows |
 |------|------|---------------|
-| `airflow/reports/*.json` | durable evidence | latest feature and training pipeline summaries plus history |
-| `.state/monitoring/prediction-events.jsonl` | durable evidence | retained prediction-event history by model version and the history source for local S3-backed monitoring readers |
-| `foehncast_monitoring.prediction_events` warehouse table | durable evidence | hosted BigQuery-backed prediction-event history for Cloud Run and other cloud-native readers |
-| `.state/monitoring/prediction-log.jsonl` | bounded local working set | recent prediction rows retained for local request-side drift evaluation; not a fallback history source |
-| `.state/hosted-sync/last-success.json` | durable evidence | latest hosted sync success marker |
-| app `/metrics` | composed scrape surface | app-owned monitoring state and summary-derived metrics |
-| StatsD exporter | scrape surface | Evidently-backed drift metrics |
-| Prometheus and Grafana | operator tooling | time-series storage, dashboards, and alert evaluation |
+| `airflow/reports/*.json` | durable | latest feature and training pipeline summaries plus history |
+| `.state/monitoring/prediction-events.jsonl` | durable | prediction-event history by model version (local S3-backed runtimes) |
+| `foehncast_monitoring.prediction_events` BigQuery table | durable | prediction-event history (Cloud Run and cloud-native readers) |
+| `.state/monitoring/prediction-log.jsonl` | bounded working set | recent prediction rows for local drift evaluation; not a history source |
+| `.state/hosted-sync/last-success.json` | durable | latest hosted sync success marker |
+| app `/metrics` | composed scrape | app-owned monitoring state and summary-derived metrics |
+| StatsD exporter `:9102` | scrape | Evidently-backed drift metrics |
 
 Durable files survive restarts and support audits. Runtime counters on `/metrics` describe process health and reset with the process.
 
-## Metrics And Drift
+## Metrics
 
-The serving application publishes one composed Prometheus payload on `/metrics`. It includes feature and training summary metrics, retained prediction-history metrics, hosted sync status metrics, and in-process scheduling or execution counters.
+The serving application publishes one composed Prometheus payload on `/metrics`:
 
-Drift detection is backed by Evidently and exported through StatsD. Feature drift compares reference and current feature datasets on shared columns. Prediction drift compares retained prediction history across reference and recent windows, using retained JSONL history locally and the BigQuery warehouse contract on hosted BigQuery-backed runtimes. Emitted StatsD metrics are mapped into Prometheus as `foehncast_drift_metric`.
+<div class="mermaid">
+flowchart LR
+    subgraph App ["/metrics payload"]
+        direction TB
+        FPS["Feature pipeline summary gauges"]
+        TPS["Training pipeline summary gauges"]
+        PHS["Prediction history gauges"]
+        PMC["Prediction monitoring counters"]
+        HSS["Hosted sync status"]
+        REG["Registered model version"]
+    end
 
-This keeps the operator scrape path simple: Prometheus reads the app surface for app-owned monitoring state and the StatsD exporter for drift metrics.
+    subgraph StatsD ["StatsD path"]
+        direction TB
+        EVD["Evidently drift report"]
+        SDE["StatsD exporter"]
+    end
 
-## Dashboards And Alerts
+    FPS --> PROM["Prometheus"]
+    TPS --> PROM
+    PHS --> PROM
+    PMC --> PROM
+    HSS --> PROM
+    REG --> PROM
+    EVD --> SDE --> PROM
+</div>
 
-Prometheus scrapes the app on `/metrics`, the StatsD exporter, and Grafana itself. Grafana is provisioned from repository-owned dashboards and alert rules.
+Key metric families:
 
-The checked-in dashboard covers pipeline summary counts, stage durations and failures, feature and inference drift share, retained prediction-log size and model coverage, prediction-monitoring schedule failures, and seconds since the last hosted sync.
+| Metric prefix | Source | Labels |
+|------|--------|--------|
+| `foehncast_feature_pipeline_*` | persisted `airflow/reports/` summaries | `dataset`, `storage_backend` |
+| `foehncast_training_pipeline_*` | persisted training summaries | `dataset` |
+| `foehncast_prediction_monitoring_*` | in-process counters (ephemeral) | `endpoint`, `result` |
+| `foehncast_drift_metric` | Evidently via StatsD | column-level drift scores |
+
+Feature and training summary metrics include per-stage state gauges (`succeeded`, `failed`, `not_run`), spot counts, row counts, duration gauges, and failure counts. Prediction monitoring counters track background task scheduling and execution attempts.
+
+## Drift Detection
+
+Drift detection uses Evidently to compare reference and current datasets, then exports results through StatsD.
+
+| Drift kind | Reference | Current | Method |
+|------|-----------|---------|--------|
+| Feature drift | stored reference feature dataset | latest curated features | column-level statistical tests via Evidently |
+| Prediction drift | historical prediction events | recent prediction window | comparison across `prediction-events.jsonl` or the BigQuery warehouse contract |
+
+Emitted StatsD metrics are mapped into Prometheus as `foehncast_drift_metric`. The StatsD host defaults to `127.0.0.1:8125` and can be overridden through `monitoring.statsd_host` in `config.yaml`.
+
+## Scrape Configuration
+
+Prometheus scrapes four targets, all checked in at `prometheus_config/prometheus.yml`:
+
+| Job | Target | What it collects |
+|------|--------|------------------|
+| `foehncast_app` | `app:8000/metrics` | app-owned pipeline, prediction, and sync metrics |
+| `statsd_exporter` | `statsd:9102` | Evidently drift metrics |
+| `grafana` | `grafana:3000/metrics` | Grafana self-monitoring |
+| `prometheus` | `prometheus:9090` | Prometheus self-monitoring |
+
+Scrape interval is 15 seconds. Alert rules are evaluated at the same interval.
 
 ## Alert Rules
 
-The checked-in alert rules cover the main operator failure modes.
+The checked-in rules at `prometheus_config/alerting_rules.yml` cover four failure modes:
 
-| Rule family | What it guards |
-|------|-----------------|
-| Prediction Monitoring Schedule Failures | background monitoring jobs that fail to schedule for one endpoint |
-| Prediction Monitoring Execution Failures | background monitoring jobs that start but fail during execution |
-| Prediction Monitoring Stale Success | endpoints that keep scheduling work without recording a recent successful execution |
-| Feature Stage Failures | persisted feature-pipeline stage failure counts |
-| Training Stage Failures | persisted training-pipeline stage failure counts |
-| Hosted Sync Stale | hosted compose sync status that has not reported a recent success |
+| Alert | Severity | Trigger | What it guards |
+|------|----------|---------|----------------|
+| `AppDown` | critical | app target unreachable for 2 min | serving availability |
+| `HighRequestLatency` | warning | p95 latency above 2 s for 5 min | request performance |
+| `PredictionErrorRateHigh` | warning | error rate above 0.1/s for 5 min | prediction reliability |
+| `StatsdExporterDown` | warning | StatsD target unreachable for 5 min | drift pipeline availability |
 
-The contact point and policy tree stay checked in too, so the alert routing contract is reviewable without depending on a live Grafana instance.
+All rules, the contact point, and the alert routing policy are checked into the repository so the alerting contract is reviewable without a live Grafana instance.
+
+## Dashboards
+
+Grafana is provisioned from the repository-owned dashboard at `grafana_work/dashboards/foehncast-overview.json`. The dashboard covers:
+
+- feature pipeline summary count and latest run success by dataset and backend
+- failed spot counts
+- monitoring target health
+
+Dashboard JSON and provisioning config are version-controlled so the operator view is reproducible from a fresh `docker compose up`.
 
 ## Recovery Evidence
 
@@ -88,33 +169,31 @@ Recovery work should leave durable evidence that operators can compare before an
 
 | Recovery task | Evidence | Check |
 |------|----------|-------|
-| feature retry or backfill | latest feature summary JSON plus history | summary timestamp advances and the feature-stage alert clears |
-| training follow-up after a replay | latest training summary JSON plus history | stage and model version are recorded and the training-stage alert clears |
-| deploy, promote, or rollback handoff retry | latest runtime-release summary JSON plus history | GitHub summary and runtime acknowledgement match |
-| retained operator host refresh verification | latest sync status file | hosted-sync stale signal clears and `/metrics` republishes the new sync state |
+| Feature retry or backfill | latest feature summary JSON | summary timestamp advances |
+| Training follow-up | latest training summary JSON | stage and model version are recorded |
+| Deploy, promote, or rollback | latest runtime-release summary | GitHub summary and runtime acknowledgement match |
+| Hosted sync refresh | latest sync status file | sync state updates on `/metrics` |
 
-Capture the initiating run reference with the summary artifacts: the GitHub workflow URL for reviewed delivery, or the logical date and DAG run id for hosted Airflow recovery.
-
-These checks stay intentionally small. They give operators one repeatable evidence pack without turning the monitoring stack into the system that performs the recovery itself. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the retry and backfill procedures.
+Capture the run reference with the summary artifacts: the GitHub workflow URL for reviewed delivery, or the logical date and DAG run id for hosted Airflow recovery. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for retry and backfill procedures.
 
 ## Public-Safe Evidence
 
-Explain monitoring with rendered evidence, not live control-plane embeds.
+Explain monitoring with rendered evidence, not live control-plane embeds:
 
 - rendered `/metrics` snippets or screenshots
-- checked-in Prometheus scrape config
-- checked-in Grafana dashboards and alert rules
+- checked-in Prometheus scrape and alert configs
+- checked-in Grafana dashboards
 - pipeline summary JSON artifacts under `airflow/reports/`
-- retained prediction-event files under `.state/monitoring/` when showing structure rather than sensitive runtime data
+- prediction-event file structure under `.state/monitoring/`
 
-This keeps the public docs understandable in review while leaving live Grafana, Prometheus, and Airflow as operator tools.
+This keeps public docs understandable in review while leaving live Grafana, Prometheus, and Airflow as operator tools.
 
 ## Why This Structure Works
 
-- it keeps operator monitoring separate from the rider-facing app and docs pages
-- it preserves durable monitoring evidence across restarts without turning runtime state into product data
-- it keeps alerting reviewable because dashboards, rules, and scrape config live in git
-- it keeps the monitoring boundary stable even while the hosted operator surface changes underneath it
-- it lets one `/metrics` surface describe the app-owned monitoring contract while StatsD handles Evidently drift export
+- operator monitoring stays separate from the rider-facing app
+- durable evidence survives restarts without turning runtime state into product data
+- alerting is reviewable because dashboards, rules, and scrape config live in git
+- the monitoring boundary stays stable even while hosted operator surfaces change
+- one `/metrics` surface describes the app-owned contract while StatsD handles drift export
 
 See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Feature Pipeline](feature-pipeline.md), and [Getting Started](../getting-started.md) for the surrounding system and local operator path.


### PR DESCRIPTION
## What changed

**Monitoring page** (major):
- Fix alert rules table to match actual `alerting_rules.yml` — had 6 aspirational rules, now shows the 4 implemented (`AppDown`, `HighRequestLatency`, `PredictionErrorRateHigh`, `StatsdExporterDown`)
- Add structured Mermaid diagrams for signal path and metric composition flow
- Add Prometheus scrape configuration table from `prometheus.yml`
- Add metric families table with actual prefixes and labels from source code
- Add dedicated drift detection section
- Simplify recovery evidence table

**Inference page** (light pass):
- Tighten intro and scope admonition
- Add runtime role table matching feature/training/monitoring doc style
- Remove verbose `it keeps/it lets` patterns in closing section

## Why

Applies the same simple-language + diagrams treatment used in the feature pipeline and training pipeline docs. Fixes factual inaccuracy in monitoring alert rules.

## Verification

- `mkdocs build --strict` clean
- 409 tests pass
- All pre-commit hooks pass