### PR TITLE
chore(monitoring): expand Prometheus alert rules with domain health group

### DIFF
--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -142,14 +142,27 @@ Scrape interval is 15 seconds. Alert rules are evaluated at the same interval.
 
 ## Alert Rules
 
-The checked-in rules at `prometheus_config/alerting_rules.yml` cover four failure modes:
+Alerting uses two evaluation tiers so domain alerts fire even if Grafana is unavailable.
 
-| Alert | Severity | Trigger | What it guards |
-|------|----------|---------|----------------|
-| `AppDown` | critical | app target unreachable for 2 min | serving availability |
-| `HighRequestLatency` | warning | p95 latency above 2 s for 5 min | request performance |
-| `PredictionErrorRateHigh` | warning | error rate above 0.1/s for 5 min | prediction reliability |
-| `StatsdExporterDown` | warning | StatsD target unreachable for 5 min | drift pipeline availability |
+### Prometheus-native rules
+
+The checked-in rules at `prometheus_config/alerting_rules.yml` cover service health and domain health:
+
+| Alert | Group | Severity | Trigger | What it guards |
+|------|-------|----------|---------|----------------|
+| `AppDown` | service-health | critical | app target unreachable for 2 min | serving availability |
+| `HighRequestLatency` | service-health | warning | p95 latency above 2 s for 5 min | request performance |
+| `PredictionErrorRateHigh` | service-health | warning | error rate above 0.1/s for 5 min | prediction reliability |
+| `StatsdExporterDown` | service-health | warning | StatsD target unreachable for 5 min | drift pipeline availability |
+| `PredictionMonitoringScheduleFailure` | domain-health | warning | schedule failures in last 15 min | background monitoring scheduling |
+| `PredictionMonitoringExecutionFailure` | domain-health | warning | execution failures in last 15 min | background monitoring execution |
+| `FeaturePipelineStageFailure` | domain-health | warning | any feature stage failure count > 0 | feature pipeline reliability |
+| `TrainingPipelineStageFailure` | domain-health | warning | any training stage failure count > 0 | training pipeline reliability |
+| `HostedSyncStale` | domain-health | warning | no sync success for 15 min | hosted environment freshness |
+
+### Grafana-provisioned rules
+
+The Grafana alerting provisioning at `grafana_work/etc/provisioning/alerting/foehncast-alert-rules.yml` evaluates the same domain signals with dashboard-linked context. These rules are tied to specific Grafana panels and provide richer annotation when the operator is working inside the dashboard.
 
 All rules, the contact point, and the alert routing policy are checked into the repository so the alerting contract is reviewable without a live Grafana instance.
 

--- a/prometheus_config/alerting_rules.yml
+++ b/prometheus_config/alerting_rules.yml
@@ -37,3 +37,51 @@ groups:
         annotations:
           summary: "StatsD exporter is down"
           description: "The statsd_exporter target has been unreachable for more than 5 minutes."
+
+  - name: foehncast-domain-health
+    interval: 1m
+    rules:
+      - alert: PredictionMonitoringScheduleFailure
+        expr: sum by (endpoint) (increase(foehncast_prediction_monitoring_schedule_total{result="failed"}[15m])) > 0
+        for: 0s
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prediction monitoring schedule failures"
+          description: "Background prediction-monitoring scheduling failures detected for {{ $labels.endpoint }}."
+
+      - alert: PredictionMonitoringExecutionFailure
+        expr: sum by (endpoint) (increase(foehncast_prediction_monitoring_execution_total{result="failed"}[15m])) > 0
+        for: 0s
+        labels:
+          severity: warning
+        annotations:
+          summary: "Prediction monitoring execution failures"
+          description: "Background prediction-monitoring execution failures detected for {{ $labels.endpoint }}."
+
+      - alert: FeaturePipelineStageFailure
+        expr: max by (dataset, storage_backend, stage) (foehncast_feature_pipeline_stage_failure_count) > 0
+        for: 0s
+        labels:
+          severity: warning
+        annotations:
+          summary: "Feature pipeline stage failure"
+          description: "Feature pipeline stage {{ $labels.stage }} failed for {{ $labels.dataset }}/{{ $labels.storage_backend }}."
+
+      - alert: TrainingPipelineStageFailure
+        expr: max by (dataset, requested_stage, stage) (foehncast_training_pipeline_stage_failure_count) > 0
+        for: 0s
+        labels:
+          severity: warning
+        annotations:
+          summary: "Training pipeline stage failure"
+          description: "Training pipeline stage {{ $labels.stage }} failed for {{ $labels.dataset }}/{{ $labels.requested_stage }}."
+
+      - alert: HostedSyncStale
+        expr: (time() - max by (git_ref, compose_deploy_mode) (foehncast_online_compose_sync_last_success_timestamp_seconds)) > 900
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Hosted sync stale"
+          description: "Hosted compose sync for {{ $labels.git_ref }}/{{ $labels.compose_deploy_mode }} has not reported success for more than 15 minutes."

--- a/tests/test_monitoring_stack.py
+++ b/tests/test_monitoring_stack.py
@@ -73,6 +73,28 @@ def test_statsd_mapping_preserves_drift_metric_labels() -> None:
     assert mapping["mappings"][0]["name"] == "foehncast_drift_metric"
 
 
+def test_prometheus_alerting_rules_cover_service_and_domain_health() -> None:
+    rules = _read_yaml("prometheus_config/alerting_rules.yml")
+    groups = {g["name"]: g for g in rules["groups"]}
+
+    service = {r["alert"]: r for r in groups["foehncast-service-health"]["rules"]}
+    assert groups["foehncast-service-health"]["interval"] == "30s"
+    assert "AppDown" in service
+    assert "HighRequestLatency" in service
+    assert "PredictionErrorRateHigh" in service
+    assert "StatsdExporterDown" in service
+    assert service["AppDown"]["labels"]["severity"] == "critical"
+
+    domain = {r["alert"]: r for r in groups["foehncast-domain-health"]["rules"]}
+    assert groups["foehncast-domain-health"]["interval"] == "1m"
+    assert "PredictionMonitoringScheduleFailure" in domain
+    assert "PredictionMonitoringExecutionFailure" in domain
+    assert "FeaturePipelineStageFailure" in domain
+    assert "TrainingPipelineStageFailure" in domain
+    assert "HostedSyncStale" in domain
+    assert all(r["labels"]["severity"] == "warning" for r in domain.values())
+
+
 def test_grafana_provisioning_points_to_prometheus_dashboard_dir() -> None:
     datasource = _read_yaml(
         "grafana_work/etc/provisioning/datasources/foehncast-prometheus-datasource.yml"


### PR DESCRIPTION
## What changed

- Add `foehncast-domain-health` Prometheus rule group with five domain-level alerts:
  `PredictionMonitoringScheduleFailure`, `PredictionMonitoringExecutionFailure`,
  `FeaturePipelineStageFailure`, `TrainingPipelineStageFailure`, `HostedSyncStale`
- These mirror the existing Grafana-provisioned alerts so domain signals fire
  independently of Grafana
- Expand the monitoring docs Alert Rules section into a two-tier description
  (Prometheus-native + Grafana-provisioned)
- Add `test_prometheus_alerting_rules_cover_service_and_domain_health` contract test

## Why

Domain health alerts should fire at the Prometheus level even when Grafana is
unavailable. The existing Grafana-provisioned rules are dashboard-linked and
only evaluated inside Grafana.

## Verification

- 410 tests passing
- `make lint` clean
- `make docs-build` clean

Part of #268