### PR TITLE
docs(system): simplify language in architecture and delivery docs

### DIFF
--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -60,7 +60,7 @@ See [Interfaces and Surfaces](interfaces-and-surfaces.md) for the dedicated publ
 | Operator dashboards and control planes | maintainer or deployment operator | internal-only by default | Airflow, MLflow, Prometheus, and Grafana |
 | Public docs and rendered evidence | course reviewer, fork reader, maintainer | public-safe | docs pages, evaluation markdown, summary JSON-derived charts, and screenshots |
 
-Grafana stays on the operator side. The rider-facing experience comes from the app layer. Public docs should therefore show rendered evidence or screenshots, not live embeds of private dashboards.
+Grafana stays on the operator side. The rider-facing experience comes from the app layer. Public docs show rendered evidence or screenshots, not live embeds of private dashboards.
 
 ## Runtime Lanes
 
@@ -121,7 +121,7 @@ flowchart LR
 | Airflow | scheduled or asset-triggered runtime execution | curated-feature, Feast-sync, training-request, MLflow, evaluation, and registry assets |
 | FastAPI | live serving | `/predict`, `/rank`, `/spots`, `/features/online`, `/metrics` |
 
-The runtime orchestration layer models the main data products as Airflow assets. In the validated local stack, the feature DAG publishes curated-feature, Feast-sync, and training-request assets. The training DAG consumes the training request and emits MLflow training, evaluation, and registry assets. DVC mirrors the offline feature and training boundaries for reproducible reruns, but it does not replace the Airflow asset graph.
+The runtime orchestration layer models main data products as Airflow assets. The feature DAG publishes curated-feature, Feast-sync, and training-request assets. The training DAG consumes the training request and emits MLflow training, evaluation, and registry assets. DVC mirrors the offline feature and training boundaries for reproducible reruns but does not replace the Airflow asset graph.
 
 ## Deployment Targets
 
@@ -157,7 +157,7 @@ flowchart LR
 | Hosted operator target | Cloud Build for runtime images, Cloud Composer for hosted Airflow workloads, and managed operator services for MLflow and monitoring | hosted build, orchestration, and operator surface |
 | GitHub automation | review, workflow dispatch, and Terraform workflows | shared cloud delivery control plane |
 
-The hosted targets deploy runtime services only. Development assets, notebooks, docs build tooling, and local emulators stay local or CI-only. Cloud Run owns the public API lane. Cloud Composer owns hosted orchestration. The operator services stay private by default.
+The hosted targets deploy runtime services only. Development assets, notebooks, docs tooling, and local emulators stay local or CI-only. Cloud Run owns the public API lane. Cloud Composer owns hosted orchestration. Operator services stay private by default.
 
 See [Cloud Mapping](cloud-mapping.md) and [Hosted Full-Stack](hosted-full-stack.md) for the hosted topology and managed service boundaries.
 
@@ -211,7 +211,7 @@ flowchart LR
     APP --> MON
 </div>
 
-The Airflow control plane reflects those hand-offs directly. The feature pipeline owns curated-row and Feast-sync publication, then emits a training-request asset. The training pipeline starts from that asset instead of a direct DAG-to-DAG trigger, so the Assets view shows the real dependency graph between feature persistence, Feast serving preparation, model training, evaluation, and registration.
+The Airflow control plane reflects those hand-offs directly. The feature pipeline owns curated-row and Feast-sync publication, then emits a training-request asset. The training pipeline starts from that asset instead of a direct DAG-to-DAG trigger, so the Assets view shows the real dependency graph.
 
 ## Hosted Runtime Detail
 
@@ -255,7 +255,7 @@ flowchart LR
     DATA --> RAPI
 </div>
 
-The hosted lanes reuse the same application boundaries, but they deploy different runtime surfaces. The first diagram shows the retained private operator lane used in the active shared environment. The second shows the public API lane on Cloud Run. The managed hosted direction changes the build and orchestration plane around those diagrams; it does not change the core pipeline split.
+The hosted lanes reuse the same application boundaries but deploy different runtime surfaces. The first diagram shows the private operator lane. The second shows the public API lane on Cloud Run. Changing the build and orchestration plane does not change the core pipeline split.
 
 ## Representative Validation
 
@@ -269,10 +269,10 @@ The hosted lanes reuse the same application boundaries, but they deploy differen
 
 ## Why This Architecture Holds Up
 
-- The personalized ranking logic stays in the inference layer.
-- Feature engineering and training remain reusable across local and hosted paths.
+- Personalized ranking stays in the inference layer.
+- Feature engineering and training are reusable across local and hosted paths.
 - Hosted changes mostly affect storage, auth, orchestration, and image delivery.
-- The retained operator lane supports the active hosted path, but it is not the desired long-term hosted design.
+- The retained operator lane supports the active hosted path but is not the desired long-term design.
 - Feast layers on top of the same curated features instead of splitting the design.
 
 ## Storage Contract

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -36,9 +36,9 @@ flowchart TD
     end
 </div>
 
-The split matters because the local path is the supported onboarding path, while the cloud path assumes GCP ownership, GitHub repository administration, and access to private operator surfaces.
+The local path is the supported onboarding path. The cloud path assumes GCP ownership, GitHub repository administration, and access to private operator surfaces.
 
-The remote workflow lands on two hosted runtime surfaces: Cloud Run for the public API lane and Cloud Composer for hosted orchestration, scheduling, and recovery. Cloud Build publishes runtime images.
+The remote workflow lands on two hosted runtime surfaces: Cloud Run for the public API lane and Cloud Composer for orchestration, scheduling, and recovery. Cloud Build publishes runtime images.
 
 ## Supported Paths
 
@@ -61,21 +61,21 @@ This path does not require local `gcloud`, Terraform, or GitHub Actions reposito
 
 ## One-Time Shared Cloud Bootstrap
 
-The cloud bootstrap is a maintainer workflow, not a second onboarding path. The preferred first-time environment is Google Cloud Shell. That keeps admin tools off the default evaluator machine and matches the supported no-local-install path.
+The cloud bootstrap is a maintainer workflow, not a second onboarding path. The preferred environment is Google Cloud Shell so admin tools stay off the default evaluator machine.
 
 For the initial shared-cloud setup, run:
 
 `./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions`
 
-The script is interactive by design. It asks the operator to authenticate with `gcloud`, choose or create the target project and billing context, confirm the hosted identifiers and data surfaces, choose which hosted targets to enable, and sync the GitHub repository variables that the remote workflow uses later.
+The script is interactive. It walks the operator through `gcloud` authentication, project and billing selection, hosted-target choices, and GitHub repository-variable sync.
 
-In `--bootstrap-only` mode, the script prepares the remote Terraform control plane, prints the remote-state and identity handoff, and leaves the broader hosted apply to the remote workflow. It also writes `.env` and `terraform/terraform.tfvars` in the working tree so the local checkout reflects the selected project and platform identifiers.
+In `--bootstrap-only` mode the script prepares the remote Terraform backend, prints the handoff summary, and leaves the broader hosted apply to the remote workflow. It writes `.env` and `terraform/terraform.tfvars` so the local checkout reflects the selected project.
 
-When the script runs a normal apply instead of bootstrap-only mode, it verifies both hosted lanes. Cloud Run must answer `/health`, `/spots`, and `/metrics`, and the operator host must keep its app URL private.
+In normal apply mode the script also verifies both hosted lanes: Cloud Run must answer `/health`, `/spots`, and `/metrics`, and the operator host must keep its app URL private.
 
 ## Reviewed Day-2 Delivery
 
-After the one-time bootstrap establishes OIDC, the remote backend, and the repository-variable contract, GitHub Actions becomes the primary operator surface for Terraform-managed changes.
+After the one-time bootstrap establishes OIDC and the remote backend, GitHub Actions becomes the primary surface for Terraform-managed changes.
 
 | Surface | Purpose |
 |------|---------|
@@ -87,11 +87,11 @@ After the one-time bootstrap establishes OIDC, the remote backend, and the repos
 | `.github/workflows/trigger-runtime-release.yml` | send one explicit reviewed runtime release request to the Composer Airflow API |
 | `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up after a remote apply and curated BigQuery rows exist |
 
-The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted target toggles. Lower-level Cloud Run settings such as minimum and maximum instance count, container port, CPU, and memory stay repo-variable-backed instead of becoming manual workflow inputs.
+The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted-target toggles. Cloud Run settings such as instance count, container port, CPU, and memory are also repo-variable-backed.
 
-GitHub publishes the repo-managed DAG and source bundle into the Composer DAG bucket. Composer gets a reviewed PyPI baseline for the checked-in DAG bundle and can consume reviewed `sm://...` Secret Manager env references through the shared runtime env helper.
+GitHub publishes the repo-managed DAG and source bundle into the Composer DAG bucket. Composer gets a reviewed PyPI baseline for the checked-in DAG bundle and can consume `sm://...` Secret Manager env references through the shared runtime env helper.
 
-Checked-in examples and bootstrap outputs can seed the contract, but GitHub repository variables stay structural delivery inputs only. Runtime passwords, API tokens, and other secret-bearing values belong in the runtime environment or a managed secret path instead of the repository-variable sync. Both hosted lanes read the same Terraform-managed storage, Feast, and MLflow contract. See [Configuration and Contracts](configuration-and-contracts.md) for the reviewed inventory.
+Repository variables stay structural delivery inputs only. Runtime passwords, API tokens, and other secrets belong in the runtime environment or a managed secret path. Both hosted lanes read the same Terraform-managed storage, Feast, and MLflow contract. See [Configuration and Contracts](configuration-and-contracts.md) for the full inventory.
 
 ## Hosted Orchestration
 
@@ -118,14 +118,12 @@ GitHub Actions may trigger reviewed delivery workflows, but runtime scheduling d
 
 ## Runtime Release Trigger Contract
 
-GitHub now has exactly one reviewed handoff into runtime execution.
+GitHub has exactly one reviewed handoff into runtime execution.
 
 <div class="mermaid">
 flowchart LR
     GHW["fab:fa-github Runtime release workflow"] --> TARGET["reviewed receiver selection"]
-<div class="mermaid">
-flowchart LR
-    GHW["fab:fa-github Runtime release workflow"] --> AUTH["OIDC + access token"]
+    TARGET --> AUTH["OIDC + access token"]
     AUTH --> API["Composer Airflow API"]
     API --> DAG["runtime_release DAG"]
     DAG --> REPORT["runtime-release-latest.json"]
@@ -208,14 +206,14 @@ These boundaries stay explicit across the scripts, Terraform reference, and work
 - Grafana, Airflow, MLflow, and Prometheus remain operator surfaces rather than rider-facing product surfaces
 - public docs should explain those surfaces with rendered evidence and checked-in configuration, not live control-plane embeds
 
-The same split also keeps cloud retirement reviewable. Destroy and cleanup stay separate workflow commands, and cleanup only runs the follow-up actions the operator selected.
+The same split keeps cloud retirement reviewable. Destroy and cleanup stay separate workflow commands, and cleanup only runs the follow-up actions the operator selected.
 
 ## Why This Workflow Works
 
-- it gives contributors one supported setup path instead of parallel onboarding stories
-- it keeps the one-time cloud bootstrap explicit and interactive, which is safer for project, billing, and hosted-target choices
-- it moves normal day-2 infrastructure changes into GitHub Actions so operators do not need local Terraform for routine work
-- it keeps shared-cloud configuration reviewable because Terraform outputs, repository variables, and workflow behavior are tied together by regression tests
-- it uses managed orchestration through Cloud Composer instead of VM-owned scheduling
+- contributors get one supported setup path instead of parallel onboarding stories
+- the one-time cloud bootstrap is explicit and interactive, which is safer for project, billing, and hosted-target choices
+- day-2 infrastructure changes run through GitHub Actions so operators do not need local Terraform
+- Terraform outputs, repository variables, and workflow behavior are tied together by regression tests
+- managed orchestration through Cloud Composer replaces VM-owned scheduling
 
 See [Interfaces and Surfaces](interfaces-and-surfaces.md), [Hosted Full-Stack](hosted-full-stack.md), [Cloud Mapping](cloud-mapping.md), and [Monitoring](monitoring.md) for the surrounding runtime and exposure boundaries.


### PR DESCRIPTION
## What changed

- Apply the same simple-language treatment used in the recently merged
  feature-pipeline, training-pipeline, monitoring, and inference docs
- Fix broken nested Mermaid diagram in the runtime release trigger section
  of delivery-and-operator-workflow.md
- Tighten verbose sentences and remove filler words throughout both files

## Why

Consistency pass to bring architecture.md and delivery-and-operator-workflow.md
in line with the cleaner style already applied to the other system docs.

## Verification

- 409 tests passing (all contract tests green)
- `make lint` clean
- `make docs-build` clean

Part of #266