### PR TITLE
chore(security): document diskcache transitive risk and dismiss alert #4

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -16,3 +16,9 @@ If you discover a security vulnerability, please report it by opening a private 
 
 - Dependencies are pinned via `uv.lock`.
 - Automated vulnerability scanning via GitHub Dependabot.
+
+### Accepted Transitive Risks
+
+| Package | Via | Severity | Status | Rationale |
+|---------|-----|----------|--------|-----------|
+| `diskcache` (pickle deserialization) | `dvc` → `dvc-data` | moderate | no fix available | DVC-internal cache on local filesystem only; not imported by application code; not present in the production container; exploitation requires local filesystem write access to the DVC cache directory |


### PR DESCRIPTION
## What changed

- Add accepted transitive risks table to SECURITY.md documenting the diskcache
  pickle deserialization vulnerability
- Dismiss Dependabot alert #4 as tolerable risk

## Why

`diskcache` is transitive via `dvc → dvc-data`. No patched version exists.
The package is not imported by application code, not present in the production
container, and only used internally by DVC for local filesystem caching.
Exploitation requires local write access to the DVC cache directory.

## Verification

- 409 tests passing
- `make lint` clean

Part of #266