### PR TITLE
test(airflow-api): add CLI main() entrypoint coverage

### DIFF
--- a/tests/test_airflow_api.py
+++ b/tests/test_airflow_api.py
@@ -66,3 +66,63 @@ def test_airflow_dag_run_status_reports_terminal_failure() -> None:
     assert result["status"] == "failed"
     assert result["state"] == "failed"
     assert result["run"]["dag_run_id"] == "runtime_release__1"
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint (main)
+# ---------------------------------------------------------------------------
+
+
+def test_main_health_returns_0_for_healthy_payload(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = (
+        '{"metadatabase":{"status":"healthy"},"scheduler":{"status":"healthy"},'
+        '"dag_processor":{"status":"healthy"},"triggerer":{"status":"healthy"}}'
+    )
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+    assert airflow_api.main(["health"]) == 0
+
+
+def test_main_health_returns_1_for_unhealthy_payload(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload = (
+        '{"metadatabase":{"status":"healthy"},"scheduler":{"status":"unhealthy"},'
+        '"dag_processor":{"status":"healthy"},"triggerer":{"status":"healthy"}}'
+    )
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+    assert airflow_api.main(["health"]) == 1
+    assert "scheduler" in capsys.readouterr().err
+
+
+def test_main_dag_run_returns_0_and_prints_run_id_on_success(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload = (
+        '{"dag_runs":[{"dag_run_id":"run_1","state":"success","run_type":"manual"}]}'
+    )
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+    assert airflow_api.main(["dag-run", "--expected-state", "success"]) == 0
+    assert "run_1" in capsys.readouterr().out
+
+
+def test_main_dag_run_returns_2_and_prints_run_on_failure(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    payload = (
+        '{"dag_runs":[{"dag_run_id":"run_2","state":"failed","run_type":"manual"}]}'
+    )
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+    assert airflow_api.main(["dag-run", "--expected-state", "success"]) == 2
+    assert "run_2" in capsys.readouterr().err
+
+
+def test_main_dag_run_returns_1_when_pending(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    payload = (
+        '{"dag_runs":[{"dag_run_id":"run_3","state":"running","run_type":"manual"}]}'
+    )
+    monkeypatch.setattr("sys.stdin", __import__("io").StringIO(payload))
+    assert airflow_api.main(["dag-run", "--expected-state", "success"]) == 1


### PR DESCRIPTION
Adds 5 tests for `airflow_api.main()`, covering health (pass/fail) and dag-run (success/fail/pending) subcommands via the `argv` parameter.

`airflow_api.py` module coverage: 53% → 95%. Total: 415 tests green, lint clean.

Closes #300