### PR TITLE
feat(monitoring): add hindcast accuracy panel to ML Diagnostics dashboard and sidebar model card

### DIFF
--- a/grafana_work/dashboards/foehncast-ml-diagnostics.json
+++ b/grafana_work/dashboards/foehncast-ml-diagnostics.json
@@ -2191,6 +2191,200 @@
         "colorMode": "value"
       },
       "description": "Seconds since the last successful prediction-monitoring execution."
+    },
+    {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 120
+      },
+      "id": 550,
+      "panels": [],
+      "title": "Hindcast Validation",
+      "type": "row"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 0,
+        "y": 121
+      },
+      "id": 551,
+      "targets": [
+        {
+          "expr": "foehncast_hindcast_accuracy",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Hindcast Accuracy",
+      "type": "gauge",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "percentunit",
+          "min": 0,
+          "max": 1,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#ff6e6e",
+                "value": null
+              },
+              {
+                "color": "#d1833d",
+                "value": 0.5
+              },
+              {
+                "color": "#0e6d6e",
+                "value": 0.7
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "showThresholdLabels": false,
+        "showThresholdMarkers": true,
+        "orientation": "auto"
+      },
+      "description": "Fraction of past predictions where the predicted quality class matched the observed class."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 8,
+        "y": 121
+      },
+      "id": 552,
+      "targets": [
+        {
+          "expr": "foehncast_hindcast_mae",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Hindcast MAE",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 2,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#0e6d6e",
+                "value": null
+              },
+              {
+                "color": "#d1833d",
+                "value": 1.0
+              },
+              {
+                "color": "#ff6e6e",
+                "value": 2.0
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "colorMode": "value"
+      },
+      "description": "Mean absolute error between predicted and observed quality index."
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 8,
+        "x": 16,
+        "y": 121
+      },
+      "id": 553,
+      "targets": [
+        {
+          "expr": "foehncast_hindcast_validated_count",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "Validated Pairs",
+      "type": "stat",
+      "fieldConfig": {
+        "defaults": {
+          "unit": "short",
+          "decimals": 0,
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "#5f6f7f",
+                "value": null
+              },
+              {
+                "color": "#0e6d6e",
+                "value": 1
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "options": {
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto",
+        "colorMode": "value"
+      },
+      "description": "Number of prediction/observation pairs validated via hindcast."
     }
   ],
   "schemaVersion": 39,

--- a/ui/app.py
+++ b/ui/app.py
@@ -497,6 +497,7 @@ def _render_sidebar_ml_panels() -> None:
     rmse_val = _prom_query('foehncast_training_pipeline_run_metric{metric_name="rmse"}')
     feat_count = _prom_query("foehncast_training_pipeline_feature_count")
     train_rows = _prom_query("foehncast_training_pipeline_row_count")
+    hindcast_acc = _prom_query("foehncast_hindcast_accuracy")
 
     if verified:
         badge_color = "var(--accent)"
@@ -524,6 +525,7 @@ def _render_sidebar_ml_panels() -> None:
         'padding-top:10px;border-top:1px solid rgba(23,50,77,0.08)">'
         + _stat("R²", r2_val)
         + _stat("RMSE", rmse_val)
+        + _stat("Hind.", hindcast_acc, ".0%")
         + _stat("Feats", feat_count, ".0f")
         + _stat("Rows", train_rows, ".0f")
         + "</div>"
@@ -573,6 +575,17 @@ def _render_sidebar_ml_panels() -> None:
             "foehncast-rider",
             panel_id=304,
             from_range="now-1h",
+        )
+        st.iframe(url, height=120)
+
+    # --- Hindcast Accuracy (Grafana gauge embed) --------------------------
+    if _grafana_embedding_enabled():
+        st.caption("Hindcast Accuracy")
+        url = _grafana_solo_panel_url(
+            _ML_DASHBOARD_UID,
+            _ML_DASHBOARD_SLUG,
+            panel_id=551,
+            from_range="now-24h",
         )
         st.iframe(url, height=120)
 


### PR DESCRIPTION
Closes #307

Add Grafana panels and sidebar integration for hindcast validation metrics introduced in #305.

### Changes
- New **Hindcast Validation** row in the ML Diagnostics Grafana dashboard (panels 550–553):
  - Gauge: Hindcast Accuracy (`foehncast_hindcast_accuracy`, 0–1 scale)
  - Stat: Hindcast MAE (`foehncast_hindcast_mae`)
  - Stat: Validated Pairs (`foehncast_hindcast_validated_count`)
- Hindcast accuracy wired into sidebar model card stats row (`Hind.` column)
- Grafana solo panel embed for hindcast accuracy gauge below confidence gauge in sidebar

### Testing
- 427 tests passing
- Lint clean (`ruff check`)
- Valid JSON (`foehncast-ml-diagnostics.json`)