### PR TITLE
docs(site): update for hindcast, scheduled inference, and dashboard overhaul

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -34,6 +34,7 @@ The bootstrap starts the local evaluator stack, waits for the feature-to-trainin
 | MLflow | `http://127.0.0.1:5001` | operator surface for runs and model versions |
 | Prometheus | `http://127.0.0.1:9090` | operator surface for scraped metrics |
 | Grafana | `http://127.0.0.1:3000` | operator surface for dashboards and alerts |
+| Streamlit | `http://127.0.0.1:8501` | rider console with live rankings and model card |
 
 The objectstore UI and the Feast emulator endpoint are printed by the bootstrap helper when the stack comes up. For the full surface boundary, use [Interfaces and Surfaces](system/interfaces-and-surfaces.md).
 

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -76,10 +76,10 @@ Grafana stays on the operator side. The rider-facing experience comes from the a
 |------|----------------|-------------------------|
 | Feature pipeline | Collect data, engineer curated rows, validate them, and store the result | local Airflow DAG plus the configured storage backend |
 | Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
-| Inference pipeline | Serve health, predict, rank, and spot-list responses | FastAPI app container |
+| Inference pipeline | Serve health, predict, rank, and spot-list responses; run batch predictions after model registration | FastAPI app container plus the asset-triggered `inference_pipeline` DAG |
 | Orchestration | Schedule runtime DAGs, retries, backfills, and operator inspection | local Airflow in the local evaluator; Cloud Composer in the hosted environment |
 | Online features | Surface curated fields through an online lookup route | Feast-backed service path plus demo page |
-| Monitoring | Scrape runtime metrics, collect pushed gauges, and visualize starter alerts | Prometheus, StatsD exporter, and Grafana operator stack |
+| Monitoring | Scrape runtime metrics, collect pushed gauges, run hindcast validation, and visualize through three operator dashboards | Prometheus, StatsD exporter, and Grafana operator stack |
 
 ## DVC And Airflow
 
@@ -87,7 +87,7 @@ The same feature and training boundaries are driven by two different control pat
 
 - DVC is the reproducible path for local reruns and CI. It tracks file dependencies and outputs in `dvc.yaml`.
 - Airflow is the runtime control plane. It schedules DAG runs, handles retries, and shows asset hand-offs.
-- Inference is neither a DVC stage nor an Airflow DAG. The FastAPI app serves live requests from the registered model and online feature surfaces.
+- The `inference_pipeline` DAG bridges inference into the Airflow world: it is asset-triggered by model registration and runs batch predictions across all configured spots, feeding the prediction-event history that hindcast validation and drift detection consume.
 
 <div class="mermaid">
 flowchart LR
@@ -103,6 +103,7 @@ flowchart LR
     subgraph AirflowPath ["Airflow runtime path"]
         FDAG["feature_dag"]:::ctl --> FEAT["Feature pipeline"]:::pipe
         TDAG["training_dag"]:::ctl --> TRAIN["Training pipeline"]:::pipe
+        IDAG["inference_dag"]:::ctl --> INF["Inference pipeline"]:::pipe
     end
 
     DVCCLI --> FEAT
@@ -111,6 +112,8 @@ flowchart LR
     CUR --> TRAIN
     CUR --> FEAST["Feast serving prep"]:::store
     TRAIN --> REG["MLflow model + reports"]:::store
+    REG --> INF
+    INF --> PLOG["Prediction event log"]:::store
     FEAST --> API["FastAPI inference"]:::serve
     REG --> API
 </div>
@@ -118,10 +121,10 @@ flowchart LR
 | Path | Main job | Main outputs |
 |------|----------|--------------|
 | DVC | repeatable offline reruns in local or CI contexts | `data/${dataset}`, `reports/train_metrics.json`, `reports/feature_importance.png` |
-| Airflow | scheduled or asset-triggered runtime execution | curated-feature, Feast-sync, training-request, MLflow, evaluation, and registry assets |
+| Airflow | scheduled or asset-triggered runtime execution | curated-feature, Feast-sync, training-request, MLflow, evaluation, registry, and prediction-log assets |
 | FastAPI | live serving | `/predict`, `/rank`, `/spots`, `/features/online`, `/metrics` |
 
-The runtime orchestration layer models main data products as Airflow assets. The feature DAG publishes curated-feature, Feast-sync, and training-request assets. The training DAG consumes the training request and emits MLflow training, evaluation, and registry assets. DVC mirrors the offline feature and training boundaries for reproducible reruns but does not replace the Airflow asset graph.
+The runtime orchestration layer models main data products as Airflow assets. The feature DAG publishes curated-feature, Feast-sync, and training-request assets. The training DAG consumes the training request and emits MLflow training, evaluation, and registry assets. The inference DAG consumes the registry asset and produces prediction-log events for monitoring. DVC mirrors the offline feature and training boundaries for reproducible reruns but does not replace the Airflow asset graph.
 
 ## Deployment Targets
 

--- a/docs/site/system/composer-dag-validation.md
+++ b/docs/site/system/composer-dag-validation.md
@@ -41,6 +41,7 @@ Expected DAGs:
 |--------|----------|-------------|
 | `feature_pipeline` | `0 */6 * * *` | Ingest, engineer, validate, store features; trigger retraining |
 | `training_pipeline` | Asset-triggered | Train, evaluate, register model |
+| `inference_pipeline` | Asset-triggered | Predict all spots after model registration; write prediction log |
 | `runtime_release` | Manual | Record runtime release handoff |
 
 ## 3. Trigger Feature Pipeline DAG

--- a/docs/site/system/inference-pipeline.md
+++ b/docs/site/system/inference-pipeline.md
@@ -148,16 +148,31 @@ The monitoring hand-off is:
 
 - `/predict` and `/rank` schedule background prediction-monitoring work after a successful response payload is built
 - the background path records scheduling and execution outcomes and emits prediction-drift metrics from retained prediction history
-- `/metrics` merges durable feature and training summaries, retained prediction-log metrics, hosted-sync metrics, and in-process prediction-monitoring counters
+- `/metrics` merges durable feature and training summaries, retained prediction-log metrics, hosted-sync metrics, hindcast validation results, and in-process prediction-monitoring counters
+- hindcast validation runs hourly in the background, comparing past predictions against observed weather to measure real forecast accuracy; results persist in `.state/monitoring/hindcast-validation.json`
 
 This keeps the inference service responsible for request-side facts while leaving dashboards, alert rules, and long-range operator review to the monitoring stack.
+
+## Scheduled Inference
+
+Inference also runs as a scheduled Airflow DAG alongside the request-driven app path.
+
+The `inference_pipeline` DAG is:
+
+- triggered by the `foehncast_mlflow_model_registry` asset, meaning it runs automatically after a new model version is registered
+- executes `run_inference_pipeline_step`, which predicts across all configured spots using the champion model
+- emits the `foehncast_inference_prediction_log` asset so downstream monitoring and hindcast validation can consume fresh predictions
+- can also be triggered manually from the Airflow UI when the operator wants a batch prediction refresh
+
+This keeps the prediction-event history populated even when no rider requests arrive, which is important for hindcast validation and drift detection over time.
 
 ## Runtime Role
 
 | Runtime mode | Inference role |
 |------|---------------------|
-| Local evaluator | FastAPI app serves predictions from locally-registered MLflow model |
+| Local evaluator | FastAPI app serves predictions from locally-registered MLflow model; the `inference_pipeline` DAG runs batch predictions after model registration |
 | Cloud Run | shared public API with the same serving contract |
+| Cloud Composer | scheduled inference DAG runs batch predictions after model registration |
 | Private operator host | internal checks next to other hosted operator services |
 
 See [Architecture](architecture.md) for the lane summary and [Hosted Full-Stack](hosted-full-stack.md) for the hosted exposure and transition rules.

--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -19,6 +19,7 @@ flowchart LR
         AIR["Airflow pipeline summaries"]
         PRED["Prediction requests"]
         SYNC["Hosted sync status"]
+        HIND["Hindcast validation"]
     end
 
     subgraph Processing ["Metric composition"]
@@ -39,6 +40,7 @@ flowchart LR
     AIR --> APP
     PRED --> LOG
     SYNC --> APP
+    HIND --> APP
     LOG --> APP
     LOG --> DRIFT
     DRIFT --> STATSD
@@ -68,6 +70,7 @@ The public-versus-private surface rule is documented in [Interfaces and Surfaces
 | `.state/monitoring/prediction-events.jsonl` | durable | prediction-event history by model version (local S3-backed runtimes) |
 | `foehncast_monitoring.prediction_events` BigQuery table | durable | prediction-event history (Cloud Run and cloud-native readers) |
 | `.state/monitoring/prediction-log.jsonl` | bounded working set | recent prediction rows for local drift evaluation; not a history source |
+| `.state/monitoring/hindcast-validation.json` | durable | latest hindcast accuracy, MAE, and validated-pair counts |
 | `.state/hosted-sync/last-success.json` | durable | latest hosted sync success marker |
 | app `/metrics` | composed scrape | app-owned monitoring state and summary-derived metrics |
 | StatsD exporter `:9102` | scrape | Evidently-backed drift metrics |
@@ -168,13 +171,34 @@ All rules, the contact point, and the alert routing policy are checked into the 
 
 ## Dashboards
 
-Grafana is provisioned from the repository-owned dashboard at `grafana_work/dashboards/foehncast-overview.json`. The dashboard covers:
+Grafana is provisioned from three repository-owned dashboards under `grafana_work/dashboards/`:
 
-- feature pipeline summary count and latest run success by dataset and backend
-- failed spot counts
-- monitoring target health
+| Dashboard | File | Main audience | Key rows |
+|------|------|---------------|----------|
+| FoehnCast Rider | `foehncast-rider.json` | rider, reviewer | Spot Map, Model Confidence, Drift Status, System Pulse |
+| FoehnCast Operations | `foehncast-operations.json` | operator | System Health, Pipeline Status, Data Freshness, Spot Throughput, Pipeline Timing, Error Budget, Inference SLIs, Prediction Monitoring |
+| FoehnCast ML Diagnostics | `foehncast-ml-diagnostics.json` | operator, ML engineer | Drift Overview, Per-Column Drift Detail, Training Metrics, Training Data Shape, Model Registry, Feature Pipeline Detail, Spot-Level Detail, Prediction Log, Prediction Monitoring, Hindcast Validation |
+
+The rider dashboard keeps the evaluation-safe view narrow: spot geography, model confidence derived from drift scores, and system pulse. The operations dashboard focuses on service health and pipeline reliability. The ML diagnostics dashboard carries the deep inspection panels for drift, training, model registry, and hindcast accuracy.
 
 Dashboard JSON and provisioning config are version-controlled so the operator view is reproducible from a fresh `docker compose up`.
+
+## Hindcast Validation
+
+Hindcast validation compares past predictions against observed weather data to measure real-world forecast accuracy.
+
+The validation path is:
+
+- the app runs a background hindcast task hourly via `asyncio.to_thread` inside the FastAPI lifespan
+- eligible predictions are those older than a 120-hour buffer (accounting for Open-Meteo archive API latency of roughly five days)
+- for each eligible prediction, the archive API provides observed weather at the same spot and timestamp
+- ground-truth quality labels are recomputed from observed values using the same `compute_quality_index` function used in training
+- accuracy, MAE, and per-class counts are calculated and persisted to `.state/monitoring/hindcast-validation.json`
+- Prometheus scrapes the cached result; the app never calls the archive API on scrape
+
+The ML Diagnostics dashboard shows hindcast accuracy in a dedicated row with gauge, MAE stat, and validated-pairs count panels. The Streamlit sidebar model card also embeds the hindcast accuracy gauge.
+
+This closes the prediction-to-observation feedback loop without relying on manual evaluation notebooks.
 
 ## Recovery Evidence
 

--- a/docs/site/system/repository.md
+++ b/docs/site/system/repository.md
@@ -16,6 +16,7 @@ src/foehncast/
   spots/
 dags/
 containers/
+ui/
 scripts/
 terraform/
 feature_repo/
@@ -33,6 +34,7 @@ flowchart TD
   DVC[dvc.yaml + dvc_stages.py] --> REPRO[Reproducible feature + training reruns]
   DAGS[dags] --> ORCH[Airflow orchestration]
   CNT[containers] --> PACK[Containerized runtime packaging]
+  UI[ui] --> RIDER[Streamlit rider console]
   OPS[scripts + terraform] --> DELIV[Bootstrap and hosted delivery]
   TESTS[tests] --> VERIFY[Regression validation]
   DOCS[docs] --> SITE[Public documentation]
@@ -43,13 +45,14 @@ flowchart TD
 - `src/foehncast/`: the application modules for configuration, feature engineering, training, inference, monitoring, and spot metadata.
 - `src/foehncast/dvc_stages.py`: the thin CLI entry point that exposes the DVC `curate` and `train` stages.
 - `dvc.yaml`: the file-based reproducibility contract for offline feature and training reruns.
-- `dags/`: Airflow entry points for the feature and training workflows.
+- `dags/`: Airflow entry points for the feature, training, and inference workflows.
 
 | Area | What it holds |
 |------|---------------|
 | `src/foehncast/` | application code for configuration, features, training, inference, monitoring, and spot metadata |
 | `dvc.yaml` and `src/foehncast/dvc_stages.py` | reproducible local and CI reruns of the offline feature and training path |
-| `dags/` | Airflow entry points for feature and training workflows |
+| `dags/` | Airflow entry points for feature, training, and inference workflows |
+| `ui/` | Streamlit rider console application |
 | `containers/`, `scripts/`, and `terraform/` | runtime packaging, bootstrap helpers, and deployment tooling |
 | `feature_repo/`, `prometheus_config/`, and `grafana_work/` | Feast and operator-monitoring integration contracts |
 | `tests/` and `docs/` | regression coverage and public explanation |


### PR DESCRIPTION
**What changed**: Update six docs pages to reflect features delivered in #304–#310 (dashboard overhaul, hindcast validation, scheduled inference DAG, backfill, containerized UI).

**Why**: The docs site was accurate through #303 but did not cover the recent monitoring and inference features. This brings the site current for MS3 presentation.

**Changes**:
- `monitoring.md`: three-dashboard structure (Rider/Operations/ML Diagnostics), hindcast validation section, updated signal path
- `inference-pipeline.md`: scheduled inference DAG section, hindcast in monitoring hand-off, expanded runtime role table
- `architecture.md`: inference DAG in pipeline boundaries and DVC/Airflow diagram
- `repository.md`: added `ui/` directory, updated DAGs to include inference
- `getting-started.md`: Streamlit endpoint in local endpoints table
- `composer-dag-validation.md`: `inference_pipeline` in expected DAGs table

**Verification**: `mkdocs build --strict` passes clean.

Closes #311