### PR TITLE
feat(monitoring): add scheduled drift detection Airflow DAG

### DIFF
--- a/dags/drift_dag.py
+++ b/dags/drift_dag.py
@@ -1,0 +1,57 @@
+"""Airflow DAG for scheduled data and prediction drift detection."""
+
+from __future__ import annotations
+
+from datetime import datetime
+import os
+
+try:
+    from airflow.providers.standard.operators.python import PythonOperator
+    from airflow.sdk import Asset, DAG
+except ModuleNotFoundError:  # pragma: no cover - Airflow is container-only
+    dag = None
+else:
+    from foehncast.airflow_assets import drift_report_asset_uri
+    from foehncast.orchestration import (
+        resolve_airflow_schedule,
+        run_feature_drift_detection_step,
+        run_prediction_drift_detection_step,
+    )
+
+    drift_dataset = os.getenv("AIRFLOW_DRIFT_DATASET", "train").strip() or "train"
+    drift_schedule = resolve_airflow_schedule(
+        os.getenv("AIRFLOW_DRIFT_SCHEDULE"),
+        default="0 */12 * * *",
+    )
+    drift_report_asset = Asset(
+        name=f"{drift_dataset}_drift_report",
+        uri=drift_report_asset_uri(drift_dataset),
+    )
+
+    with DAG(
+        dag_id="drift_detection",
+        description=(
+            "Detect data drift across stored features and prediction drift "
+            "from the inference log.  Pushes StatsD metrics for Prometheus "
+            "scraping and Grafana alerting."
+        ),
+        start_date=datetime(2024, 1, 1),
+        schedule=drift_schedule,
+        catchup=False,
+        is_paused_upon_creation=False,
+        tags=["foehncast", "monitoring"],
+    ) as dag:
+        detect_feature_drift = PythonOperator(
+            task_id="detect_feature_drift",
+            python_callable=run_feature_drift_detection_step,
+            outlets=[drift_report_asset],
+            op_kwargs={"dataset": drift_dataset},
+        )
+
+        detect_prediction_drift = PythonOperator(
+            task_id="detect_prediction_drift",
+            python_callable=run_prediction_drift_detection_step,
+            outlets=[drift_report_asset],
+        )
+
+        detect_feature_drift >> detect_prediction_drift

--- a/src/foehncast/airflow_assets.py
+++ b/src/foehncast/airflow_assets.py
@@ -39,3 +39,7 @@ def mlflow_registry_asset_uri(model_name: str = "foehncast") -> str:
 
 def inference_prediction_log_asset_uri(dataset: str = "default") -> str:
     return f"x-foehncast://inference/prediction-log/{_asset_segment(dataset)}"
+
+
+def drift_report_asset_uri(dataset: str = "default") -> str:
+    return f"x-foehncast://monitoring/drift-report/{_asset_segment(dataset)}"

--- a/src/foehncast/orchestration.py
+++ b/src/foehncast/orchestration.py
@@ -1146,3 +1146,107 @@ def run_inference_pipeline_step() -> dict[str, Any]:
     )
     log.info("Scheduled inference: prediction log and drift metrics updated")
     return prediction_payload
+
+
+# ---------------------------------------------------------------------------
+# Drift detection pipeline
+# ---------------------------------------------------------------------------
+
+
+def run_feature_drift_detection_step(
+    dataset: str = "train",
+) -> dict[str, Any]:
+    """Detect data drift across all configured spots.
+
+    Loads the curated feature store for each spot, splits into reference
+    and current windows, runs ``detect_data_drift()``, and pushes StatsD
+    metrics.  Returns a summary dict suitable for Airflow XCom.
+    """
+    log = logging.getLogger(__name__)
+    spots = get_spots()
+    spot_ids = [spot["id"] for spot in spots]
+    drifted_spots: list[str] = []
+    checked_spots: list[str] = []
+    errors: dict[str, str] = {}
+
+    for spot_id in spot_ids:
+        try:
+            features_df = _read_optional_feature_slice(spot_id, dataset)
+            if features_df.empty or len(features_df) < 2:
+                log.info("Drift check: skipping spot '%s' — insufficient data", spot_id)
+                continue
+
+            midpoint = len(features_df) // 2
+            reference_df = features_df.iloc[:midpoint].copy()
+            current_df = features_df.iloc[midpoint:].copy()
+
+            if _emit_feature_drift_metrics(
+                spot_id=spot_id,
+                dataset=dataset,
+                reference_df=reference_df,
+                current_df=current_df,
+            ):
+                drifted_spots.append(spot_id)
+
+            checked_spots.append(spot_id)
+        except Exception as exc:
+            log.exception(
+                "Drift check: failed for spot '%s' in dataset '%s'",
+                spot_id,
+                dataset,
+            )
+            errors[spot_id] = str(exc)
+
+    log.info(
+        "Feature drift check: %d/%d spots checked, %d drifted",
+        len(checked_spots),
+        len(spot_ids),
+        len(drifted_spots),
+    )
+    return {
+        "dataset": dataset,
+        "checked_spots": checked_spots,
+        "drifted_spots": drifted_spots,
+        "errors": errors,
+    }
+
+
+def run_prediction_drift_detection_step() -> dict[str, Any]:
+    """Detect prediction drift from the logged prediction history.
+
+    Loads the prediction event log, runs ``detect_prediction_drift()``,
+    and pushes StatsD metrics.  Returns a summary dict.
+    """
+    from foehncast.monitoring.prediction_log import (
+        read_prediction_history,
+    )
+
+    log = logging.getLogger(__name__)
+    try:
+        predictions_log = read_prediction_history(None)
+        if predictions_log.empty or len(predictions_log) < 2:
+            log.info("Prediction drift check: insufficient prediction history")
+            return {"prediction_drift": None, "reason": "insufficient_data"}
+
+        predictions_log.attrs.update(
+            {"dataset_name": "inference_predictions", "dataset_version": "v1"}
+        )
+        from foehncast.monitoring.drift import detect_prediction_drift
+
+        report = detect_prediction_drift(predictions_log)
+        push_drift_metrics(report)
+        log.info(
+            "Prediction drift check: drift=%s, drifted_columns=%d/%d",
+            report.dataset_drift,
+            report.drifted_column_count,
+            report.column_count,
+        )
+        return {
+            "prediction_drift": report.dataset_drift,
+            "drifted_column_count": report.drifted_column_count,
+            "column_count": report.column_count,
+            "share_of_drifted_columns": report.share_of_drifted_columns,
+        }
+    except Exception as exc:
+        log.exception("Prediction drift check failed")
+        return {"prediction_drift": None, "error": str(exc)}

--- a/tests/test_dags.py
+++ b/tests/test_dags.py
@@ -11,6 +11,7 @@ import pytest
 
 from foehncast.airflow_assets import (
     curated_feature_store_asset_uri,
+    drift_report_asset_uri,
     feast_feature_store_asset_uri,
     mlflow_evaluation_asset_uri,
     mlflow_registry_asset_uri,
@@ -93,6 +94,8 @@ def _load_dag_module(
         "AIRFLOW_FEATURE_SCHEDULE",
         "AIRFLOW_AUTO_RETRAIN_MODE",
         "AIRFLOW_TRAINING_DATASET",
+        "AIRFLOW_DRIFT_DATASET",
+        "AIRFLOW_DRIFT_SCHEDULE",
     ):
         monkeypatch.delenv(name, raising=False)
 
@@ -291,3 +294,58 @@ def test_runtime_release_dag_accepts_manual_handoff_requests(
         "dag_run_id": "{{ run_id }}",
         "dag_id": "runtime_release",
     }
+
+
+def test_drift_dag_defaults_to_twelve_hour_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AIRFLOW_DRIFT_DATASET", raising=False)
+    monkeypatch.delenv("AIRFLOW_DRIFT_SCHEDULE", raising=False)
+    module, operators = _load_dag_module(monkeypatch, "dags/drift_dag.py")
+
+    assert module.dag.kwargs["schedule"] == "0 */12 * * *"
+    assert module.dag.kwargs["catchup"] is False
+    assert module.dag.kwargs["is_paused_upon_creation"] is False
+    assert module.dag.kwargs["tags"] == ["foehncast", "monitoring"]
+    assert [operator.kwargs["task_id"] for operator in operators] == [
+        "detect_feature_drift",
+        "detect_prediction_drift",
+    ]
+    assert operators[0].kwargs["op_kwargs"] == {"dataset": "train"}
+    assert [asset.uri for asset in operators[0].kwargs["outlets"]] == [
+        drift_report_asset_uri("train"),
+    ]
+    assert [asset.uri for asset in operators[1].kwargs["outlets"]] == [
+        drift_report_asset_uri("train"),
+    ]
+
+
+def test_drift_dag_supports_custom_schedule_and_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, operators = _load_dag_module(
+        monkeypatch,
+        "dags/drift_dag.py",
+        env={
+            "AIRFLOW_DRIFT_DATASET": "validation",
+            "AIRFLOW_DRIFT_SCHEDULE": "0 0 * * *",
+        },
+    )
+
+    assert module.dag.kwargs["schedule"] == "0 0 * * *"
+    assert operators[0].kwargs["op_kwargs"] == {"dataset": "validation"}
+    assert [asset.uri for asset in operators[0].kwargs["outlets"]] == [
+        drift_report_asset_uri("validation"),
+    ]
+
+
+def test_drift_dag_can_be_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    module, _operators = _load_dag_module(
+        monkeypatch,
+        "dags/drift_dag.py",
+        env={"AIRFLOW_DRIFT_SCHEDULE": "manual"},
+    )
+
+    assert module.dag.kwargs["schedule"] is None


### PR DESCRIPTION
### What Changed

- New `dags/drift_dag.py`: `drift_detection` DAG with two tasks (`detect_feature_drift` → `detect_prediction_drift`), scheduled every 12 hours
- `orchestration.py`: added `run_feature_drift_detection_step()` and `run_prediction_drift_detection_step()` callables
- `airflow_assets.py`: added `drift_report_asset_uri()`
- `test_dags.py`: 3 new tests covering default schedule, custom dataset/schedule, and manual disable

### Why

The drift detection module (`monitoring/drift.py`) was only called inline during feature pipeline storage. A dedicated scheduled DAG decouples drift monitoring from the feature pipeline, enabling continuous monitoring even when no new features are ingested. This strengthens the Monitoring rubric (R5) for MS3.

### Verification

```bash
uv run python -m pytest tests/test_dags.py tests/test_drift.py -v  # 12/12 pass
uv run ruff check dags/ src/foehncast/airflow_assets.py src/foehncast/orchestration.py tests/test_dags.py
```

### Closes

- Closes #315