### PR TITLE
chore: update pre-commit ruff hook to v0.15.10

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,7 +12,7 @@ repos:
       - id: detect-private-key
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.15.10
     hooks:
       - id: ruff
         args: [--fix]


### PR DESCRIPTION
### What Changed

- `.pre-commit-config.yaml`: ruff-pre-commit rev v0.9.1 → v0.15.10

### Why

The pre-commit hook was pinned to ruff v0.9.1 while CI and the project use v0.15.10. The version mismatch caused lambda formatting disagreements — the hook would reformat code one way, CI expected another, leading to spurious lint failures (e.g. PR #318).

### Verification

```bash
pre-commit run ruff-format --all-files  # Passed
pre-commit run ruff --all-files         # Passed
```

### Closes

- Closes #319