### PR TITLE
feat(infra): wire GCP compose overlay with storage and Feast env contracts

### DIFF
--- a/containers/mlflow/docker-compose.yml
+++ b/containers/mlflow/docker-compose.yml
@@ -12,9 +12,6 @@ services:
       - MLFLOW_PORT=5001
       - MLFLOW_ARTIFACT_DESTINATION=${MLFLOW_ARTIFACT_DESTINATION:-file:///mlartifacts}
       - MLFLOW_BACKEND_STORE_URI=sqlite:///metadata/metadata.sqlite
-      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY:-}
-      - MLFLOW_S3_ENDPOINT_URL=http://objectstore:9000
       - GCP_PROJECT_ID=${GCP_PROJECT_ID:-}
       - GOOGLE_CLOUD_PROJECT=${GCP_PROJECT_ID:-}
     volumes:

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -1,33 +1,71 @@
+x-gcp-runtime-env: &gcp-runtime-env
+  STORAGE_BACKEND: bigquery
+  STORAGE_BIGQUERY_PROJECT_ID: ${GCP_PROJECT_ID:?GCP_PROJECT_ID required}
+  STORAGE_BIGQUERY_DATASET: ${STORAGE_BIGQUERY_DATASET:-foehncast}
+  STORAGE_BIGQUERY_TABLE: ${STORAGE_BIGQUERY_TABLE:-forecast_features}
+  GCP_PROJECT_ID: ${GCP_PROJECT_ID:?GCP_PROJECT_ID required}
+  GCP_LOCATION: ${GCP_LOCATION:-europe-west6}
+  GOOGLE_CLOUD_PROJECT: ${GCP_PROJECT_ID:?GCP_PROJECT_ID required}
+
+x-feast-gcp-env: &feast-gcp-env
+  FOEHNCAST_FEAST_SOURCE: bigquery
+  FOEHNCAST_FEAST_PROJECT: foehncast
+  FOEHNCAST_FEAST_PROJECT_ID: ${GCP_PROJECT_ID:?GCP_PROJECT_ID required}
+  FOEHNCAST_FEAST_REGISTRY: gs://${GCP_ARTIFACT_BUCKET_NAME:-foehncast-data}/feast/registry.db
+  FOEHNCAST_FEAST_GCS_BUCKET: ${GCP_ARTIFACT_BUCKET_NAME:-foehncast-data}
+  FOEHNCAST_FEAST_GCS_STAGING_LOCATION: gs://${GCP_ARTIFACT_BUCKET_NAME:-foehncast-data}/feast/staging
+  FOEHNCAST_FEAST_BIGQUERY_DATASET: ${STORAGE_BIGQUERY_DATASET:-foehncast}
+  FOEHNCAST_FEAST_BIGQUERY_LOCATION: ${STORAGE_BIGQUERY_LOCATION:-EU}
+  FOEHNCAST_FEAST_BIGQUERY_TABLE: ${GCP_PROJECT_ID:?GCP_PROJECT_ID required}.${STORAGE_BIGQUERY_DATASET:-foehncast}.${STORAGE_BIGQUERY_TABLE:-forecast_features}
+  FOEHNCAST_FEAST_DATASTORE_DATABASE: ${FOEHNCAST_FEAST_DATASTORE_DATABASE:-feast-online}
+
 services:
   app:
     platform: linux/amd64
+    environment:
+      <<: [*gcp-runtime-env, *feast-gcp-env]
+      FOEHNCAST_PIPELINE_REPORT_DIR: gs://${GCP_ARTIFACT_BUCKET_NAME:-foehncast-data}/airflow/reports
     volumes:
       - ${HOME}/.config/gcloud:/home/appuser/.config/gcloud:ro
 
   model-registry:
+    environment:
+      MLFLOW_ARTIFACT_DESTINATION: gs://${GCP_ARTIFACT_BUCKET_NAME:-foehncast-data}/mlflow/artifacts
     volumes:
       - ${HOME}/.config/gcloud:/root/.config/gcloud:ro
 
   development_env:
+    environment:
+      <<: [*gcp-runtime-env, *feast-gcp-env]
     volumes:
       - ${HOME}/.config/gcloud:/home/appuser/.config/gcloud:ro
 
   airflow-init:
+    environment:
+      <<: [*gcp-runtime-env, *feast-gcp-env]
     volumes:
       - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro
 
   airflow-webserver:
+    environment:
+      <<: [*gcp-runtime-env, *feast-gcp-env]
     volumes:
       - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro
 
   airflow-dag-processor:
+    environment:
+      <<: [*gcp-runtime-env, *feast-gcp-env]
     volumes:
       - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro
 
   airflow-scheduler:
+    environment:
+      <<: [*gcp-runtime-env, *feast-gcp-env]
     volumes:
       - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro
 
   airflow-triggerer:
+    environment:
+      <<: [*gcp-runtime-env, *feast-gcp-env]
     volumes:
       - ${HOME}/.config/gcloud:/home/airflow/.config/gcloud:ro


### PR DESCRIPTION
Closes #321

The GCP compose overlay previously only mounted gcloud credentials into containers. This PR adds full storage and Feast environment wiring, making it a proper mirror of the objectstore overlay for the cloud path.

### Changes

- **`docker-compose.gcp.yml`**: Add `x-gcp-runtime-env` and `x-feast-gcp-env` YAML anchors, inject them into all services. MLflow gets `gs://` artifact destination. App gets pipeline report dir on GCS.
- **`containers/mlflow/docker-compose.yml`**: Remove hardcoded `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, and `MLFLOW_S3_ENDPOINT_URL` from the base service definition — the objectstore overlay already injects these for the local path.

### Validation

- `docker compose -f docker-compose.yml -f docker-compose.objectstore.yml config` — OK
- `GCP_PROJECT_ID=test docker compose -f docker-compose.yml -f docker-compose.gcp.yml config` — OK
- model-registry: `MLFLOW_ARTIFACT_DESTINATION=gs://...`, no `MLFLOW_S3_ENDPOINT_URL`
- All services: `STORAGE_BACKEND=bigquery`, full Feast BQ/GCS wiring
- 436 tests pass, pre-commit clean