### PR TITLE
docs(architecture): document compose overlay pattern

### DIFF
--- a/docs/site/getting-started.md
+++ b/docs/site/getting-started.md
@@ -48,7 +48,7 @@ curl -fsS -X POST http://127.0.0.1:8000/rank \
 
 ## Maintainer Path
 
-Most contributors can stop at the local evaluator path. If you maintain the shared cloud environment, start with [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md). The cloud path stays separate from the default contributor path and does not belong in the first-run setup.
+Most contributors can stop at the local evaluator path. If you maintain the shared cloud environment, start with [Delivery and Operator Workflow](system/delivery-and-operator-workflow.md). For the technical overlay mechanism that switches the local stack between MinIO and GCP backends, see [Compose Overlay Pattern](system/architecture.md#compose-overlay-pattern). The cloud path stays separate from the default contributor path and does not belong in the first-run setup.
 
 Hosted deployment keeps the runtime scope tight. Runtime services deploy to the cloud path. Local notebooks, docs tooling, and local emulators stay local or CI-only.
 

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -162,6 +162,28 @@ flowchart LR
 
 The hosted targets deploy runtime services only. Development assets, notebooks, docs tooling, and local emulators stay local or CI-only. Cloud Run owns the public API lane. Cloud Composer owns hosted orchestration. Operator services stay private by default.
 
+### Compose Overlay Pattern
+
+The local stack uses a layered Compose architecture. A shared base defines pipeline services. Storage and identity overlays swap the backend without changing the application layer.
+
+| File | Role | Storage backend |
+|------|------|----------------|
+| `docker-compose.yml` | Base services: Airflow, MLflow, app, UI, monitoring | None — storage is injected by an overlay |
+| `docker-compose.objectstore.yml` | Local overlay: MinIO, Feast Datastore emulator, S3 credentials | `STORAGE_BACKEND=s3`, MinIO on port 9000 |
+| `docker-compose.gcp.yml` | Cloud overlay: ADC credential mounts, BigQuery/GCS wiring, Feast GCS registry | `STORAGE_BACKEND=bigquery`, `gs://` artifact paths |
+
+Usage:
+
+```bash
+# Local development (default)
+docker compose -f docker-compose.yml -f docker-compose.objectstore.yml up
+
+# Cloud-parity testing with GCP credentials
+GCP_PROJECT_ID=my-project docker compose -f docker-compose.yml -f docker-compose.gcp.yml up
+```
+
+The overlays are mutually exclusive. Each injects environment variables into all services through YAML anchors (`x-objectstore-runtime-env` / `x-gcp-runtime-env`). The Python config layer reads `STORAGE_BACKEND` to resolve storage paths at runtime. CI validates both overlay configurations on every pull request.
+
 See [Cloud Mapping](cloud-mapping.md) and [Hosted Full-Stack](hosted-full-stack.md) for the hosted topology and managed service boundaries.
 
 ## Shared Core Vs Runtime Differences


### PR DESCRIPTION
Adds a **Compose Overlay Pattern** subsection under Deployment Targets in the architecture page.

### What it documents
- The three compose files and their roles (base, objectstore overlay, GCP overlay)
- Storage backends each overlay injects (`STORAGE_BACKEND=s3` vs `bigquery`)
- Usage commands for local and cloud-parity testing
- Mutual exclusivity, YAML anchor injection, and CI validation

### Why
The dual-lane concept was described at a high level but the technical implementation (compose overlays, env var switching) was not explicit in the docs. This strengthens the Architecture and Reproducibility rubric areas for MS3.

Closes #325