### PR TITLE
chore(ci): cache uv installs and gate compose smoke on relevant paths

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,41 @@ permissions:
   contents: read
 
 jobs:
-  compose:
+  changes:
     if: ${{ github.actor == github.repository_owner && (github.event_name ==
       'pull_request' || github.triggering_actor == github.repository_owner) }}
+    runs-on: ubuntu-latest
+    outputs:
+      compose: ${{ steps.filter.outputs.compose }}
+    steps:
+      - uses: actions/checkout@v6.0.2
+      - uses: dorny/paths-filter@v3.0.2
+        id: filter
+        with:
+          filters: |
+            compose:
+              - 'src/**'
+              - 'pyproject.toml'
+              - 'uv.lock'
+              - 'docker-compose*.yml'
+              - 'docker_includes/**'
+              - 'containers/**'
+              - 'Dockerfile*'
+              - 'Makefile'
+              - 'scripts/bootstrap-local.sh'
+              - 'scripts/smoke-local-evaluator.sh'
+              - 'config.yaml'
+              - '.github/workflows/ci.yml'
+
+  compose:
+    needs: changes
+    if: ${{ needs.changes.outputs.compose == 'true' || github.event_name == 'push' || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
       - run: docker compose -f docker-compose.yml config
       - run: GCP_PROJECT_ID=ci-validate docker compose -f docker-compose.yml -f
           docker-compose.gcp.yml config
@@ -55,6 +83,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
       - run: uv sync --frozen
       - run: uv run ruff check .
       - run: uv run ruff format --check .
@@ -66,6 +96,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
       - run: uv sync --frozen
       - run: uv run pytest tests/ -v
 
@@ -76,6 +108,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
       - run: uv sync --frozen
       - name: Validate pipeline DAG
         run: uv run dvc dag
@@ -122,5 +156,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6.0.2
       - uses: astral-sh/setup-uv@v8.1.0
+        with:
+          enable-cache: true
       - run: uv sync --frozen --only-group docs --no-default-groups
       - run: uv run mkdocs build -f docs/mkdocs.yml --strict


### PR DESCRIPTION
What changed:
- enable the setup-uv built-in cache on the lint, test, dvc, docs, and compose jobs
- add a paths-filter changes job so the compose smoke only runs on PRs that touch files affecting the local stack
- on push to main and workflow_dispatch the compose smoke runs unconditionally so post-merge regressions are still caught

Why:
- the compose smoke takes around 7 minutes and dominates the PR critical path
- docs-only, dashboard-only, terraform-only, and tests-only PRs do not need the local-stack smoke to validate the change
- lint and test (the required checks) still run on every PR

Verification:
- yaml load of .github/workflows/ci.yml succeeds
- branch protection: only lint and test are required on main, so skipping compose is safe

Closes #331