### PR TITLE
chore(infra): raise Cloud Run resources and add BQ prediction-event backfill

### DIFF
--- a/scripts/backfill-bq-prediction-events.py
+++ b/scripts/backfill-bq-prediction-events.py
@@ -1,0 +1,110 @@
+"""Backfill BigQuery prediction_events from local NDJSON via `bq load`.
+
+Filters out rows that overlap the existing BigQuery time window, JSON-encodes
+the requested_spot_ids array, and uses `bq load --source_format=NEWLINE_DELIMITED_JSON`.
+
+Usage:
+    PROJECT=mlops-hslu-h4izq DATASET=foehncast_monitoring TABLE=prediction_events \\
+        python scripts/backfill-bq-prediction-events.py
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _iso_to_dt(value: str) -> datetime:
+    return datetime.fromisoformat(value.replace("Z", "+00:00")).astimezone(timezone.utc)
+
+
+def _bq_minmax(table_fq: str) -> tuple[datetime | None, datetime | None]:
+    res = subprocess.run(
+        [
+            "bq",
+            "query",
+            "--use_legacy_sql=false",
+            "--format=json",
+            f"SELECT MIN(prediction_timestamp) AS lo, MAX(prediction_timestamp) AS hi FROM `{table_fq}`",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    rows = json.loads(res.stdout)
+    if not rows:
+        return None, None
+    lo_raw = rows[0].get("lo")
+    hi_raw = rows[0].get("hi")
+    lo = _iso_to_dt(lo_raw) if lo_raw else None
+    hi = _iso_to_dt(hi_raw) if hi_raw else None
+    return lo, hi
+
+
+def main() -> int:
+    project = os.environ.get("PROJECT", "mlops-hslu-h4izq")
+    dataset = os.environ.get("DATASET", "foehncast_monitoring")
+    table = os.environ.get("TABLE", "prediction_events")
+    table_fq = f"{project}.{dataset}.{table}"
+
+    jsonl = _PROJECT_ROOT / ".state" / "monitoring" / "prediction-events.jsonl"
+    if not jsonl.exists():
+        print(f"missing: {jsonl}", file=sys.stderr)
+        return 1
+
+    lo, hi = _bq_minmax(table_fq)
+    print(f"existing BQ range: [{lo}, {hi}]  table={table_fq}")
+
+    fd, out_path_str = tempfile.mkstemp(prefix="bq-backfill-", suffix=".ndjson")
+    os.close(fd)
+    out_path = Path(out_path_str)
+    kept = 0
+    skipped = 0
+    with (
+        jsonl.open("r", encoding="utf-8") as fh,
+        out_path.open("w", encoding="utf-8") as out,
+    ):
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            row = json.loads(line)
+            ts = _iso_to_dt(row["prediction_timestamp"])
+            if lo is not None and hi is not None and lo <= ts <= hi:
+                skipped += 1
+                continue
+            rsi = row.get("requested_spot_ids")
+            if isinstance(rsi, list):
+                row["requested_spot_ids"] = json.dumps(rsi)
+            out.write(json.dumps(row) + "\n")
+            kept += 1
+
+    print(f"kept {kept} | skipped {skipped} | tmp={out_path}")
+    if kept == 0:
+        out_path.unlink(missing_ok=True)
+        return 0
+
+    cmd = [
+        "bq",
+        "load",
+        "--source_format=NEWLINE_DELIMITED_JSON",
+        "--noreplace",
+        f"--project_id={project}",
+        f"{dataset}.{table}",
+        str(out_path),
+    ]
+    print("running:", " ".join(cmd))
+    res = subprocess.run(cmd)
+    out_path.unlink(missing_ok=True)
+    return res.returncode
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -888,8 +888,8 @@ resource "google_cloud_run_v2_service" "grafana" {
     timeout = "30s"
 
     scaling {
-      min_instance_count = 0
-      max_instance_count = 2
+      min_instance_count = 1
+      max_instance_count = 3
     }
 
     containers {
@@ -901,13 +901,15 @@ resource "google_cloud_run_v2_service" "grafana" {
 
       resources {
         limits = {
-          cpu = "1"
+          cpu = "2"
           # 512Mi caused continuous OOMs on Cloud Run (logs show
           # "Memory limit of 512 MiB exceeded with 515 MiB used"), which
           # in turn triggered grafana-apiserver Handler timeouts and
           # SQLite lock contention. 1Gi is the documented minimum for
-          # Grafana with embedded SQLite + provisioning.
-          memory = "1Gi"
+          # Grafana with embedded SQLite + provisioning. Bumped to 2Gi
+          # alongside cpu=2 and min_instances=1 to keep the embedded
+          # dashboards warm for the public UI.
+          memory = "2Gi"
         }
       }
 
@@ -1066,8 +1068,8 @@ resource "google_cloud_run_v2_service" "mlflow" {
     timeout         = "300s"
 
     scaling {
-      min_instance_count = 0
-      max_instance_count = 2
+      min_instance_count = 1
+      max_instance_count = 3
     }
 
     volumes {
@@ -1086,8 +1088,8 @@ resource "google_cloud_run_v2_service" "mlflow" {
 
       resources {
         limits = {
-          cpu    = "1"
-          memory = "2Gi"
+          cpu    = "2"
+          memory = "4Gi"
         }
       }
 
@@ -1157,8 +1159,8 @@ resource "google_cloud_run_v2_service" "ui" {
     timeout         = "300s"
 
     scaling {
-      min_instance_count = 0
-      max_instance_count = 2
+      min_instance_count = 1
+      max_instance_count = 3
     }
 
     containers {
@@ -1170,8 +1172,8 @@ resource "google_cloud_run_v2_service" "ui" {
 
       resources {
         limits = {
-          cpu    = "1"
-          memory = "1Gi"
+          cpu    = "2"
+          memory = "2Gi"
         }
       }
 
@@ -1267,8 +1269,8 @@ resource "google_cloud_run_v2_job" "feature_pipeline" {
 
         resources {
           limits = {
-            cpu    = "2"
-            memory = "2Gi"
+            cpu    = "4"
+            memory = "4Gi"
           }
         }
 
@@ -1307,8 +1309,8 @@ resource "google_cloud_run_v2_job" "training_pipeline" {
 
         resources {
           limits = {
-            cpu    = "2"
-            memory = "4Gi"
+            cpu    = "4"
+            memory = "8Gi"
           }
         }
 
@@ -1347,8 +1349,8 @@ resource "google_cloud_run_v2_job" "inference_pipeline" {
 
         resources {
           limits = {
-            cpu    = "1"
-            memory = "1Gi"
+            cpu    = "2"
+            memory = "2Gi"
           }
         }
 


### PR DESCRIPTION
Raise CPU, memory, and min-instance counts across app, grafana, mlflow, ui
Cloud Run services and across the feature, training, inference jobs to keep
hosted services warm and give pipeline jobs enough headroom.

Also add scripts/backfill-bq-prediction-events.py, a one-shot bq-load
helper that uploads local .state/monitoring/prediction-events.jsonl into
foehncast_monitoring.prediction_events, skipping any rows that overlap
the existing BigQuery time window.

Closes #336
