### PR TITLE
fix(ci): drop Grafana alert-rule and notification checks from local smoke

### DIFF
--- a/scripts/bootstrap-local.sh
+++ b/scripts/bootstrap-local.sh
@@ -362,48 +362,6 @@ verify_grafana_provisioning() {
     '"uid"[[:space:]]*:[[:space:]]*"foehncast-operations"' \
     '"title"[[:space:]]*:[[:space:]]*"FoehnCast Operations"' \
     'dashboard title FoehnCast Operations'
-
-  echo "Checking Grafana alert-rule provisioning..."
-  alert_rules_payload="$(grafana_api_get "/api/v1/provisioning/alert-rules")"
-  require_payload_patterns \
-    "$alert_rules_payload" \
-    '"uid"[[:space:]]*:[[:space:]]*"foehncast_predmon_schedule_fail"' \
-    'schedule failure alert rule' \
-    '"uid"[[:space:]]*:[[:space:]]*"foehncast_predmon_execution_fail"' \
-    'execution failure alert rule' \
-    '"uid"[[:space:]]*:[[:space:]]*"foehncast_predmon_stale_success"' \
-    'stale success alert rule' \
-    '"uid"[[:space:]]*:[[:space:]]*"foehncast_feature_stage_failures"' \
-    'feature stage failure alert rule' \
-    '"uid"[[:space:]]*:[[:space:]]*"foehncast_training_stage_failures"' \
-    'training stage failure alert rule' \
-    '"uid"[[:space:]]*:[[:space:]]*"foehncast_hosted_sync_stale"' \
-    'hosted sync stale alert rule'
-
-  echo "Checking Grafana contact point provisioning..."
-  contact_points_payload="$(grafana_api_get "/api/v1/provisioning/contact-points?name=foehncast-email")"
-  require_payload_patterns \
-    "$contact_points_payload" \
-    '"uid"[[:space:]]*:[[:space:]]*"foehncast_email"' \
-    '"name"[[:space:]]*:[[:space:]]*"foehncast-email"' \
-    'foehncast email contact point name'
-
-  echo "Checking Grafana notification policy provisioning..."
-  policies_payload="$(grafana_api_get "/api/v1/provisioning/policies")"
-  require_payload_patterns \
-    "$policies_payload" \
-    '"receiver"[[:space:]]*:[[:space:]]*"foehncast-email"' \
-    'notification policy receiver foehncast-email' \
-    '"object_matchers"' \
-    'notification policy route matchers' \
-    '"inference-monitoring"' \
-    'notification policy inference-monitoring matcher' \
-    '"feature-pipeline"' \
-    'notification policy feature-pipeline matcher' \
-    '"training-pipeline"' \
-    'notification policy training-pipeline matcher' \
-    '"hosted-operator"' \
-    'notification policy hosted-operator matcher'
 }
 
 

--- a/tests/test_monitoring_stack.py
+++ b/tests/test_monitoring_stack.py
@@ -331,18 +331,6 @@ def test_local_bootstrap_verifies_grafana_provisioning() -> None:
 
     assert "verify_grafana_provisioning" in bootstrap
     assert "/api/search?dashboardUIDs=foehncast-operations" in bootstrap
-    assert "/api/v1/provisioning/alert-rules" in bootstrap
-    assert "foehncast_predmon_schedule_fail" in bootstrap
-    assert "foehncast_predmon_execution_fail" in bootstrap
-    assert "foehncast_predmon_stale_success" in bootstrap
-    assert "foehncast_feature_stage_failures" in bootstrap
-    assert "foehncast_training_stage_failures" in bootstrap
-    assert "foehncast_hosted_sync_stale" in bootstrap
-    assert "/api/v1/provisioning/contact-points?name=foehncast-email" in bootstrap
-    assert "/api/v1/provisioning/policies" in bootstrap
-    assert '"feature-pipeline"' in bootstrap
-    assert '"training-pipeline"' in bootstrap
-    assert '"hosted-operator"' in bootstrap
 
 
 def test_app_compose_routes_monitoring_metrics_to_statsd_service() -> None:


### PR DESCRIPTION
PR #334 removed the inline alert rules, contact points, and notification
policies from Grafana provisioning, but bootstrap-local.sh kept asserting
them, breaking the 'compose' smoke job on every push. Keep the dashboard
provisioning check, drop the stale ones.
