### PR TITLE
docs: stack mermaid diagrams vertically (TD) for better page fit

### DIFF
--- a/docs/site/index.md
+++ b/docs/site/index.md
@@ -5,7 +5,7 @@ FoehnCast ranks Swiss kiteboarding spots for one rider profile by combining live
 ## Product In One View
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     WX[Forecast + spot context] --> RANK[Rank session options]
     RIDER[Rider + drive context] --> RANK
     RANK --> DECIDE[Choose where to ride next]
@@ -36,7 +36,7 @@ flowchart LR
 ## System Flow
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     INGEST[Ingest forecasts] --> FEATURES[Build curated features] --> TRAIN[Train and register model] --> SERVE[Serve prediction and ranking]
 </div>
 

--- a/docs/site/overview.md
+++ b/docs/site/overview.md
@@ -5,7 +5,7 @@ FoehnCast is a local-first ML system for deciding where to kite next. This page 
 ## Shared System Core
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
   %% Branded colors
   classDef app fill:#222,stroke:#333,color:#fff
   classDef data fill:#ececff,stroke:#9370db,color:#000

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -12,7 +12,7 @@ FoehnCast keeps the same Feature-Training-Inference split in every runtime. The 
 ## System In One View
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     %% Styling
     classDef cloud fill:#f5f5f5,stroke:#333
     classDef pipe fill:#e1f5fe,stroke:#01579b
@@ -90,7 +90,7 @@ The same feature and training boundaries are driven by two different control pat
 - The `inference_pipeline` DAG bridges inference into the Airflow world: it is asset-triggered by model registration and runs batch predictions across all configured spots, feeding the prediction-event history that hindcast validation and drift detection consume.
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     classDef ctl fill:#f5f5f5,stroke:#333
     classDef pipe fill:#e1f5fe,stroke:#01579b
     classDef store fill:#ececff,stroke:#9370db
@@ -129,7 +129,7 @@ The runtime orchestration layer models main data products as Airflow assets. The
 ## Deployment Targets
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     classDef core fill:#f5f5f5,stroke:#333
     classDef local fill:#e1f5fe,stroke:#01579b
     classDef cloud fill:#fff8e1,stroke:#f57f17
@@ -203,7 +203,7 @@ Cloud Composer runs the hosted Airflow surface used for scheduling, retries, bac
 ## Local Evaluator Architecture
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     %% Stylings
     classDef infra fill:#f5f5f5,stroke:#333
     classDef pipeline fill:#e1f5fe,stroke:#01579b
@@ -241,7 +241,7 @@ The Airflow control plane reflects those hand-offs directly. The feature pipelin
 ## Hosted Runtime Detail
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     classDef data fill:#ececff,stroke:#9370db
     classDef operator fill:#fff8e1,stroke:#f57f17
 
@@ -263,7 +263,7 @@ flowchart LR
 </div>
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     classDef input fill:#f5f5f5,stroke:#333
     classDef data fill:#ececff,stroke:#9370db
     classDef serve fill:#fff8e1,stroke:#f57f17

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -107,7 +107,7 @@ This boundary matters because the hosted app is the product and service surface.
 ## Hosted Topology
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     %% Styling
     classDef infra fill:#f5f5f5,stroke:#333
     classDef runner fill:#f4f1ea,stroke:#f05032
@@ -200,7 +200,7 @@ This is role matching, not a literal copy. Some local tools map to hosted servic
 ## Cloud Pipeline Shape
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     classDef source fill:#f5f5f5,stroke:#333
     classDef process fill:#e1f5fe,stroke:#01579b
     classDef data fill:#ececff,stroke:#9370db

--- a/docs/site/system/configuration-and-contracts.md
+++ b/docs/site/system/configuration-and-contracts.md
@@ -13,7 +13,7 @@ The goal is not to document every environment variable in isolation. The goal is
 ## Contract In One View
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     TF["Terraform and GitHub delivery variables"] --> ENV[".env and environment variables"]
     YAML["config.yaml"] --> PY["src/foehncast/config.py"]
     ENV --> PY

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -121,7 +121,7 @@ GitHub Actions may trigger reviewed delivery workflows, but runtime scheduling d
 GitHub has exactly one reviewed handoff into runtime execution.
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     GHW["fab:fa-github Runtime release workflow"] --> TARGET["reviewed receiver selection"]
     TARGET --> AUTH["OIDC + access token"]
     AUTH --> API["Composer Airflow API"]

--- a/docs/site/system/feature-pipeline.md
+++ b/docs/site/system/feature-pipeline.md
@@ -13,7 +13,7 @@ This page describes the validated feature contract. It focuses on what each stag
 ## Pipeline Shape
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     subgraph Input ["Inputs"]
         direction TB
         CFG["Spot and storage config"]
@@ -141,7 +141,7 @@ This layer does not decide whether a forecast is good for riding. That belongs t
 Storage works only if it behaves like persistence rather than transformation. A stored feature frame should come back with the same schema, index semantics, and numeric values that validation approved.
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     FEAT["Curated feature frame"] --> WRITE["write_features"]
     WRITE --> BACKEND["Local, S3-compatible, or BigQuery backend"]
     BACKEND --> READ["read_features"]
@@ -191,7 +191,7 @@ Terraform is part of the storage boundary because it provisions the cloud-side G
 Feast is downstream from the curated feature store. It should consume curated rows, not reach back into raw ingestion or recompute engineering logic.
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     STORED["Stored curated rows"] --> OFF["build_offline_store_frame"]
     STORED --> ENT["build_entity_rows"]
     OFF --> HIST["Historical retrieval inputs"]

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -13,7 +13,7 @@ This page describes the hosted full-stack contract and how the managed services 
 ## Target Shape
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     classDef infra fill:#f5f5f5,stroke:#333
     classDef runner fill:#f4f1ea,stroke:#f05032
     classDef platform fill:#fff,stroke:#4285F4

--- a/docs/site/system/inference-pipeline.md
+++ b/docs/site/system/inference-pipeline.md
@@ -13,7 +13,7 @@ This page describes what the running app owns and what stays optional or operato
 ## Inference Shape
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     subgraph RequestPath ["Request path"]
         direction TB
         REQ["Requested spots"]

--- a/docs/site/system/interfaces-and-surfaces.md
+++ b/docs/site/system/interfaces-and-surfaces.md
@@ -11,7 +11,7 @@ FoehnCast exposes five surface classes: rider, service, operator, delivery, and 
 ## Surface Map
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     classDef public fill:#f5f5f5,stroke:#333
     classDef service fill:#e1f5fe,stroke:#01579b
     classDef operator fill:#fff8e1,stroke:#f57f17

--- a/docs/site/system/local-evaluator.md
+++ b/docs/site/system/local-evaluator.md
@@ -13,7 +13,7 @@ This page describes the default contributor runtime contract. It documents the s
 ## Target Shape
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     classDef pipeline fill:#e1f5fe,stroke:#01579b
     classDef registry fill:#fff,stroke:#d32f2f
     classDef app fill:#222,stroke:#333,color:#fff

--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -13,7 +13,7 @@ This page describes what is measured, where the evidence comes from, and how ope
 ## Signal Path
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     subgraph Sources ["Evidence sources"]
         direction TB
         AIR["Airflow pipeline summaries"]
@@ -82,7 +82,7 @@ Durable files survive restarts and support audits. Runtime counters on `/metrics
 The serving application publishes one composed Prometheus payload on `/metrics`:
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     subgraph App ["/metrics payload"]
         direction TB
         FPS["Feature pipeline summary gauges"]

--- a/docs/site/system/training-pipeline.md
+++ b/docs/site/system/training-pipeline.md
@@ -13,7 +13,7 @@ This page describes what each stage owns and what remains an explicit operator c
 ## Pipeline Shape
 
 <div class="mermaid">
-flowchart LR
+flowchart TD
     CUR["Curated feature store asset"] --> LAB["Label curated rows"]
     REQ["Training-request asset"] --> LAB
     LAB --> TRN["Train model"]


### PR DESCRIPTION
Closes #352

Convert every 'flowchart LR' under docs/site to 'flowchart TD' so the
diagrams render top-down inside the article column instead of forcing
horizontal scroll on the published site. No diagram content changes,
only orientation.
