### PR TITLE
fix(training): reset stage_failure_counts at the start of a new training run

### DIFF
--- a/src/foehncast/orchestration.py
+++ b/src/foehncast/orchestration.py
@@ -1031,9 +1031,15 @@ def run_training_pipeline_step(
     requested_stage: str = "Candidate",
 ) -> str:
     """Train the model and persist the latest step-level training summary."""
-    training_state = _training_summary_state(
+    # Start a fresh training summary: the "train" stage is the first step of a
+    # new training run, so any persisted stage_failure_counts /
+    # stage_durations_seconds from prior runs must not bleed into the new
+    # run's stage_states (otherwise a one-off historical failure would keep
+    # the rail's train pill stuck at "failed" forever).
+    training_state = TrainingPipelineState.from_summary(
         dataset=dataset,
         requested_stage=requested_stage,
+        summary={},
     )
 
     def _run() -> str:


### PR DESCRIPTION
Closes #356

The System tab training rail showed the 'train' stage as failed even
when the latest Cloud Run training job succeeded end-to-end.

Root cause: run_training_pipeline_step loaded the latest persisted
training summary at entry. If a prior run failed at 'train', the
persisted stage_failure_counts['train'] stayed > 0, and the new run's
successful completion only recorded a duration; it never decremented
the counter. _stage_states then computed stage_states['train'] =
'failed' forever.

Build a fresh TrainingPipelineState at the start of
run_training_pipeline_step. evaluate_training_run and
register_training_run keep their current behaviour: they load the
matching summary by training_run_id, which is the correct continuation
path.
