### PR TITLE
chore: finalize post-simplification cleanup

### DIFF
--- a/.github/workflows/promote-candidate.yml
+++ b/.github/workflows/promote-candidate.yml
@@ -97,7 +97,7 @@ jobs:
             echo "- Target alias: $TARGET_ALIAS"
             echo
             echo "GitHub Actions no longer promotes live runtime state directly."
-            echo "Use Trigger Runtime Release with action promote_candidate so GitHub sends one reviewed request into hosted Airflow."
+            echo "Use the reviewed runtime release handoff with action promote_candidate so the request goes through the configured Airflow API path."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo 'Candidate promotion is no longer executed directly from GitHub Actions. Use Trigger Runtime Release with action promote_candidate instead.' >&2
+          echo 'Candidate promotion is no longer executed directly from GitHub Actions. Use the reviewed runtime release handoff with action promote_candidate instead.' >&2
           exit 1

--- a/.github/workflows/publish-app-image.yml
+++ b/.github/workflows/publish-app-image.yml
@@ -152,7 +152,7 @@ jobs:
             echo "- Builder: Cloud Build"
             echo "- Build id: ${{ steps.submit.outputs.build_id }}"
             echo "- Runtime handoff: not executed from GitHub in this workflow"
-            echo "- Next step: run Trigger Runtime Release with action deploy_candidate and this immutable image URI"
+            echo "- Next step: use the reviewed runtime release handoff with action deploy_candidate and this immutable image URI"
           } >> "$GITHUB_STEP_SUMMARY"
 
   skipped:

--- a/.github/workflows/rollback-live-release.yml
+++ b/.github/workflows/rollback-live-release.yml
@@ -112,7 +112,7 @@ jobs:
             echo "- Target alias: $TARGET_ALIAS"
             echo
             echo "GitHub Actions no longer restores live runtime state directly."
-            echo "Use Trigger Runtime Release with action rollback_live so GitHub sends one reviewed request into hosted Airflow."
+            echo "Use the reviewed runtime release handoff with action rollback_live so the request goes through the configured Airflow API path."
           } >> "$GITHUB_STEP_SUMMARY"
-          echo 'Live rollback is no longer executed directly from GitHub Actions. Use Trigger Runtime Release with action rollback_live instead.' >&2
+          echo 'Live rollback is no longer executed directly from GitHub Actions. Use the reviewed runtime release handoff with action rollback_live instead.' >&2
           exit 1

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ flowchart LR
 | Feature pipeline | Working | Airflow ingests, engineers, validates, and stores curated weather features |
 | Training pipeline | Working | Airflow labels data, trains the model, evaluates it, and registers fresh versions in MLflow under the requested registry alias |
 | Inference pipeline | Working | FastAPI serves `/health`, `/spots`, `/predict`, `/rank`, and online-feature routes, and `ui/app.py` provides the Streamlit demo |
-| Hosted runtime | Working | The shared environment uses Cloud Run as the only promoted public API path while keeping the hosted full-stack target online for operator tooling |
+| Hosted runtime | Working | The shared environment uses Cloud Run for the public API and hosted cloud services, while local Airflow remains the reviewed orchestration path |
 | Automation | Working | GitHub Actions publishes images, validates infrastructure, and drives remote Terraform workflows |
 | Monitoring | Working | Docker Compose runs Prometheus and a StatsD exporter; the app exposes `/metrics`; the Streamlit UI renders native Altair charts from direct PromQL queries; and Prometheus loads alert rules from checked-in config |
 

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -76,6 +76,5 @@ nav:
       - Seasonality: system/seasonality.md
   - Operations:
       - Monitoring: system/monitoring.md
-      - Composer DAG Validation: system/composer-dag-validation.md
   - Evidence:
       - Grading Checklist: system/grading-checklist.md

--- a/docs/site/system/architecture.md
+++ b/docs/site/system/architecture.md
@@ -1,12 +1,12 @@
 # Architecture
 
-FoehnCast keeps the same Feature-Training-Inference split in every runtime. The cloud path adds a public API lane on Cloud Run and a private operator lane for Airflow, MLflow, and monitoring. Image builds run through Cloud Build and orchestration runs on Cloud Composer.
+FoehnCast keeps the same Feature-Training-Inference split in every runtime. The cloud path adds a public API lane on Cloud Run plus private operator services and managed cloud automation on the same shared data layer. Image builds run through Cloud Build, while local Airflow remains the reviewed DAG runtime.
 
 !!! note "How to read this page"
 
     Start with the local Compose stack.
     In the cloud, Cloud Run is the public API lane.
-    Cloud Composer is the hosted orchestration surface.
+    Cloud Workflows and Cloud Scheduler automate the hosted cloud path.
     Rider-facing screens are separate from operator dashboards.
 
 ## System In One View
@@ -68,7 +68,7 @@ Monitoring visualization uses native Altair charts in the Streamlit UI. Public d
 |------|----------------|-------|-----------|----------|
 | Local evaluator lane | local Compose stack | stable baseline | validate the full system on one machine | local-only |
 | Shared API lane | hosted inference target on Cloud Run | active hosted target | serve the shared FastAPI product and service routes | public |
-| Operator lane | Cloud Composer plus managed operator services | active hosted operator surface | provide the private operator surface for Airflow, MLflow, and monitoring | private by default |
+| Operator lane | hosted operator services on Cloud Run and managed GCP surfaces | active hosted operator surface | provide private tracking, monitoring, and automation surfaces | private by default |
 
 ## Stable Pipeline Boundaries
 
@@ -77,7 +77,7 @@ Monitoring visualization uses native Altair charts in the Streamlit UI. Public d
 | Feature pipeline | Collect data, engineer curated rows, validate them, and store the result | local Airflow DAG plus the configured storage backend |
 | Training pipeline | Label data, train the model, evaluate it, and register a serving version | local Airflow DAG plus MLflow |
 | Inference pipeline | Serve health, predict, rank, and spot-list responses; run batch predictions after model registration | FastAPI app container plus the asset-triggered `inference_pipeline` DAG |
-| Orchestration | Schedule runtime DAGs, retries, backfills, and operator inspection | local Airflow in the local evaluator; Cloud Composer in the hosted environment |
+| Orchestration | Schedule runtime DAGs, retries, backfills, and operator inspection | local Airflow in the local evaluator; Cloud Workflows and Cloud Scheduler in the hosted environment |
 | Online features | Surface curated fields through an online lookup route | Feast-backed service path plus demo page |
 | Monitoring | Scrape runtime metrics, collect pushed gauges, run hindcast validation, and visualize through native Altair charts in the Streamlit UI | Prometheus, StatsD exporter, and Streamlit metric panels |
 
@@ -145,7 +145,7 @@ flowchart TD
     subgraph HostedTargets ["fab:fa-google Hosted lanes"]
         direction TB
         RUN["Cloud Run API"]:::cloud
-        CMP["Cloud Composer"]:::cloud
+        WF["Cloud Workflows + Scheduler"]:::cloud
         CB["Cloud Build"]:::cloud
     end
 
@@ -157,10 +157,10 @@ flowchart TD
 |------|-----------|----------|
 | Local evaluator target | Airflow, MLflow, FastAPI, Prometheus, StatsD exporter, MinIO, Feast emulator, and optional `development_env` | default development and evaluation |
 | Hosted inference target | FastAPI only, backed by shared GCP services | primary hosted API surface |
-| Hosted operator target | Cloud Build for runtime images, Cloud Composer for hosted Airflow workloads, and managed operator services for MLflow and monitoring | hosted build, orchestration, and operator surface |
+| Hosted operator target | Cloud Build for runtime images, Cloud Workflows and Cloud Scheduler for hosted automation, and managed operator services for MLflow and monitoring | hosted build, automation, and operator surface |
 | GitHub automation | review, workflow dispatch, and Terraform workflows | shared cloud delivery control plane |
 
-The hosted targets deploy runtime services only. Development assets, notebooks, docs tooling, and local emulators stay local or CI-only. Cloud Run owns the public API lane. Cloud Composer owns hosted orchestration. Operator services stay private by default.
+The hosted targets deploy runtime services only. Development assets, notebooks, docs tooling, and local emulators stay local or CI-only. Cloud Run owns the public API lane. Hosted automation stays on managed cloud services. Operator services stay private by default.
 
 ### Compose Overlay Pattern
 
@@ -196,9 +196,9 @@ See [Cloud Mapping](cloud-mapping.md) and [Hosted Full-Stack](hosted-full-stack.
 
 Read the left column as the stable design. Read the other columns as deployment choices around that design.
 
-## Hosted Orchestration
+## Hosted Automation
 
-Cloud Composer runs the hosted Airflow surface used for scheduling, retries, backfills, and runtime release handoff. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the delivery boundary.
+The hosted cloud path uses Cloud Workflows and Cloud Scheduler for serverless automation, while the reviewed runtime-release handoff still targets an Airflow API endpoint. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the delivery boundary.
 
 ## Local Evaluator Architecture
 
@@ -253,13 +253,13 @@ flowchart TD
 
     subgraph ManagedOps ["fab:fa-google Managed ops"]
         direction TB
-        CMP["Cloud Composer"]:::operator
-        MLF["MLflow"]:::operator
-        CMP --> MLF
+        WF["Cloud Workflows + Scheduler"]:::operator
+        MLF["MLflow + monitoring"]:::operator
+        WF --> MLF
     end
 
-    OPSDATA --> CMP
-    APPDATA --> CMP
+    OPSDATA --> MLF
+    APPDATA --> WF
 </div>
 
 <div class="mermaid">
@@ -280,7 +280,7 @@ flowchart TD
     DATA --> RAPI
 </div>
 
-The hosted lanes reuse the same application boundaries but deploy different runtime surfaces. The first diagram shows the private operator lane. The second shows the public API lane on Cloud Run. Changing the build and orchestration plane does not change the core pipeline split.
+The hosted lanes reuse the same application boundaries but deploy different runtime surfaces. The first diagram shows the private operator and automation surfaces. The second shows the public API lane on Cloud Run. Changing the build or automation plane does not change the core pipeline split.
 
 ## Representative Validation
 
@@ -297,7 +297,7 @@ The hosted lanes reuse the same application boundaries but deploy different runt
 - Personalized ranking stays in the inference layer.
 - Feature engineering and training are reusable across local and hosted paths.
 - Hosted changes mostly affect storage, auth, orchestration, and image delivery.
-- The retained operator lane supports the active hosted path but is not the desired long-term design.
+- Hosted operator services stay thin and reuse the same pipeline boundaries without reintroducing a hosted Airflow stack.
 - Feast layers on top of the same curated features instead of splitting the design.
 
 ## Storage Contract

--- a/docs/site/system/cloud-architecture.md
+++ b/docs/site/system/cloud-architecture.md
@@ -73,7 +73,6 @@ flowchart TB
 
     click UI "https://console.cloud.google.com/run?project=" "Open Cloud Run"
     click APP "https://console.cloud.google.com/run?project=" "Open Cloud Run"
-    click GF "https://console.cloud.google.com/run?project=" "Open Cloud Run"
     click MLF "https://console.cloud.google.com/run?project=" "Open Cloud Run"
     click WF "https://console.cloud.google.com/workflows?project=" "Open Workflows"
     click SCHED "https://console.cloud.google.com/cloudscheduler?project=" "Open Scheduler"

--- a/docs/site/system/configuration-and-contracts.md
+++ b/docs/site/system/configuration-and-contracts.md
@@ -91,9 +91,9 @@ The checked-in `.env.example` shows the kind of values that belong in runtime wi
 | Monitoring history path | `FOEHNCAST_PREDICTION_EVENT_LOG_PATH` |
 | Feast runtime binding | `FOEHNCAST_FEAST_SOURCE`, `FOEHNCAST_FEAST_REPO_PATH`, `FOEHNCAST_FEAST_CONFIG_PATH`, `FOEHNCAST_FEAST_BIGQUERY_*`, `FOEHNCAST_FEAST_DATASTORE_*` |
 
-These values describe one concrete runtime instance. They should stay overridable because the local evaluator, hosted full-stack target, and hosted inference target do not all bind to the same services.
+These values describe one concrete runtime instance. They should stay overridable because the local evaluator, shared API lane, and hosted operator surfaces do not all bind to the same services.
 
-In the shared hosted path, the full-stack target represents the active operator lane. That lane is a retained operator surface, so the runtime wiring should stay explicit instead of being treated as a permanent deployment shape.
+In the shared hosted path, the operator surfaces stay intentionally smaller than the local evaluator. Their runtime wiring should stay explicit instead of being treated as a permanent deployment shape.
 
 ## Cloud Runtime Inventory
 

--- a/docs/site/system/grading-checklist.md
+++ b/docs/site/system/grading-checklist.md
@@ -15,7 +15,7 @@ FoehnCast follows a Feature-Training-Inference (FTI) split with clear module bou
 | Containerized services | 8 container definitions in `containers/` (Airflow, MLflow, app, UI, monitoring, development) |
 | Modular Compose with includes | `docker-compose.yml` includes from `docker_includes/` and `containers/` |
 | Local and cloud runtime lanes | `scripts/bootstrap-local.sh` (local), `scripts/bootstrap-gcp.sh` + Terraform (cloud) |
-| Cloud Run serving + Cloud Composer orchestration | `terraform/main.tf`, `.github/workflows/publish-app-image.yml` |
+| Cloud Run serving + hosted cloud automation | `terraform/main.tf`, `.github/workflows/publish-app-image.yml` |
 | Storage abstraction (S3/BigQuery) | `src/foehncast/feature_pipeline/store.py` with backend selection |
 
 **Docs**: [Architecture](architecture.md), [Cloud Mapping](cloud-mapping.md)
@@ -28,8 +28,8 @@ CI/CD, infrastructure-as-code, and pipeline scheduling run without manual steps 
 |-------|----------|
 | CI pipeline (7 jobs) | `.github/workflows/ci.yml` — shell, lint, terraform, dvc, compose, test, docs |
 | Automated image publishing | `.github/workflows/publish-app-image.yml`, `publish-runtime-images.yml` |
-| DAG bundle publishing to Composer | `.github/workflows/publish-composer-dags.yml` |
-| Runtime release trigger | `.github/workflows/trigger-runtime-release.yml` |
+| Hosted automation provisioning | `terraform/main.tf`, `.github/workflows/terraform.yml` |
+| Runtime release handoff | `scripts/trigger-runtime-release.sh`, `dags/runtime_release_dag.py`, `.github/workflows/promote-candidate.yml`, `.github/workflows/rollback-live-release.yml` |
 | Infrastructure-as-code (Terraform) | `terraform/main.tf`, `terraform/providers.tf`, `terraform/outputs.tf`, `terraform/versions.tf` |
 | Cloud Build configs | 4 configs in `cloudbuild/` |
 | Bootstrap scripts | `scripts/bootstrap-local.sh`, `scripts/bootstrap-gcp.sh` (19 scripts total) |
@@ -37,7 +37,7 @@ CI/CD, infrastructure-as-code, and pipeline scheduling run without manual steps 
 | Asset-triggered inference | Training DAG registers model → Inference DAG auto-runs |
 | Pre-commit hooks | `.pre-commit-config.yaml` — 8 hooks including ruff lint and format |
 
-**Docs**: [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Composer DAG Validation](composer-dag-validation.md)
+**Docs**: [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Cloud Architecture](cloud-architecture.md)
 
 ## Reproducibility (20%)
 

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -1,13 +1,14 @@
 # Hosted Full-Stack
 
-FoehnCast keeps the hosted full-stack target as the private operator lane in the shared environment. Cloud Run carries the public API lane. Cloud Composer owns hosted orchestration. Cloud Build publishes runtime images. The operator services — MLflow, monitoring, and private app checks — run on managed GCP surfaces alongside the same shared data layer.
+FoehnCast no longer runs a separate hosted full-stack Airflow target. The shared environment now keeps a public Cloud Run lane plus a smaller set of private operator surfaces and managed cloud automation. Local Airflow remains the reviewed DAG runtime and runtime-release handoff path.
 
-This page describes the hosted full-stack contract and how the managed services split responsibilities.
+This page describes the hosted surfaces that remain after removing the old full-stack VM and managed-orchestration tracks.
 
 !!! note "Scope"
 
-    This page describes the validated hosted operator contract.
-    It explains the split between Cloud Run, Cloud Composer, Cloud Build, and supporting operator services.
+    This page describes the remaining hosted cloud surfaces.
+    Cloud Run carries the public API lane.
+    Cloud Workflows, Cloud Scheduler, MLflow, and monitoring stay on the operator side.
     It is not the local evaluator setup guide.
 
 ## Target Shape
@@ -25,88 +26,78 @@ flowchart TD
     subgraph GCP ["fab:fa-google Hosted environment"]
         direction LR
         DATA["BigQuery + GCS + Datastore"]:::platform
-        RUN["Cloud Run API"]:::platform
-        CMP["Cloud Composer"]:::operator
+        RUN["Cloud Run services"]:::platform
+        WF["Cloud Workflows + Scheduler"]:::operator
         MLF["MLflow"]:::operator
-        MON["Monitoring"]:::operator
+        MON["Managed monitoring"]:::operator
     end
 
     TF --> DATA
     DATA --> RUN
-    DATA --> CMP
+    DATA --> MLF
+    DATA --> WF
     GH --> RUN
-    GH --> CMP
-    CMP --> MLF
-    CMP --> MON
+    GH --> MLF
+    GH --> WF
+    RUN --> MON
+    MLF --> MON
 </div>
 
 ## Role In The Shared Environment
 
 | Lane | Concrete target | Main role |
 |------|----------------|-----------|
-| Shared API lane | Cloud Run hosted inference target | serve the public FastAPI routes |
-| Operator lane | Cloud Composer plus managed operator services | provide the hosted orchestration, tracking, and monitoring surface |
+| Shared API lane | Cloud Run hosted API and UI surfaces | serve the public FastAPI routes and rider-facing views |
+| Operator surfaces | protected MLflow, monitoring, and internal checks | provide private tracking and review surfaces |
+| Hosted automation | Cloud Workflows plus Cloud Scheduler | coordinate scheduled cloud-side refreshes |
 
-The hosted full-stack target stays a runtime target, not a contributor environment. It depends on shared GCP storage and identities instead of local emulators, and it stays private while Cloud Run owns public serving.
+The hosted cloud path stays a runtime target, not a contributor environment. It depends on shared GCP storage and identities instead of local emulators, and it stays private while Cloud Run owns public serving.
 
 ## Shared Core And Hosted Differences
 
-| Shared with the local evaluator | Different in the hosted operator lane |
+| Shared with the local evaluator | Different in the hosted cloud path |
 |------|--------------------------------------|
 | Same Feature-Training-Inference boundaries | BigQuery, GCS, and Datastore replace local object and emulator surfaces |
-| Same FastAPI app and Feast-backed feature path | Cloud Run carries the shared public API while the operator services stay private |
-| Same Airflow, MLflow, and monitoring roles | Cloud Composer owns orchestration; MLflow and monitoring run as managed operator services |
+| Same FastAPI app and Feast-backed feature path | Cloud Run carries the shared public API while operator surfaces stay private |
+| Same MLflow and monitoring roles | hosted automation moves to Cloud Workflows and Cloud Scheduler instead of a hosted Airflow stack |
 | Same repository and runtime contracts | service accounts and GitHub OIDC replace local developer credentials |
 
-That makes the hosted full-stack target a managed operator surface, not a single-VM deployment.
+That keeps the hosted path smaller than the old full-stack design without changing the pipeline boundaries.
 
 ## Surface Responsibilities
 
 | Surface | Main responsibility | Must not become |
 |------|----------------------|-----------------|
 | Shared GCP baseline | provide Artifact Registry, GCS, BigQuery, Datastore, and identity foundations | the application runtime itself |
-| Cloud Composer | schedule DAGs, retries, backfills, and runtime release handoff | a contributor setup path or notebook host |
-| Cloud Run | serve the public FastAPI product and service routes | a hidden deployment control plane |
+| Cloud Run | serve the public FastAPI product and service routes plus selected hosted services | a hidden deployment control plane |
+| Cloud Workflows + Scheduler | coordinate scheduled hosted automation | a contributor setup path or notebook host |
 | Cloud Build | publish reviewed runtime images to Artifact Registry | a substitute for GitHub-reviewed delivery |
-| MLflow and Prometheus | operator tracking and monitoring | the rider-facing interface |
+| MLflow and monitoring | operator tracking and monitoring | the rider-facing interface |
 | GitHub OIDC delivery | run remote Terraform and image-driven deploy updates | a substitute for the runtime orchestrator |
 
 ## Runtime Contract
 
-The hosted full-stack target relies on these shared runtime dependencies:
+The hosted cloud path relies on these shared runtime dependencies:
 
 - BigQuery for the curated cloud feature layer
-- GCS for MLflow artifacts and Feast registry-style storage
+- GCS for MLflow artifacts, pipeline reports, and Feast registry-style storage
 - a named Datastore-mode database for Feast online serving
-- the same Feast runtime contract used by the Cloud Run path so both hosted targets point at the same logical serving configuration
+- Cloud SQL for MLflow metadata
 - runtime service accounts with appropriate IAM roles instead of mounted key files
 
 The identity split around this target is deliberate:
 
-- GitHub Actions uses the deployer identity for Terraform apply, image publish, and Cloud Run rollout work.
-- Cloud Run uses its own narrower runtime identity for the inference-only service.
-- Cloud Composer uses a dedicated service account scoped to orchestration, training, MLflow, and Feast preparation.
+- GitHub Actions uses the deployer identity for Terraform apply, image publish, and Cloud Run rollout work
+- Cloud Run services use narrower runtime identities for serving and service-to-service access
+- Cloud Workflows and Cloud Scheduler use managed service identities to call reviewed runtime entry points
 
-The Composer identity remains broader than the Cloud Run identity only because orchestration still owns more responsibilities in the hosted environment. The goal is to keep each service's IAM scope as narrow as its actual duties require.
+The goal is to keep each service's IAM scope as narrow as its actual duties require.
 
 ## Bootstrap And Day-2 Delivery
 
-The hosted full-stack target is not part of the default contributor path. Its lifecycle splits into one-time maintainer bootstrap and GitHub-managed day-2 delivery after bootstrap. For this target, the hosted-specific contract is: Terraform provisions managed services and shared cloud data surfaces, GitHub Actions publishes DAGs and images, and the operator services stay private while Cloud Run remains the public API lane.
+The hosted cloud path is not part of the default contributor setup. Its lifecycle splits into one-time maintainer bootstrap and GitHub-managed day-2 delivery after bootstrap. Terraform provisions shared services and optional hosted automation, GitHub Actions publishes images and updates hosted surfaces, and local Airflow remains the reviewed DAG runtime when maintainers need explicit runtime-release evidence.
 
 See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed bootstrap, remote Terraform, and runtime-release handoff steps.
-
-## Hosted Sync Contract
-
-The hosted environment tracks deployment state through durable evidence rather than VM-local state.
-
-The sync contract is:
-
-- Cloud Composer receives reviewed DAG bundles from the GitHub publish workflow
-- each successful sync writes `.state/hosted-sync/last-success.json`
-- the app republishes that status through `/metrics`
-- the Streamlit UI can show the last successful hosted refresh from the same sync state
-
-This makes the hosted target observable through standard metrics and evidence files.
 
 ## Exposure And Verification
 
@@ -114,15 +105,15 @@ The shared hosted target keeps exposure narrow by default.
 
 The exposure contract is:
 
-- Cloud Composer and MLflow stay private through IAM and network controls
-- operator monitoring surfaces remain on the operator side unless you deliberately publish them
+- Cloud Run API and UI surfaces are the only public-facing endpoints by default
+- MLflow, monitoring, and hosted automation surfaces stay private through IAM and network controls
 - `bootstrap-gcp` treats Cloud Run as the primary hosted API path and verifies `/health`, `/spots`, and `/metrics`
 
 This preserves the same public-surface rule used across the rest of the docs: the app is the product and service surface, while operator tools remain private by default.
 
 ## What Stays Out Of This Target
 
-The hosted full-stack path deploys runtime services only.
+The hosted cloud path deploys runtime services only.
 
 These surfaces stay local or CI-only:
 
@@ -134,7 +125,7 @@ These surfaces stay local or CI-only:
 
 ## Rollback
 
-Cloud Run remains the only supported public API path in the shared environment, so rollback uses the reviewed runtime trigger contract. The runtime trigger sends a reviewed rollback request to the Composer Airflow API.
+Cloud Run remains the only supported public API path in the shared environment, so rollback still uses the reviewed runtime-release handoff. The request goes through `scripts/trigger-runtime-release.sh` against the configured Airflow API endpoint, typically from the local operator path.
 
 See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed rollback and retry runbooks.
 

--- a/docs/site/system/inference-pipeline.md
+++ b/docs/site/system/inference-pipeline.md
@@ -1,6 +1,6 @@
 # Inference Pipeline
 
-FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs locally, on Cloud Run, and on the private operator lane. Cloud Run is the shared public API. The operator-lane app stays private for internal checks.
+FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs locally and on Cloud Run. Internal checks and hosted automation reuse that contract without creating a separate rider-facing surface.
 
 This page describes what the running app owns and what stays optional or operator-controlled.
 
@@ -172,8 +172,8 @@ This keeps the prediction-event history populated even when no rider requests ar
 |------|---------------------|
 | Local evaluator | FastAPI app serves predictions from locally-registered MLflow model; the `inference_pipeline` DAG runs batch predictions after model registration |
 | Cloud Run | shared public API with the same serving contract |
-| Cloud Composer | scheduled inference DAG runs batch predictions after model registration |
-| Private operator host | internal checks next to other hosted operator services |
+| Cloud Workflows + Scheduler | hosted automation can coordinate scheduled refreshes without changing the FastAPI serving contract |
+| Hosted operator surfaces | private checks and tracking stay separate from the rider-facing API |
 
 See [Architecture](architecture.md) for the lane summary and [Hosted Full-Stack](hosted-full-stack.md) for the hosted exposure and transition rules.
 

--- a/docs/site/system/training-pipeline.md
+++ b/docs/site/system/training-pipeline.md
@@ -149,7 +149,7 @@ That keeps the orchestration boundary visible:
 - the training DAG emits MLflow training-run, evaluation-report, and model-registry assets
 - dataset and stage can still be overridden through DAG config when needed
 
-This makes the Airflow Assets view reflect the real dependency graph between curated feature persistence, training, evaluation, and registration. In the shared hosted path, those Airflow-owned steps run on the retained operator lane until orchestration moves to Cloud Composer. That infrastructure change should preserve the same training-stage ownership and evidence boundaries.
+This makes the Airflow Assets view reflect the real dependency graph between curated feature persistence, training, evaluation, and registration. The local evaluator runs those steps directly in Airflow, while the hosted cloud path preserves the same training-stage ownership even when serving and scheduled automation move onto Cloud Run and Cloud Workflows.
 
 ## Alias Controls Outside The DAG
 

--- a/src/foehncast/runtime_release.py
+++ b/src/foehncast/runtime_release.py
@@ -268,10 +268,9 @@ def normalize_runtime_release_request(
         ).lower(),
     }
 
-    if (
-        not normalized_request["selected_airflow_target"]
-        and normalized_request["requested_airflow_target"] == "composer_airflow"
-    ):
+    if not normalized_request["selected_airflow_target"] and normalized_request[
+        "requested_airflow_target"
+    ] not in {"", "auto", "unspecified"}:
         normalized_request["selected_airflow_target"] = normalized_request[
             "requested_airflow_target"
         ]
@@ -361,7 +360,7 @@ def build_runtime_release_summary(
     return {
         "generated_at": normalized_request["requested_at"],
         "state": "accepted",
-        "runtime_receiver": "hosted_airflow",
+        "runtime_receiver": "airflow_api",
         "requested_airflow_target": normalized_request["requested_airflow_target"],
         "selected_airflow_target": normalized_request["selected_airflow_target"],
         "dag_id": dag_id,

--- a/terraform/README.md
+++ b/terraform/README.md
@@ -1,6 +1,6 @@
 # Terraform Baseline
 
-This directory defines one shared GCP baseline, two hosted runtime targets, and one optional managed orchestration target.
+This directory defines one shared GCP baseline plus optional hosted Cloud Run and Cloud Workflows surfaces.
 
 This is maintainer/operator reference material. Default contributor setup stays local with Docker and does not require Terraform, `gcloud`, or `gh`.
 
@@ -11,28 +11,25 @@ Start with [../docs/site/system/delivery-and-operator-workflow.md](../docs/site/
 | Surface | Purpose | Deploys |
 |---------|---------|---------|
 | Shared GCP baseline | APIs, storage, identities, and registries | no app containers |
-| Hosted full-stack target | keep Airflow, MLflow, and the API online together | runtime services only |
-| Hosted inference target | publish the inference API as a smaller hosted surface | FastAPI only |
-| Managed orchestration target | provision Cloud Composer for hosted Airflow readiness work | managed Airflow environment only |
+| Hosted Cloud Run surfaces | publish the hosted API and optional supporting services | runtime services only |
+| Hosted automation target | provision Cloud Run Jobs, Cloud Workflows, and Cloud Scheduler for serverless pipeline orchestration | managed automation only |
 | GitHub OIDC delivery | remote Terraform and image-based deploys | no runtime services |
 
 ```mermaid
 flowchart TD
    TF[Terraform] --> BASE[Shared GCP baseline]
-   BASE --> HOST[Hosted full-stack target]
    BASE --> RUN[Hosted inference target]
-   BASE --> COMP[Managed orchestration target]
+   BASE --> WF[Hosted automation target]
    BASE --> GH[GitHub OIDC delivery]
 ```
 
 ## What This Directory Covers
 
-This directory covers four cloud surfaces:
+This directory covers three cloud surfaces:
 
 - a shared GCP baseline for datasets, registries, identities, and the hosted runtime targets
-- an inference-only Cloud Run target for the shared public API
-- a single online Docker host target that runs the full Airflow, MLflow, and API stack from the same repo
-- an optional Cloud Composer environment for managed-orchestration readiness work
+- hosted Cloud Run surfaces for the shared public API and optional supporting services
+- an optional Cloud Workflows plus Cloud Scheduler automation target for serverless orchestration
 
 ## Current Scope
 
@@ -51,10 +48,10 @@ Terraform also seeds `FOEHNCAST_PIPELINE_REPORT_DIR` to the shared `gs://<artifa
 
 ## Deployment Scope Rule
 
-Deploy only runtime surfaces in cloud environments.
+Deploy only runtime and automation surfaces in cloud environments.
 
-- The hosted full-stack target deploys Airflow, MLflow, and the API.
-- The hosted inference target deploys the FastAPI service only.
+- Hosted Cloud Run surfaces deploy runtime services only.
+- The hosted automation target deploys Cloud Run Jobs, Cloud Workflows, and Cloud Scheduler, not contributor tooling.
 - `development_env`, notebooks, docs build tooling, the local objectstore, and the local Datastore emulator stay local or CI-only.
 
 ## Which Path To Use
@@ -62,8 +59,8 @@ Deploy only runtime surfaces in cloud environments.
 | Target | Use it when | What deploys |
 |--------|-------------|--------------|
 | Shared GCP baseline | you need the cloud data and identity foundation | no containers |
-| Hosted full-stack target | you want Airflow, MLflow, and the API online together | runtime services only |
-| Hosted inference target | you only need the inference API | FastAPI only |
+| Hosted Cloud Run surfaces | you need the shared API and optional hosted service surfaces | runtime services only |
+| Hosted automation target | you need serverless pipeline automation in GCP | managed automation only |
 
 ## Hosted Inference Target Inputs
 

--- a/tests/test_cloud_operator_contract.py
+++ b/tests/test_cloud_operator_contract.py
@@ -508,7 +508,7 @@ def test_publish_app_image_stops_at_image_publish_boundary() -> None:
         in summary_step["run"]
     )
     assert (
-        'echo "- Next step: run Trigger Runtime Release with action deploy_candidate and this immutable image URI"'
+        'echo "- Next step: use the reviewed runtime release handoff with action deploy_candidate and this immutable image URI"'
         in summary_step["run"]
     )
 
@@ -620,7 +620,7 @@ def test_promote_candidate_workflow_redirects_to_runtime_trigger_contract() -> N
         in blocked_step["run"]
     )
     assert (
-        "Use Trigger Runtime Release with action promote_candidate"
+        "Use the reviewed runtime release handoff with action promote_candidate"
         in blocked_step["run"]
     )
 
@@ -703,7 +703,8 @@ def test_rollback_live_release_workflow_redirects_to_runtime_trigger_contract() 
         in blocked_step["run"]
     )
     assert (
-        "Use Trigger Runtime Release with action rollback_live" in blocked_step["run"]
+        "Use the reviewed runtime release handoff with action rollback_live"
+        in blocked_step["run"]
     )
 
 

--- a/tests/test_pre_dvc_baseline.py
+++ b/tests/test_pre_dvc_baseline.py
@@ -173,7 +173,7 @@ def test_ci_compose_job_runs_smoke_after_build() -> None:
 
 
 def test_hosted_dag_bundle_contains_feature_and_training_dags() -> None:
-    """Cloud Composer receives the same DAG files that the local evaluator uses."""
+    """The hosted docs still point at the same DAG sources as the local evaluator."""
     feature_dag = Path("dags/feature_dag.py")
     training_dag = Path("dags/training_dag.py")
 

--- a/tests/test_runtime_release.py
+++ b/tests/test_runtime_release.py
@@ -108,12 +108,12 @@ def test_normalize_runtime_release_request_tracks_airflow_targets() -> None:
         {
             "action": "promote_candidate",
             "requested_airflow_target": "AUTO",
-            "selected_airflow_target": "COMPOSER_AIRFLOW",
+            "selected_airflow_target": "LOCAL_AIRFLOW",
         }
     )
 
     assert request["requested_airflow_target"] == "auto"
-    assert request["selected_airflow_target"] == "composer_airflow"
+    assert request["selected_airflow_target"] == "local_airflow"
 
 
 def test_runtime_release_request_from_env_builds_normalized_payload() -> None:
@@ -126,7 +126,7 @@ def test_runtime_release_request_from_env_builds_normalized_payload() -> None:
             "GITHUB_RUN_ID": "42",
             "GITHUB_SHA": "abc123",
             "REQUESTED_AIRFLOW_TARGET": "AUTO",
-            "AIRFLOW_TARGET": "COMPOSER_AIRFLOW",
+            "AIRFLOW_TARGET": "LOCAL_AIRFLOW",
             "CANDIDATE_ALIAS": "Candidate",
         },
         requested_at="2026-05-16T12:00:00+00:00",
@@ -139,7 +139,7 @@ def test_runtime_release_request_from_env_builds_normalized_payload() -> None:
         == "https://github.com/javihslu/foehncast/actions/runs/42"
     )
     assert request["requested_airflow_target"] == "auto"
-    assert request["selected_airflow_target"] == "composer_airflow"
+    assert request["selected_airflow_target"] == "local_airflow"
     assert request["candidate_alias"] == "candidate"
 
 
@@ -155,7 +155,7 @@ def test_write_runtime_release_request_file_persists_normalized_payload(
             "GITHUB_WORKFLOW": "Trigger Runtime Release",
             "GITHUB_RUN_ID": "99",
             "GITHUB_SHA": "def456",
-            "REQUESTED_AIRFLOW_TARGET": "composer_airflow",
+            "REQUESTED_AIRFLOW_TARGET": "local_airflow",
             "IMAGE_URI": "europe-west6-docker.pkg.dev/demo/foehncast/foehncast-app:sha-123",
         },
         requested_at="2026-05-16T12:05:00+00:00",
@@ -164,8 +164,8 @@ def test_write_runtime_release_request_file_persists_normalized_payload(
     request = json.loads(request_path.read_text(encoding="utf-8"))
     assert request["action"] == "deploy_candidate"
     assert request["requested_at"] == "2026-05-16T12:05:00+00:00"
-    assert request["requested_airflow_target"] == "composer_airflow"
-    assert request["selected_airflow_target"] == "composer_airflow"
+    assert request["requested_airflow_target"] == "local_airflow"
+    assert request["selected_airflow_target"] == "local_airflow"
     assert request["image_uri"]
 
 
@@ -207,7 +207,7 @@ def test_main_normalize_request_prints_normalized_payload(
             {
                 "action": "PROMOTE_CANDIDATE",
                 "requested_airflow_target": "AUTO",
-                "selected_airflow_target": "Composer_Airflow",
+                "selected_airflow_target": "Local_Airflow",
                 "candidate_alias": "Candidate",
                 "target_alias": "Champion",
                 "github_repository": "javihslu/foehncast",
@@ -229,7 +229,7 @@ def test_main_normalize_request_prints_normalized_payload(
     payload = json.loads(capsys.readouterr().out)
     assert payload["action"] == "promote_candidate"
     assert payload["requested_airflow_target"] == "auto"
-    assert payload["selected_airflow_target"] == "composer_airflow"
+    assert payload["selected_airflow_target"] == "local_airflow"
     assert payload["candidate_alias"] == "candidate"
     assert payload["target_alias"] == "champion"
 
@@ -369,7 +369,7 @@ def test_build_runtime_release_summary_normalizes_deploy_candidate_request() -> 
         {
             "action": "DEPLOY_CANDIDATE",
             "requested_airflow_target": "auto",
-            "selected_airflow_target": "composer_airflow",
+            "selected_airflow_target": "local_airflow",
             "image_uri": "europe-west6-docker.pkg.dev/demo/foehncast/foehncast-app:sha-123",
             "candidate_revision_tag": "Candidate",
             "candidate_alias": "Candidate",
@@ -390,9 +390,9 @@ def test_build_runtime_release_summary_normalizes_deploy_candidate_request() -> 
     assert summary["target_alias"] == "champion"
     assert summary["dag_id"] == "runtime_release"
     assert summary["dag_run_id"] == "runtime_release__2026-05-14T10-00-00Z"
-    assert summary["runtime_receiver"] == "hosted_airflow"
+    assert summary["runtime_receiver"] == "airflow_api"
     assert summary["requested_airflow_target"] == "auto"
-    assert summary["selected_airflow_target"] == "composer_airflow"
+    assert summary["selected_airflow_target"] == "local_airflow"
 
 
 def test_build_runtime_release_summary_requires_rollback_coordinates() -> None:
@@ -412,9 +412,9 @@ def test_write_runtime_release_summary_persists_latest_and_history(
     summary = {
         "generated_at": "2026-05-14T11:00:00+00:00",
         "state": "accepted",
-        "runtime_receiver": "hosted_airflow",
+        "runtime_receiver": "airflow_api",
         "requested_airflow_target": "auto",
-        "selected_airflow_target": "composer_airflow",
+        "selected_airflow_target": "local_airflow",
         "dag_id": "runtime_release",
         "dag_run_id": "runtime_release__2026-05-14T11-00-00Z",
         "action": "promote_candidate",
@@ -441,7 +441,7 @@ def test_write_runtime_release_summary_persists_latest_and_history(
     assert (
         _read_json(latest_path)["dag_run_id"] == "runtime_release__2026-05-14T11-00-00Z"
     )
-    assert _read_json(latest_path)["selected_airflow_target"] == "composer_airflow"
+    assert _read_json(latest_path)["selected_airflow_target"] == "local_airflow"
     history_paths = runtime_release.runtime_release_summary_history_paths()
     assert len(history_paths) == 1
     assert history_paths[0].name == "runtime-release-20260514T110000000000Z.json"
@@ -479,9 +479,9 @@ def test_write_runtime_release_summary_supports_gcs_location(
     summary = {
         "generated_at": "2026-05-14T11:00:00+00:00",
         "state": "accepted",
-        "runtime_receiver": "hosted_airflow",
+        "runtime_receiver": "airflow_api",
         "requested_airflow_target": "auto",
-        "selected_airflow_target": "composer_airflow",
+        "selected_airflow_target": "local_airflow",
         "dag_id": "runtime_release",
         "dag_run_id": "runtime_release__2026-05-14T11-00-00Z",
         "action": "promote_candidate",


### PR DESCRIPTION
## Summary

Finalize the architecture simplification by removing the last Composer-specific runtime-release contract and reconciling regressed docs and workflow messaging with the current stack.

## Changes

- remove the last `composer_airflow` and `hosted_airflow` assumptions from `runtime_release.py` and its tests
- rewrite regressed system docs around the current model: Cloud Run public surfaces, local Airflow runtime handoff, and hosted cloud automation via Cloud Workflows plus Cloud Scheduler
- remove the deleted Composer docs nav entry from `docs/mkdocs.yml`
- update blocked release workflows and image-publish summaries to point at the reviewed runtime-release handoff instead of a nonexistent Trigger Runtime Release workflow
- fix the broken Grafana click target left in `cloud-architecture.md`

## Verification

- `pytest` full suite: 415 passed
- `mkdocs build -f docs/mkdocs.yml --strict`: passed
- final stale-reference sweep leaves only the intentional historical `removed` row in `cloud-mapping.md`
