### PR TITLE
refactor(serve): remove dead Grafana-era PromQL proxy routes

### DIFF
--- a/src/foehncast/inference_pipeline/serve.py
+++ b/src/foehncast/inference_pipeline/serve.py
@@ -510,51 +510,6 @@ def create_app() -> FastAPI:
             },
         }
 
-    @app.get("/api/v1/query_range")
-    @app.post("/api/v1/query_range")
-    def prom_query_range(
-        query: str = "", start: str = "", end: str = "", step: str = ""
-    ) -> dict:
-        # Return the current instant values at each requested timestamp.
-        # This is sufficient for panels that display recent data.
-        results = _eval_instant_query(query)
-        matrix = []
-        for sample in results:
-            matrix.append(
-                {
-                    "metric": sample["metric"],
-                    "values": [sample["value"]],
-                }
-            )
-        return {
-            "status": "success",
-            "data": {
-                "resultType": "matrix",
-                "result": matrix,
-            },
-        }
-
-    @app.get("/api/v1/labels")
-    @app.post("/api/v1/labels")
-    def prom_labels() -> dict:
-        text = _metrics_payload().decode("utf-8", errors="replace")
-        samples = _parse_metrics_text(text)
-        labels: set[str] = set()
-        for s in samples:
-            labels.update(s["metric"].keys())
-        return {"status": "success", "data": sorted(labels)}
-
-    @app.get("/api/v1/label/{label_name}/values")
-    def prom_label_values(label_name: str) -> dict:
-        text = _metrics_payload().decode("utf-8", errors="replace")
-        samples = _parse_metrics_text(text)
-        values: set[str] = set()
-        for s in samples:
-            v = s["metric"].get(label_name, "")
-            if v:
-                values.add(v)
-        return {"status": "success", "data": sorted(values)}
-
     return app
 
 


### PR DESCRIPTION
## Summary

Remove 3 dead API route handlers from `serve.py` that served as Prometheus-compatible datasource proxies for the now-removed Grafana iframe panels.

## Removed Endpoints

- `GET/POST /api/v1/query_range` — matrix range queries (Grafana panel datasource)
- `GET/POST /api/v1/labels` — label discovery (Grafana variable queries)
- `GET /api/v1/label/{name}/values` — label value enumeration (Grafana variable queries)

## Retained

- `GET/POST /api/v1/query` — instant vector queries (actively used by `ui/app.py` sidebar panels)
- All supporting functions (`_eval_instant_query`, `_parse_metrics_text`, `_match_metric`, etc.)

## Verification

- All 415 tests pass
- `serve.py`: 561 → 516 lines (−45)
- No callers found in src/, tests/, ui/, dags/, docs/, or CI workflows