### PR TITLE
test: mock configure_mlflow_auth to fix 12s test timeout

### DIFF
--- a/tests/test_orchestration.py
+++ b/tests/test_orchestration.py
@@ -490,6 +490,7 @@ def test_run_feature_pipeline_job_logs_to_mlflow_when_env_present(
 
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "https://mlflow.example.com")
     monkeypatch.setattr(_orch_feature, "mlflow", _FeatureJobMlflow(logged))
+    monkeypatch.setattr(_orch_feature, "configure_mlflow_auth", lambda: None)
     monkeypatch.setattr(
         _orch_feature,
         "get_mlflow_config",
@@ -527,6 +528,7 @@ def test_run_feature_pipeline_job_context_reports_drift_and_logs_mlflow(
 
     monkeypatch.setenv("MLFLOW_TRACKING_URI", "https://mlflow.example.com")
     monkeypatch.setattr(_orch_feature, "mlflow", _FeatureJobMlflow(logged))
+    monkeypatch.setattr(_orch_feature, "configure_mlflow_auth", lambda: None)
     monkeypatch.setattr(
         _orch_feature,
         "get_mlflow_config",


### PR DESCRIPTION
## Problem

Two orchestration tests set `MLFLOW_TRACKING_URI` to an `https://` URL which triggered `configure_mlflow_auth()` to attempt fetching a GCP ID token from the metadata server. This network request times out after ~9s in local dev.

## Fix

Mock `configure_mlflow_auth` as a no-op in both tests (the auth behavior isn't under test here).

## Impact

| Scope | Before | After |
|-------|--------|-------|
| `test_orchestration.py` | 14.0s | 1.5s |
| Full suite (415 tests) | ~16s | ~3.7s |

76% faster test suite from a 2-line change.