### PR TITLE
test: extract shared BigQuery fakes into reusable module

### DIFF
--- a/tests/bigquery_fakes.py
+++ b/tests/bigquery_fakes.py
@@ -1,0 +1,54 @@
+"""Shared fake BigQuery classes for tests.
+
+Both test_store.py and test_prediction_log.py need lightweight stand-ins for
+the google-cloud-bigquery SDK objects. This module provides canonical fakes
+so each test file only defines domain-specific helpers.
+"""
+
+from __future__ import annotations
+
+
+class FakeLoadJobConfig:
+    def __init__(self, write_disposition: str, **kwargs: object) -> None:
+        self.write_disposition = write_disposition
+        for name, value in kwargs.items():
+            setattr(self, name, value)
+
+
+class FakeTimePartitioning:
+    def __init__(
+        self,
+        *,
+        type_: object,
+        field: str,
+        expiration_ms: int,
+        require_partition_filter: bool,
+    ) -> None:
+        self.type_ = type_
+        self.field = field
+        self.expiration_ms = expiration_ms
+        self.require_partition_filter = require_partition_filter
+
+
+class FakeScalarQueryParameter:
+    def __init__(self, name: str, param_type: str, value: object) -> None:
+        self.name = name
+        self.param_type = param_type
+        self.value = value
+
+
+class FakeQueryJobConfig:
+    def __init__(self, query_parameters: list[object]) -> None:
+        self.query_parameters = query_parameters
+
+
+class FakeCompletedJob:
+    """A job whose .result() immediately returns None."""
+
+    def __init__(self, callback=None) -> None:
+        self._callback = callback
+
+    def result(self):
+        if self._callback is not None:
+            self._callback()
+        return None

--- a/tests/test_prediction_log.py
+++ b/tests/test_prediction_log.py
@@ -11,50 +11,13 @@ import pandas as pd
 import pytest
 
 from foehncast.monitoring import prediction_log
-
-
-class _FakePredictionLoadJobConfig:
-    def __init__(self, write_disposition: str, **kwargs: object) -> None:
-        self.write_disposition = write_disposition
-        for name, value in kwargs.items():
-            setattr(self, name, value)
-
-
-class _FakePredictionTimePartitioning:
-    def __init__(
-        self,
-        *,
-        type_: object,
-        field: str,
-        expiration_ms: int,
-        require_partition_filter: bool,
-    ) -> None:
-        self.type_ = type_
-        self.field = field
-        self.expiration_ms = expiration_ms
-        self.require_partition_filter = require_partition_filter
-
-
-class _FakePredictionScalarQueryParameter:
-    def __init__(self, name: str, param_type: str, value: object) -> None:
-        self.name = name
-        self.param_type = param_type
-        self.value = value
-
-
-class _FakePredictionQueryJobConfig:
-    def __init__(self, query_parameters: list[object]) -> None:
-        self.query_parameters = query_parameters
-
-
-class _PredictionCompletedJob:
-    def __init__(self, callback=None) -> None:
-        self._callback = callback
-
-    def result(self):
-        if self._callback is not None:
-            self._callback()
-        return None
+from tests.bigquery_fakes import (
+    FakeCompletedJob,
+    FakeLoadJobConfig,
+    FakeQueryJobConfig,
+    FakeScalarQueryParameter,
+    FakeTimePartitioning,
+)
 
 
 class _PredictionFrameRowIterator:
@@ -801,29 +764,27 @@ def test_append_prediction_log_bigquery_uses_prediction_event_warehouse_contract
             frame: pd.DataFrame,
             table_id: str,
             job_config: object,
-        ) -> _PredictionCompletedJob:
+        ) -> FakeCompletedJob:
             captured["table_id"] = table_id
             captured["frame"] = frame.copy()
             captured["write_disposition"] = job_config.write_disposition
             captured["time_partitioning"] = job_config.time_partitioning
             captured["clustering_fields"] = job_config.clustering_fields
             captured["schema_update_options"] = job_config.schema_update_options
-            return _PredictionCompletedJob(
-                lambda: captured.update({"job_completed": True})
-            )
+            return FakeCompletedJob(lambda: captured.update({"job_completed": True}))
 
     monkeypatch.setattr(
         prediction_log,
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            LoadJobConfig=_FakePredictionLoadJobConfig,
-            QueryJobConfig=_FakePredictionQueryJobConfig,
-            ScalarQueryParameter=_FakePredictionScalarQueryParameter,
+            LoadJobConfig=FakeLoadJobConfig,
+            QueryJobConfig=FakeQueryJobConfig,
+            ScalarQueryParameter=FakeScalarQueryParameter,
             SchemaUpdateOption=types.SimpleNamespace(
                 ALLOW_FIELD_ADDITION="ALLOW_FIELD_ADDITION"
             ),
-            TimePartitioning=_FakePredictionTimePartitioning,
+            TimePartitioning=FakeTimePartitioning,
             TimePartitioningType=types.SimpleNamespace(DAY="DAY"),
         ),
     )
@@ -915,8 +876,8 @@ def test_read_prediction_history_bigquery_uses_warehouse_contract_by_default(
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            QueryJobConfig=_FakePredictionQueryJobConfig,
-            ScalarQueryParameter=_FakePredictionScalarQueryParameter,
+            QueryJobConfig=FakeQueryJobConfig,
+            ScalarQueryParameter=FakeScalarQueryParameter,
         ),
     )
     _patch_prediction_event_bigquery_not_found(monkeypatch)
@@ -960,7 +921,7 @@ def test_emit_prediction_drift_metrics_uses_bigquery_history_when_backend_is_big
             frame: pd.DataFrame,
             table_id: str,
             job_config: object,
-        ) -> _PredictionCompletedJob:
+        ) -> FakeCompletedJob:
             if state["table"] is None:
                 state["table"] = frame.copy()
             else:
@@ -968,7 +929,7 @@ def test_emit_prediction_drift_metrics_uses_bigquery_history_when_backend_is_big
                     [state["table"], frame.copy()],
                     ignore_index=True,
                 )
-            return _PredictionCompletedJob()
+            return FakeCompletedJob()
 
         def query(
             self, query: str, job_config: object | None = None
@@ -997,13 +958,13 @@ def test_emit_prediction_drift_metrics_uses_bigquery_history_when_backend_is_big
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            LoadJobConfig=_FakePredictionLoadJobConfig,
-            QueryJobConfig=_FakePredictionQueryJobConfig,
-            ScalarQueryParameter=_FakePredictionScalarQueryParameter,
+            LoadJobConfig=FakeLoadJobConfig,
+            QueryJobConfig=FakeQueryJobConfig,
+            ScalarQueryParameter=FakeScalarQueryParameter,
             SchemaUpdateOption=types.SimpleNamespace(
                 ALLOW_FIELD_ADDITION="ALLOW_FIELD_ADDITION"
             ),
-            TimePartitioning=_FakePredictionTimePartitioning,
+            TimePartitioning=FakeTimePartitioning,
             TimePartitioningType=types.SimpleNamespace(DAY="DAY"),
         ),
     )

--- a/tests/test_store.py
+++ b/tests/test_store.py
@@ -8,6 +8,13 @@ import pandas as pd
 import pytest
 
 from foehncast.feature_pipeline import store
+from tests.bigquery_fakes import (
+    FakeCompletedJob,
+    FakeLoadJobConfig,
+    FakeQueryJobConfig,
+    FakeScalarQueryParameter,
+    FakeTimePartitioning,
+)
 
 
 @pytest.fixture()
@@ -33,45 +40,6 @@ def sample_features() -> pd.DataFrame:
             "wind_steadiness": [0.1, 0.2],
         }
     )
-
-
-class _FakeLoadJobConfig:
-    def __init__(self, write_disposition: str, **kwargs: object) -> None:
-        self.write_disposition = write_disposition
-        for name, value in kwargs.items():
-            setattr(self, name, value)
-
-
-class _FakeTimePartitioning:
-    def __init__(
-        self,
-        *,
-        type_: object,
-        field: str,
-        expiration_ms: int,
-        require_partition_filter: bool,
-    ) -> None:
-        self.type_ = type_
-        self.field = field
-        self.expiration_ms = expiration_ms
-        self.require_partition_filter = require_partition_filter
-
-
-class _FakeScalarQueryParameter:
-    def __init__(self, name: str, param_type: str, value: str) -> None:
-        self.name = name
-        self.param_type = param_type
-        self.value = value
-
-
-class _FakeQueryJobConfig:
-    def __init__(self, query_parameters: list[object]) -> None:
-        self.query_parameters = query_parameters
-
-
-class _CompletedJob:
-    def result(self) -> None:
-        return None
 
 
 class _FlaggingCompletedJob:
@@ -291,13 +259,13 @@ def test_write_features_bigquery_uses_load_job(
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            LoadJobConfig=_FakeLoadJobConfig,
-            QueryJobConfig=_FakeQueryJobConfig,
-            ScalarQueryParameter=_FakeScalarQueryParameter,
+            LoadJobConfig=FakeLoadJobConfig,
+            QueryJobConfig=FakeQueryJobConfig,
+            ScalarQueryParameter=FakeScalarQueryParameter,
             SchemaUpdateOption=types.SimpleNamespace(
                 ALLOW_FIELD_ADDITION="ALLOW_FIELD_ADDITION"
             ),
-            TimePartitioning=_FakeTimePartitioning,
+            TimePartitioning=FakeTimePartitioning,
             TimePartitioningType=types.SimpleNamespace(DAY="DAY"),
         ),
     )
@@ -371,11 +339,11 @@ def test_write_features_bigquery_applies_contract_when_table_is_missing(
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            LoadJobConfig=_FakeLoadJobConfig,
+            LoadJobConfig=FakeLoadJobConfig,
             SchemaUpdateOption=types.SimpleNamespace(
                 ALLOW_FIELD_ADDITION="ALLOW_FIELD_ADDITION"
             ),
-            TimePartitioning=_FakeTimePartitioning,
+            TimePartitioning=FakeTimePartitioning,
             TimePartitioningType=types.SimpleNamespace(DAY="DAY"),
         ),
     )
@@ -441,8 +409,8 @@ def test_read_features_bigquery_restores_time_index(
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            QueryJobConfig=_FakeQueryJobConfig,
-            ScalarQueryParameter=_FakeScalarQueryParameter,
+            QueryJobConfig=FakeQueryJobConfig,
+            ScalarQueryParameter=FakeScalarQueryParameter,
         ),
     )
     _patch_bigquery_not_found(monkeypatch)
@@ -481,16 +449,16 @@ def test_bigquery_round_trip_restores_original_feature_schema(
 
         def load_table_from_dataframe(
             self, frame: pd.DataFrame, table_id: str, job_config: object
-        ) -> _CompletedJob:
+        ) -> FakeCompletedJob:
             written["frame"] = frame.copy()
-            return _CompletedJob()
+            return FakeCompletedJob()
 
         def query(
             self, query: str, job_config: object | None = None
-        ) -> _CompletedJob | _FrameQueryJob:
+        ) -> FakeCompletedJob | _FrameQueryJob:
             if "DELETE FROM" in query:
                 written["frame"] = written["frame"].iloc[0:0].copy()
-                return _CompletedJob()
+                return FakeCompletedJob()
             return _FrameQueryJob(written["frame"])
 
     monkeypatch.setattr(
@@ -498,9 +466,9 @@ def test_bigquery_round_trip_restores_original_feature_schema(
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            LoadJobConfig=_FakeLoadJobConfig,
-            QueryJobConfig=_FakeQueryJobConfig,
-            ScalarQueryParameter=_FakeScalarQueryParameter,
+            LoadJobConfig=FakeLoadJobConfig,
+            QueryJobConfig=FakeQueryJobConfig,
+            ScalarQueryParameter=FakeScalarQueryParameter,
         ),
     )
     _patch_bigquery_not_found(monkeypatch)
@@ -539,13 +507,13 @@ def test_write_features_bigquery_replaces_existing_slice_on_repeated_writes(
 
         def load_table_from_dataframe(
             self, frame: pd.DataFrame, table_id: str, job_config: object
-        ) -> _CompletedJob:
+        ) -> FakeCompletedJob:
             existing = state["table"]
             if existing is None:
                 state["table"] = frame.copy()
             else:
                 state["table"] = pd.concat([existing, frame.copy()], ignore_index=True)
-            return _CompletedJob()
+            return FakeCompletedJob()
 
         def query(self, query: str, job_config: object | None = None) -> object:
             parameters = {
@@ -564,7 +532,7 @@ def test_write_features_bigquery_replaces_existing_slice_on_repeated_writes(
                         )
                     ].reset_index(drop=True)
                     state["table"] = filtered
-                return _CompletedJob()
+                return FakeCompletedJob()
 
             if table is None:
                 return _FrameQueryJob()
@@ -584,9 +552,9 @@ def test_write_features_bigquery_replaces_existing_slice_on_repeated_writes(
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            LoadJobConfig=_FakeLoadJobConfig,
-            QueryJobConfig=_FakeQueryJobConfig,
-            ScalarQueryParameter=_FakeScalarQueryParameter,
+            LoadJobConfig=FakeLoadJobConfig,
+            QueryJobConfig=FakeQueryJobConfig,
+            ScalarQueryParameter=FakeScalarQueryParameter,
         ),
     )
     _patch_bigquery_not_found(monkeypatch)
@@ -630,8 +598,8 @@ def test_read_features_bigquery_raises_file_not_found_for_empty_result(
         "_bigquery_module",
         lambda: types.SimpleNamespace(
             Client=FakeClient,
-            QueryJobConfig=_FakeQueryJobConfig,
-            ScalarQueryParameter=_FakeScalarQueryParameter,
+            QueryJobConfig=FakeQueryJobConfig,
+            ScalarQueryParameter=FakeScalarQueryParameter,
         ),
     )
     _patch_bigquery_not_found(monkeypatch)


### PR DESCRIPTION
## Summary

Extracts 5 duplicated fake BigQuery SDK classes from `test_store.py` and `test_prediction_log.py` into `tests/bigquery_fakes.py`.

**Net: −17 lines**, single source of truth for BQ test doubles.

## Verification
- 415 tests pass (~4s)
- ruff clean