### PR TITLE
refactor: extract shared BigQuery utilities into _bigquery.py

### DIFF
--- a/src/foehncast/_bigquery.py
+++ b/src/foehncast/_bigquery.py
@@ -1,0 +1,57 @@
+"""Shared BigQuery SDK utilities.
+
+Lazy-imports the google-cloud-bigquery SDK so modules remain importable
+when the SDK is not installed (e.g. local-only or S3-only deployments).
+"""
+
+from __future__ import annotations
+
+import importlib
+import types
+from typing import Any
+
+
+def bigquery_module() -> Any:
+    """Lazy-load the google.cloud.bigquery package."""
+    return importlib.import_module("google.cloud.bigquery")
+
+
+def google_exceptions_module() -> Any:
+    """Lazy-load google.api_core.exceptions."""
+    return importlib.import_module("google.api_core.exceptions")
+
+
+def bigquery_time_partitioning(bigquery: Any, contract: dict[str, Any]) -> Any:
+    """Build a TimePartitioning object from a warehouse contract dict."""
+    partition_type = contract["partition_granularity"]
+    enum = getattr(bigquery, "TimePartitioningType", None)
+    if enum is not None:
+        partition_type = getattr(enum, partition_type, partition_type)
+
+    time_partitioning = getattr(bigquery, "TimePartitioning", None)
+    expiration_ms = contract["retention_days"] * 24 * 60 * 60 * 1000
+    if time_partitioning is None:
+        return types.SimpleNamespace(
+            type_=partition_type,
+            field=contract["partition_field"],
+            expiration_ms=expiration_ms,
+            require_partition_filter=False,
+        )
+
+    return time_partitioning(
+        type_=partition_type,
+        field=contract["partition_field"],
+        expiration_ms=expiration_ms,
+        require_partition_filter=False,
+    )
+
+
+def bigquery_schema_update_options(bigquery: Any) -> list[Any]:
+    """Return schema update options allowing field addition."""
+    schema_update_option = getattr(bigquery, "SchemaUpdateOption", None)
+    allow_field_addition = getattr(
+        schema_update_option,
+        "ALLOW_FIELD_ADDITION",
+        "ALLOW_FIELD_ADDITION",
+    )
+    return [allow_field_addition]

--- a/src/foehncast/feature_pipeline/store.py
+++ b/src/foehncast/feature_pipeline/store.py
@@ -4,13 +4,18 @@ from __future__ import annotations
 
 from abc import ABC, abstractmethod
 import importlib
-import types
 from typing import Any
 
 import pandas as pd
 
 from foehncast.config import get_storage_config
 from foehncast.env import env_value
+from foehncast._bigquery import (
+    bigquery_module as _bigquery_module,
+    bigquery_schema_update_options as _bigquery_schema_update_options,
+    bigquery_time_partitioning as _bigquery_time_partitioning,
+    google_exceptions_module as _google_exceptions_module,
+)
 
 _BQ_TIME_COLUMN = "forecast_time"
 _BQ_DATASET_COLUMN = "dataset_name"
@@ -108,14 +113,6 @@ def _s3fs_module() -> Any:
     return importlib.import_module("s3fs")
 
 
-def _bigquery_module() -> Any:
-    return importlib.import_module("google.cloud.bigquery")
-
-
-def _google_exceptions_module() -> Any:
-    return importlib.import_module("google.api_core.exceptions")
-
-
 def _s3_feature_path(storage_config: dict[str, Any], spot_id: str, dataset: str) -> str:
     return f"s3://{_s3_bucket(storage_config)}/{dataset}/{spot_id}.parquet"
 
@@ -196,40 +193,6 @@ def _bigquery_curated_feature_contract(
         "cluster_fields": resolved_cluster_fields,
         "retention_days": resolved_retention_days,
     }
-
-
-def _bigquery_time_partitioning(bigquery: Any, contract: dict[str, Any]) -> Any:
-    partition_type = contract["partition_granularity"]
-    enum = getattr(bigquery, "TimePartitioningType", None)
-    if enum is not None:
-        partition_type = getattr(enum, partition_type, partition_type)
-
-    time_partitioning = getattr(bigquery, "TimePartitioning", None)
-    expiration_ms = contract["retention_days"] * 24 * 60 * 60 * 1000
-    if time_partitioning is None:
-        return types.SimpleNamespace(
-            type_=partition_type,
-            field=contract["partition_field"],
-            expiration_ms=expiration_ms,
-            require_partition_filter=False,
-        )
-
-    return time_partitioning(
-        type_=partition_type,
-        field=contract["partition_field"],
-        expiration_ms=expiration_ms,
-        require_partition_filter=False,
-    )
-
-
-def _bigquery_schema_update_options(bigquery: Any) -> list[Any]:
-    schema_update_option = getattr(bigquery, "SchemaUpdateOption", None)
-    allow_field_addition = getattr(
-        schema_update_option,
-        "ALLOW_FIELD_ADDITION",
-        "ALLOW_FIELD_ADDITION",
-    )
-    return [allow_field_addition]
 
 
 def _validate_bigquery_contract_frame(

--- a/src/foehncast/monitoring/_prediction_log_bigquery.py
+++ b/src/foehncast/monitoring/_prediction_log_bigquery.py
@@ -6,13 +6,17 @@ clustering), schema evolution, writes, and retention-aware reads.
 
 from __future__ import annotations
 
-import importlib
 import json
-import types
 from typing import Any
 
 import pandas as pd
 
+from foehncast._bigquery import (
+    bigquery_module as _bigquery_module,
+    bigquery_schema_update_options as _bigquery_schema_update_options,
+    bigquery_time_partitioning as _bigquery_time_partitioning,
+    google_exceptions_module as _google_exceptions_module,
+)
 from foehncast.monitoring._prediction_log_common import (
     _DEFAULT_BIGQUERY_PARTITION_GRANULARITY,
     _DEFAULT_PREDICTION_EVENT_CLUSTER_FIELDS,
@@ -21,14 +25,6 @@ from foehncast.monitoring._prediction_log_common import (
     _prediction_log_max_rows,
     _prediction_log_retention_days,
 )
-
-
-def _bigquery_module() -> Any:
-    return importlib.import_module("google.cloud.bigquery")
-
-
-def _google_exceptions_module() -> Any:
-    return importlib.import_module("google.api_core.exceptions")
 
 
 def prediction_event_bigquery_contract(
@@ -117,43 +113,6 @@ def _prediction_event_bigquery_not_found(storage_config: dict[str, Any]) -> bool
     return False
 
 
-def _prediction_event_bigquery_time_partitioning(
-    bigquery: Any,
-    contract: dict[str, Any],
-) -> Any:
-    partition_type = contract["partition_granularity"]
-    enum = getattr(bigquery, "TimePartitioningType", None)
-    if enum is not None:
-        partition_type = getattr(enum, partition_type, partition_type)
-
-    time_partitioning = getattr(bigquery, "TimePartitioning", None)
-    expiration_ms = contract["retention_days"] * 24 * 60 * 60 * 1000
-    if time_partitioning is None:
-        return types.SimpleNamespace(
-            type_=partition_type,
-            field=contract["partition_field"],
-            expiration_ms=expiration_ms,
-            require_partition_filter=False,
-        )
-
-    return time_partitioning(
-        type_=partition_type,
-        field=contract["partition_field"],
-        expiration_ms=expiration_ms,
-        require_partition_filter=False,
-    )
-
-
-def _prediction_event_bigquery_schema_update_options(bigquery: Any) -> list[Any]:
-    schema_update_option = getattr(bigquery, "SchemaUpdateOption", None)
-    allow_field_addition = getattr(
-        schema_update_option,
-        "ALLOW_FIELD_ADDITION",
-        "ALLOW_FIELD_ADDITION",
-    )
-    return [allow_field_addition]
-
-
 def _prediction_event_bigquery_write_frame(rows: list[dict[str, Any]]) -> pd.DataFrame:
     frame = pd.DataFrame(rows)
     if frame.empty:
@@ -200,13 +159,11 @@ def write_prediction_events_bigquery(
 
     job_config_kwargs: dict[str, Any] = {
         "write_disposition": "WRITE_APPEND",
-        "schema_update_options": _prediction_event_bigquery_schema_update_options(
-            bigquery
-        ),
+        "schema_update_options": _bigquery_schema_update_options(bigquery),
     }
     if table_missing:
-        job_config_kwargs["time_partitioning"] = (
-            _prediction_event_bigquery_time_partitioning(bigquery, contract)
+        job_config_kwargs["time_partitioning"] = _bigquery_time_partitioning(
+            bigquery, contract
         )
         job_config_kwargs["clustering_fields"] = contract["cluster_fields"]
 


### PR DESCRIPTION
Unify duplicated BigQuery SDK patterns from `store.py` and `_prediction_log_bigquery.py` into `src/foehncast/_bigquery.py`:

- `bigquery_module()` — lazy SDK import
- `google_exceptions_module()` — lazy exceptions import
- `bigquery_time_partitioning()` — TimePartitioning builder (~20 lines)
- `bigquery_schema_update_options()` — schema evolution config

Net −23 lines. All 415 tests pass.