### PR TITLE
docs: simplify system pages to student-friendly tone

### DIFF
--- a/docs/site/system/cloud-architecture.md
+++ b/docs/site/system/cloud-architecture.md
@@ -1,10 +1,6 @@
 # Cloud Architecture
 
-FoehnCast runs entirely on serverless and managed GCP services. Every compute component scales to zero when idle. The only fixed-cost resource is the Cloud SQL micro instance for MLflow metadata.
-
-!!! note "What this page covers"
-
-    Interactive architecture map, service inventory, access model, and cost forecast for the hosted environment.
+Everything runs on GCP serverless — scale-to-zero, no VMs. The only fixed cost is a Cloud SQL micro instance for MLflow (~$8/mo).
 
 ## Architecture Map
 

--- a/docs/site/system/cloud-mapping.md
+++ b/docs/site/system/cloud-mapping.md
@@ -1,47 +1,8 @@
 # Cloud Mapping
 
-FoehnCast has one public hosted lane and one private operator lane. Cloud Run serves the shared API. Cloud Build publishes runtime images. Orchestration runs locally via Airflow in Docker Compose. This page maps the cloud lanes without changing the core Feature-Training-Inference boundaries.
+This page shows how local services map to cloud equivalents. The pipeline code stays the same — only the infrastructure underneath changes.
 
-!!! note "What this page covers"
-
-    The shared GCP baseline defines one public API lane and one private operator lane.
-    Cloud Run is the shared public API lane.
-    Cloud Build is the hosted image build surface.
-    Orchestration is local (Airflow via Docker Compose).
-
-## Cloud Paths In One View
-
-<div class="grid cards">
-<ul>
-<li>
-<p><strong>Shared GCP baseline</strong></p>
-<p>Terraform provisions APIs, Artifact Registry, GCS, BigQuery, and GitHub OIDC.</p>
-</li>
-<li>
-<p><strong>Hosted operator lane</strong></p>
-<p>MLflow and monitoring run as managed operator services. Orchestration is local.</p>
-</li>
-<li>
-<p><strong>Hosted build surface</strong></p>
-<p>Cloud Build publishes reviewed runtime images to Artifact Registry.</p>
-</li>
-<li>
-<p><strong>Hosted inference target</strong></p>
-<p>Cloud Run serves the promoted FastAPI API and remains the public surface.</p>
-</li>
-</ul>
-</div>
-
-## Hosted Lanes At A Glance
-
-| Lane | Concrete target | State | Default exposure | Main job |
-|------|-----------------|-------|------------------|----------|
-| Shared API lane | hosted inference target on Cloud Run | active | public | serve the FastAPI product and service routes |
-| Operator lane | managed operator services | active | private by default | provide the tracking and monitoring surface |
-| Build surface | Cloud Build | active | private or platform-only | publish reviewed hosted runtime images to Artifact Registry |
-| Delivery lane | GitHub Actions plus Terraform plus OIDC | active review gate | not a runtime surface | publish reviewed artifacts and apply reviewed infrastructure changes |
-
-## Same Core, Different Support Stack
+## Local → Cloud
 
 <div class="mermaid">
 flowchart TD
@@ -49,257 +10,77 @@ flowchart TD
     classDef local fill:#e1f5fe,stroke:#01579b
     classDef cloud fill:#fff8e1,stroke:#f57f17
 
-    CORE["Shared FTI core\nFeature -> Training -> Inference"]:::core
+    CORE["Same Python code"]:::core
 
-    subgraph LocalSurface ["fab:fa-docker Local lane"]
-        direction TB
-        LSUP["Airflow + MLflow + monitoring"]:::local
-        LAPP["MinIO + Feast + app"]:::local
-        LSUP --> LAPP
+    subgraph Local ["Local (Docker)"]
+        direction LR
+        LSUP["Airflow + MLflow + Prometheus"]:::local
+        LDATA["MinIO + Feast emulator"]:::local
     end
 
-    subgraph CloudSurface ["fab:fa-google Cloud lane"]
-        direction TB
-        COPS["Operator tools"]:::cloud
-        CDATA["BigQuery + GCS + Datastore"]:::cloud
+    subgraph Cloud ["Cloud (GCP)"]
+        direction LR
+        COPS["Cloud Workflows + MLflow"]:::cloud
+        CDATA["BigQuery + GCS + Firestore"]:::cloud
         CAPI["Cloud Run API"]:::cloud
-        COPS --> CDATA
-        CDATA --> CAPI
     end
 
-    CORE --> LocalSurface
-    CORE --> CloudSurface
+    CORE --> Local
+    CORE --> Cloud
 </div>
 
-The main pipeline stays the same. Local and cloud mostly differ in the support tools around it.
+## Service Mapping
 
-## Mapping Principle
+| Concern | Local | Cloud |
+|---------|-------|-------|
+| Object storage | MinIO | GCS |
+| Feature storage | MinIO parquet | BigQuery |
+| Online features | Datastore emulator | Firestore |
+| Model registry | MLflow (SQLite) | MLflow (Cloud SQL) |
+| Orchestration | Airflow (Docker) | Cloud Workflows + Scheduler |
+| Serving | FastAPI (localhost) | Cloud Run |
+| Monitoring | Prometheus + StatsD | Managed Prometheus |
+| Image builds | — | Cloud Build → Artifact Registry |
+| Delivery | — | GitHub Actions + Terraform + OIDC |
 
-- Local Docker proves that the pipelines run together.
-- Local and cloud are parallel deployment targets, not upstream and downstream environments.
-- Cloud deployment keeps the same pipeline boundaries.
-- Cloud services replace the local support services used for evaluation and development.
-- Hosted deployment keeps development-only assets, notebooks, docs build tooling, and local emulators out of the runtime surface.
-- The app remains a deployable container because inference is a service, not a DAG.
+## What Stays the Same
 
-## What Stays The Same
+- `config.yaml` means the same thing in both environments
+- Feature, training, and inference pipeline boundaries
+- FastAPI routes and `/metrics` contract
+- Container images and application code
+- DVC works locally and in CI (not in cloud runtime)
 
-These parts should stay the same in local and cloud.
+## What's Different
 
-- `config.yaml` keeps the same meaning in both paths
-- the feature, training, and inference boundaries stay the same
-- the Airflow DAG logic and runtime release contract stay the same
-- the FastAPI routes and `/metrics` contract stay the same
-- the reviewed container images and app code stay the same
-- DVC should sit on top of the local curated-data-to-training path and CI, not inside the hosted runtime
+| Cloud adds | Purpose |
+|-----------|---------|
+| Cloud Run | Public API (scale-to-zero) |
+| Cloud Workflows | Scheduled pipeline triggers |
+| Cloud Build | Container image publishing |
+| BigQuery | Analytical storage for features and monitoring |
+| IAM + OIDC | Authentication (no long-lived keys) |
 
-## Surface Exposure In Cloud
+## Access Control
 
-| Surface | Intended audience | Default exposure |
-|------|-------------------|------------------|
-| FastAPI app routes | riders, service clients, smoke tests | exposed by the active hosted app target |
-| `/metrics` and scrape targets | Prometheus and operators | service-only |
-| Airflow, MLflow, and Prometheus | operators | private by default |
-| Public docs and review artifacts | reviewer, course audience, fork reader | public-safe when rendered from snapshots, markdown, or screenshots |
+| Access level | Services |
+|-------------|----------|
+| Public (`allUsers`) | FastAPI App, Streamlit UI |
+| Protected (service-account) | MLflow, Cloud Workflows |
+| IAM-only (no public endpoint) | BigQuery, GCS, Firestore, Cloud SQL |
+| OIDC (CI) | GitHub Actions → Cloud Build |
 
-This boundary matters because the hosted app is the product and service surface. Monitoring visualization uses native Altair charts in the Streamlit UI, and public docs should prefer rendered evidence over live embeds of private hosted tools.
+## What Stays Out of Cloud
 
-## Hosted Topology
+These are local/CI-only:
 
-<div class="mermaid">
-flowchart TD
-    %% Styling
-    classDef infra fill:#f5f5f5,stroke:#333
-    classDef runner fill:#f4f1ea,stroke:#f05032
-    classDef platform fill:#fff,stroke:#4285F4
-    classDef operator fill:#fff8e1,stroke:#f57f17
+- `development_env` container
+- Notebooks
+- Docs build tooling
+- Local MinIO and Datastore emulator
 
-    TF["Terraform baseline"]:::infra
-    GH["fab:fa-github Delivery + OIDC"]:::runner
+## Related Pages
 
-    subgraph GCP ["fab:fa-google Hosted environment"]
-        direction TB
-        BASE["IAM + Registry + GCS + BigQuery"]:::platform
-
-        subgraph PublicLane ["API lane"]
-            RUN["Cloud Run API"]:::platform
-        end
-
-        subgraph PrivateLane ["Ops lane"]
-            CB["Cloud Build"]:::operator
-            OPS["MLflow + monitoring"]:::operator
-        end
-
-        BASE --> RUN
-        BASE --> CMP
-    end
-
-    TF --> BASE
-    GH -- "Deploy" --> RUN
-    GH -- "Build" --> CB
-    GH -- "DAGs" --> CMP
-</div>
-
-## Implemented Hosted Surfaces
-
-| Surface | Deploys | Leaves out | Implementation status |
-|--------|---------|------------|---------------|
-| Shared GCP baseline | APIs, Artifact Registry, GCS, BigQuery, Datastore, and OIDC identities | app containers | implemented through Terraform |
-| Cloud Composer (operator lane) | hosted Airflow DAGs, orchestration, and runtime release handoff | `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | removed — orchestration is local |
-| Hosted inference target (API lane) | the FastAPI inference API on Cloud Run | Airflow, hosted MLflow container, `development_env`, notebooks, docs build tooling, local MinIO, and local emulators | active public API path |
-| Cloud Build | reviewed runtime image publishing to Artifact Registry | n/a | active hosted build surface |
-| GitHub delivery | image publishing and remote Terraform runs | runtime services | implemented and bootstrapped for the shared environment |
-| BigQuery backend support | support for a BigQuery storage backend in the app | none | available in both local and hosted runtimes |
-
-The hosted targets deploy runtime services only. Development assets stay local or CI-only. Cloud Run is the only promoted public API path. Operator services stay private by default.
-
-## Hosted Deployment Path
-
-The shared environment keeps a stable split: Cloud Run carries the shared public API URL, local Airflow owns orchestration for scheduling, retries, and runtime release handoff, and GitHub Actions plus remote Terraform advance reviewed day-2 changes after maintainer bootstrap.
-
-See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the delivery boundary and [Configuration and Contracts](configuration-and-contracts.md) for the reviewed value-surface inventory.
-
-## Local To Cloud Mapping
-
-<div class="mermaid">
-flowchart TD
-    classDef local fill:#e1f5fe,stroke:#01579b
-    classDef cloud fill:#fff8e1,stroke:#f57f17
-
-    L1["Local Airflow"]:::local --> C1["Local Airflow (same)"]:::local
-    L2["Local app container"]:::local --> C2["Cloud Run"]:::cloud
-    L3["MinIO for raw files and artifacts"]:::local --> C3["GCS"]:::cloud
-    L4["MinIO curated feature objects"]:::local --> C4["BigQuery"]:::cloud
-    L5["Feast parquet export"]:::local --> C5["BigQuery table or view"]:::cloud
-    L6["Datastore emulator"]:::local --> C6["Datastore-mode Firestore"]:::cloud
-</div>
-
-| Local | Same idea | Cloud |
-|------|-----------|-------|
-| FastAPI app container | same app routes and `/metrics` | Cloud Run API lane |
-| Local Docker image builds | same reviewed images | GitHub workflows + Cloud Build + Artifact Registry |
-| Local Airflow | same DAGs and runtime release contract | Local Airflow (no cloud equivalent) |
-| Local MLflow + MinIO artifacts | same run tracking and registry | managed MLflow + GCS artifacts |
-| Prometheus + StatsD | same operator monitoring | private hosted operator monitoring (Google Managed Prometheus) |
-| MinIO for raw files and artifact-style blobs | same object storage role | GCS |
-| MinIO curated feature objects | same curated feature contract | BigQuery |
-| Feast parquet export | same Feast offline source | BigQuery table or view |
-| Datastore emulator | same Feast online-serving boundary | Datastore-mode Firestore |
-| Streamlit and `/features/online/demo` | same rider demo role | public-safe demo or screenshots, not an operator control plane |
-| `development_env` and notebooks | same local-only helper role | no hosted runtime equivalent |
-
-This is role matching, not a literal copy. Some local tools map to hosted services. Some helpers simply stay local.
-
-## Cloud Pipeline Shape
-
-<div class="mermaid">
-flowchart TD
-    classDef source fill:#f5f5f5,stroke:#333
-    classDef process fill:#e1f5fe,stroke:#01579b
-    classDef data fill:#ececff,stroke:#9370db
-    classDef serving fill:#fff8e1,stroke:#f57f17
-
-    WX["Forecasts"]:::source --> RAW
-    RAW[(GCS landing)]:::data --> FEAT
-    FEAT["Feature job"]:::process --> BQ
-    BQ[(BigQuery curated features)]:::data --> TRAIN
-    TRAIN["Training job"]:::process --> MLF
-    MLF[(MLflow registry)]:::data --> HOST
-    MLF --> RUN
-    BQ --> FEAST
-    FEAST["Feast layer"]:::data --> HOST
-    FEAST --> RUN
-    ROUTE["OSRM API"]:::source --> LIVE
-    WX --> LIVE
-    LIVE["Live inputs"]:::source --> HOST
-    LIVE --> RUN
-
-    subgraph Serving ["fab:fa-google Serving lane"]
-        direction TB
-        HOST["Operator lane"]:::serving
-        RUN["Cloud Run API"]:::serving
-    end
-</div>
-
-| Layer | Cloud direction |
-|------|-----------------|
-| Raw landing | keep immutable API payloads in GCS when a landing layer is needed |
-| Feature pipeline | transform landed or live inputs and write curated rows to BigQuery |
-| Training pipeline | read curated rows, train, evaluate, and register through MLflow |
-| Inference pipeline | serve the public API on Cloud Run |
-| Feast serving path | point the same logical feature view at BigQuery instead of local parquet |
-
-## Storage Layering In Cloud
-
-The cloud design works best when storage is split by role.
-
-| Data role | Recommended cloud surface | Why |
-|----------|---------------------------|-----|
-| Raw landing and archive | GCS | cheap retention, append-friendly, and flexible when upstream payloads drift |
-| Curated analytical features | BigQuery native tables | query-friendly, partitionable, clusterable, and well suited to training plus Feast offline reads |
-| Feast registry and staging | GCS | metadata and staging artifacts fit object storage better than warehouse tables |
-| Feast offline source | BigQuery table or view | same curated layer used by analytics and training |
-
-External tables still make sense for raw or staging access, but they are not the preferred main store for curated features that are queried often.
-
-## Cloud Storage Control Surface
-
-The cloud path stays clear because it is built from explicit application and infrastructure surfaces, not from a loose translation of the local setup.
-
-| Surface | Cloud-facing implementation | Why it matters |
-|------|-----------------------------|----------------|
-| Backend selection | `storage.backend=bigquery` plus configured project, dataset, and table | switches curated persistence onto BigQuery without changing the upstream pipeline stages |
-| Curated warehouse target | `BigQueryFeatureStoreBackend` | keeps the same feature-store abstraction in place while using a query-friendly cloud store and preserving rerun-safe slice replacement |
-| Raw landing target | Terraform-managed GCS bucket | keeps immutable raw capture separate from curated analytical writes |
-| Feast runtime binding | Terraform and cloud bootstrap inject the Feast env contract that renders `.state/feast/feature_store.runtime.yaml` | keeps local and hosted runtimes on the same logical Feast configuration surface |
-| Feast offline cloud source | BigQuery table or view referenced by the rendered Feast runtime config | keeps Feast downstream from curated storage instead of parallel to it |
-| Feast registry and staging | GCS paths from the cloud Feast config | keeps registry metadata and staging artifacts out of warehouse tables |
-| Feast online path | Terraform-managed Firestore Datastore-mode database from the cloud Feast config | keeps online feature serving separate from offline analytical storage |
-| Terraform baseline | Terraform-managed GCS, BigQuery, and Datastore-mode Firestore surfaces | supplies the bucket and warehouse baseline without taking ownership of feature semantics |
-| Local object-store baseline | S3-compatible backend plus the bundled MinIO service back the local operator path | keeps the local object-access layer aligned with the cloud bucket/artifact pattern |
-
-In practice, GCS stores raw landing data and registry-style metadata for the cloud path. BigQuery stores the curated analytical layer. Feast reads that curated layer instead of creating a separate one. The local path uses the bundled MinIO service as its default object-access layer, while BigQuery and Datastore stay hosted-only surfaces.
-
-## Runtime Differences That Matter
-
-| Area | Local baseline | Hosted path |
-|------|----------------|-------------|
-| Storage | MinIO-backed curated objects plus local Feast parquet and a Datastore-mode emulator | GCS holds raw landing and artifacts; BigQuery becomes the shared curated cloud data surface |
-| Artifacts | MinIO-backed MLflow artifact path | GCS bucket |
-| Auth | local `.env` plus developer credentials | runtime service accounts and GitHub OIDC |
-| Image source | local builds | reviewed GitHub workflows submit Cloud Build builds that publish hosted runtime images to Artifact Registry |
-| Public exposure | local ports on the developer machine | Cloud Run is the shared hosted API surface; the operator lane stays private by default; dashboards stay private unless you deliberately publish them |
-
-## Recovery Evidence In Cloud
-
-Operators should be able to prove what changed after a retry, replay, or rollback request.
-
-The stable evidence surfaces are:
-
-- `airflow/reports/feature-pipeline-<dataset>-latest.json` and its history copy for feature retries or backfills
-- `airflow/reports/training-pipeline-<dataset>-latest.json` and its history copy for training follow-up
-- the configured runtime release summary target and its history copy for reviewed deploy, promote, or rollback handoffs
-- `.state/hosted-sync/last-success.json` for the hosted sync state
-- `/metrics` and the checked-in alert rules for post-recovery operator verification
-
-On hosted surfaces, Terraform points `FOEHNCAST_PIPELINE_REPORT_DIR` at the durable `gs://<artifact-bucket>/airflow/reports` prefix so Cloud Run `/metrics` and operator tools can read the same feature and training summary evidence.
-
-## What Is Already In Place
-
-- Terraform covers the cloud runtime slice.
-- The repo contains a Cloud Run deployment path and Artifact Registry publishing flow.
-- Runtime release acknowledgements use durable GCS storage.
-- The application supports a `bigquery` storage backend through the shared feature-store abstraction.
-- Local container runs can already mount ADC for BigQuery-based checks.
-
-## Remaining Work
-
-- Cloud Run already owns the public API lane.
-- Hosted image delivery already uses Cloud Build plus Artifact Registry; follow-up work is about provenance, signing, and trigger refinement.
-- The monitoring stack stays intentionally small and reviewable through checked-in dashboards, alert rules, and scrape config.
-
-## Why This Fits The Project Brief
-
-The goal is cloud-ready pipelines and cloud orchestration. This mapping keeps the validated backend design and uses Google-managed build and orchestration services without discarding the working local baseline.
-
-See [Architecture](architecture.md) for the runtime view and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the maintainer path that bootstraps and advances these hosted targets. The repository root also includes a Terraform README with the deployment details.
+- [Cloud Architecture](cloud-architecture.md) — detailed service inventory and costs
+- [Delivery Workflow](delivery-and-operator-workflow.md) — how code gets to Cloud Run
+- [Local Evaluator](local-evaluator.md) — the Docker-based local equivalent

--- a/docs/site/system/configuration-and-contracts.md
+++ b/docs/site/system/configuration-and-contracts.md
@@ -1,171 +1,76 @@
-# Configuration and Contracts
+# Configuration
 
-FoehnCast keeps workload configuration, runtime wiring, infrastructure inputs, and generated runtime state separate. This page describes that contract so readers do not have to reconstruct it from `config.yaml`, `src/foehncast/config.py`, the repository notes, and the operator docs.
+FoehnCast separates "what the app does" (`config.yaml`) from "where it runs" (environment variables). This page explains the split.
 
-The goal is not to document every environment variable in isolation. The goal is to make the ownership boundary explicit: what the package owns, what the runtime injects, and what infrastructure or operator tooling should keep outside the package config.
-
-!!! note "Scope"
-
-    This page describes the validated configuration boundary.
-    It is not a proposal for a future settings system.
-    New settings should follow these ownership rules unless the architecture changes first.
-
-## Contract In One View
+## The Rule
 
 <div class="mermaid">
 flowchart TD
-    TF["Terraform and GitHub delivery variables"] --> ENV[".env and environment variables"]
-    YAML["config.yaml"] --> PY["src/foehncast/config.py"]
-    ENV --> PY
-    PY --> APP["App, DAGs, training, inference"]
-    APP --> MON[".state and airflow/reports contracts"]
-    ENV --> FEASTCFG[".state/feast/feature_store.runtime.yaml"]
-    FEASTCFG --> FEAST["Feast runtime"]
+    YAML["config.yaml\n(what)"] --> PY["config.py"]
+    ENV[".env / env vars\n(where)"] --> PY
+    TF["Terraform\n(infra)"] --> ENV
+    PY --> APP["App, DAGs, training"]
 </div>
 
-The important rule is that the package owns workload semantics, while runtime and infrastructure layers own deployment-specific wiring.
+- **`config.yaml`** owns product logic: spots, model features, thresholds, weights
+- **Environment variables** own deployment details: bucket names, URIs, credentials
+- **Terraform** owns cloud infrastructure: projects, regions, service accounts
 
-## Ownership Boundary
+## What's in `config.yaml`
 
-| Surface | Owns | Example values | Must not become |
-|------|------|------------------|-----------------|
-| `config.yaml` | workload defaults and app-facing contracts | rider profile, spot list, API source settings, validation rules, model features, labeling bands, MLflow names, inference weights, monitoring thresholds | a dump of project IDs, service names, bind hosts, or deployment topology |
-| `.env` and environment variables | concrete runtime wiring for one local or hosted instance | `STORAGE_BACKEND`, `STORAGE_S3_BUCKET`, `STORAGE_S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `STORAGE_BIGQUERY_*`, `MLFLOW_TRACKING_URI`, bind hosts, Feast source selection | the source of truth for rider, spot, or model semantics |
-| `terraform/terraform.tfvars` and GitHub delivery variables | infrastructure desired state and hosted rollout inputs | regions, buckets, service names, machine shape, OIDC, remote Terraform state, Cloud Run and hosted-host toggles | the place where model features, ranking weights, or validation rules live |
-| `feature_repo/feature_store*.yaml` | checked-in Feast reference configuration | local reference config and cloud example config | a replacement for the base application config |
-| `.state/feast/feature_store.runtime.yaml` | rendered runtime Feast binding | active repo path, registry path, online-store binding, offline source target | a hand-maintained checked-in config file |
-| `.state/monitoring/*.jsonl` and `airflow/reports/*.json` | retained local monitoring and rendered operator evidence | prediction-event history and latest pipeline summary contracts | app-facing workload configuration |
+| Section | Controls |
+|---------|---------|
+| `rider` | Home location, weight, quiver |
+| `spots` | The six spots with shore orientation |
+| `api` | Open-Meteo and OSRM settings |
+| `model` | Algorithm, feature list, seed, split ratio |
+| `labeling` | Quality band rules, danger thresholds |
+| `inference` | Forecast horizon, ranking weights |
+| `monitoring` | Drift threshold, evaluation window |
+| `mlflow` | Experiment and model names |
+| `storage` | Backend mode (`s3` or `bigquery`) |
+| `validation` | Required columns, accepted ranges |
 
-This split keeps the workload code smaller and clearer. The package does not need to own deployment metadata it only consumes after runtime wiring resolves it.
+## What's in Environment Variables
 
-## What Stays In `config.yaml`
+| Category | Examples |
+|----------|---------|
+| Storage | `STORAGE_BACKEND`, `STORAGE_S3_BUCKET`, `STORAGE_S3_ENDPOINT` |
+| MLflow | `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_DESTINATION` |
+| Ports | `APP_BIND_HOST`, `AIRFLOW_BIND_HOST` |
+| Feast | `FOEHNCAST_FEAST_SOURCE`, `FOEHNCAST_FEAST_REPO_PATH` |
+| Cloud credentials | `AWS_ACCESS_KEY_ID`, `GCP_PROJECT_ID` |
 
-The checked-in YAML owns the stable workload and product contract.
+## What Stays Out of `config.yaml`
 
-| Section | What it controls |
-|------|-------------------------|
-| `rider` | baseline rider profile and home location used by ranking |
-| `api` | upstream weather and routing source settings |
-| `spots` | the fixed spot list and shore metadata |
-| `storage` | the curated-storage mode and its supported values, including `s3` and `bigquery` |
-| `warehouse` | retained warehouse contracts for curated features and prediction events |
-| `validation` | required columns, completeness rules, and accepted numeric ranges |
-| `model` | algorithm choice, feature sets, target field, split ratio, and seed |
-| `labeling` | the synthetic quality-band rules and danger thresholds |
-| `mlflow` | experiment name, model name, and alias naming |
-| `inference` | live horizon and ranking weights |
-| `monitoring` | drift threshold, evaluation window, and local retention knobs |
+- GCP project IDs, bucket names, service URLs
+- Credentials and key files
+- Port bindings and host addresses
+- GitHub OIDC configuration
+- Terraform state details
 
-This is why the training and inference pages can point back to `config.yaml` for feature lists, ranking weights, and label semantics without treating those values as runtime secrets.
+These describe **where** the system runs, not **what** it does.
 
-## What Runtime Wiring Resolves
+## How Resolution Works
 
-`src/foehncast/config.py` keeps the YAML and the runtime wiring separate instead of mutating one into the other.
+`src/foehncast/config.py` loads the YAML once, then resolves runtime values from env vars:
 
-The resolution rules are:
+- `FOEHNCAST_CONFIG_PATH` can point to a different YAML
+- Storage settings: env vars override YAML defaults
+- MLflow URI: always from env
+- Config is cached — runtime resolution doesn't mutate it
 
-- `FOEHNCAST_CONFIG_PATH` can point the loader at a different YAML file when needed
-- the loader caches the checked-in YAML, but runtime helpers resolve environment overrides when the caller asks for storage or MLflow settings
-- storage wiring resolves from environment first, then from local-safe defaults
-- MLflow experiment and model naming stay in YAML, while `MLFLOW_TRACKING_URI` remains runtime wiring
-- the resolved storage config also exposes explicit warehouse contracts for curated features and prediction events
+## Storage Backends
 
-The test contract in `tests/test_config.py` already checks the most important behaviors:
+| Backend | Local | Cloud |
+|---------|-------|-------|
+| `s3` | MinIO parquet | — |
+| `bigquery` | — | BigQuery tables |
 
-- environment overrides apply after the initial YAML load
-- runtime resolution does not mutate the cached YAML values
-- obsolete YAML runtime wiring is ignored instead of being treated as active config
-- default and custom warehouse contracts stay explicit instead of being inferred indirectly
+The app reads `STORAGE_BACKEND` and picks the right client. Same code, different data plane.
 
-That means the package does not need a second handwritten runtime config file just to switch from local to hosted wiring.
+## Related Pages
 
-## Runtime Wiring Examples
-
-The checked-in `.env.example` shows the kind of values that belong in runtime wiring.
-
-| Runtime surface | Example values |
-|------|------------------|
-| Curated storage binding | `STORAGE_BACKEND`, `STORAGE_S3_BUCKET`, `STORAGE_S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `STORAGE_BIGQUERY_PROJECT_ID`, `STORAGE_BIGQUERY_DATASET`, `STORAGE_BIGQUERY_TABLE` |
-| MLflow connection | `MLFLOW_TRACKING_URI`, `MLFLOW_ARTIFACT_DESTINATION` |
-| Local service exposure | `APP_BIND_HOST`, `AIRFLOW_BIND_HOST`, `PROMETHEUS_PORT` |
-| Monitoring history path | `FOEHNCAST_PREDICTION_EVENT_LOG_PATH` |
-| Feast runtime binding | `FOEHNCAST_FEAST_SOURCE`, `FOEHNCAST_FEAST_REPO_PATH`, `FOEHNCAST_FEAST_CONFIG_PATH`, `FOEHNCAST_FEAST_BIGQUERY_*`, `FOEHNCAST_FEAST_DATASTORE_*` |
-
-These values describe one concrete runtime instance. They should stay overridable because the local evaluator, shared API lane, and hosted operator surfaces do not all bind to the same services.
-
-In the shared hosted path, the operator surfaces stay intentionally smaller than the local evaluator. Their runtime wiring should stay explicit instead of being treated as a permanent deployment shape.
-
-## Cloud Runtime Inventory
-
-The shared cloud path uses four value surfaces plus identity-backed auth. The simple split is this: delivery surfaces carry reviewed hosted identifiers and toggles, runtime surfaces carry concrete per-environment wiring, and identities carry cloud access.
-
-| Source surface | Example values | Owned by | Consumed by | Secret rule |
-|------|---------------------------|----------|-------------|-------------|
-| checked-in examples and repo defaults | `.env.example` placeholders, `terraform/terraform.tfvars.example`, checked-in operator docs | repository | bootstrap prompts, local operators, reviewers | structural examples only; never live credentials |
-| bootstrap outputs in the working tree | `.env`, `terraform/terraform.tfvars`, Terraform outputs echoed by `./scripts/bootstrap-gcp.sh` | maintainer running bootstrap for one environment | local preview applies, bootstrap verification, `scripts/configure-github-actions.sh` | hosted identifiers and toggles only; not a long-term secret store |
-| GitHub repository variables | `GCP_PROJECT_ID`, `GCP_LOCATION`, `GCP_ARTIFACT_REPOSITORY`, `GCP_BIGQUERY_*`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT_EMAIL`, Cloud Run sizing and enablement flags | GitHub delivery control plane, normally synced from Terraform outputs | `.github/workflows/terraform.yml`, image-publish workflows, repo-config action | structural delivery contract only; do not store runtime passwords, API tokens, or key files here |
-| runtime `.env` and hosted runtime env vars | `MLFLOW_TRACKING_URI`, `AIRFLOW__API_AUTH__JWT_SECRET`, `cloud_run_env_vars` | runtime operator or platform for one running surface | local evaluator, hosted operator lane, shared API lane, Airflow auth checks | concrete runtime wiring; secret-bearing values should stay local-only or move to Secret Manager or another managed secret path |
-| identity-backed auth surfaces | GitHub OIDC, Cloud Run service account | repository admin plus GCP IAM | GitHub workflows and hosted runtimes | prefer identities over stored cloud credentials; not a secret distribution path |
-
-This inventory keeps the boundary explicit:
-
-- `config.yaml` keeps workload semantics.
-- `terraform/terraform.tfvars` and GitHub repository variables keep structural hosted rollout inputs.
-- runtime `.env` and hosted env injections carry concrete per-environment wiring for the local evaluator, the active operator lane, or the shared API lane.
-- secret-bearing runtime values should not move into committed examples or repository variables just because they are cloud-facing.
-
-This page inventories where those values live. [Delivery and Operator Workflow](delivery-and-operator-workflow.md) owns the maintainer bootstrap, repository-variable sync, and remote-apply runbook that moves between those surfaces.
-
-## Storage And Warehouse Contract
-
-The storage boundary is intentionally narrow.
-
-The curated-storage contract is:
-
-- `s3` is the local MinIO-backed baseline
-- `bigquery` is the hosted analytical baseline
-- the older file-backed curated-store compatibility path is no longer part of the runtime contract
-
-The runtime layer also keeps the warehouse contracts explicit instead of burying them in ad hoc SQL or monitoring code:
-
-- curated features default to the `foehncast.forecast_features` table contract with day partitioning on `forecast_time`
-- prediction events default to the `foehncast_monitoring.prediction_events` table contract with day partitioning on `prediction_timestamp`; BigQuery-backed hosted runtimes use that warehouse table as the durable prediction-history source
-- both contracts keep explicit clustering and retention settings
-
-This matters because retained monitoring facts belong in retained event history and warehouse tables, not in restart-sensitive request counters or implicit table names.
-
-## Feast And Monitoring Runtime State
-
-Two generated state areas are part of the runtime contract even though they are not workload config.
-
-| Generated surface | Why it exists |
-|------|----------------|
-| `.state/feast/feature_store.runtime.yaml` | binds the running environment to the checked-in Feast repo without forcing operators to hand-edit a second runtime YAML |
-| `.state/monitoring/prediction-log.jsonl` | bounded local working set derived from prediction writes for request-side drift checks |
-| `.state/monitoring/prediction-events.jsonl` | retained local prediction-event history contract and the durable history source for local S3-backed runtimes |
-| `airflow/reports/feature-pipeline-*-latest.json` | persisted pipeline summary that the app republishes through `/metrics` for Prometheus |
-
-These files are runtime artifacts. They are inspectable and useful, but they are not part of the checked-in workload contract and should not be promoted into `config.yaml`.
-
-## What Stays Out Of Package Config
-
-The package config should not absorb deployment topology or operator rollout state.
-
-Keep these outside `config.yaml`:
-
-- concrete GCP project ids, bucket names, Cloud Run service names, and hosted machine shapes
-- GitHub OIDC and remote Terraform state configuration
-- public-port exposure decisions for hosted admin surfaces
-- credentials and key-file paths
-- per-environment bind hosts, ports, and service URLs
-
-Those values belong in runtime env, Terraform inputs, or GitHub delivery variables because they describe where the system runs, not what the workload means.
-
-## Why This Split Works
-
-- training and inference can share one workload contract without hard-coding deployment details
-- local and hosted runtimes can switch storage and service bindings without forking the package config
-- Feast stays downstream from the curated feature contract instead of becoming a shadow settings system
-- operator state stays inspectable under `.state/` and `airflow/reports/` without pretending to be workload source data
-
-See [Repository](repository.md), [Feature Pipeline](feature-pipeline.md), [Inference Pipeline](inference-pipeline.md), [Local Evaluator](local-evaluator.md), [Cloud Mapping](cloud-mapping.md), and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the surrounding runtime and deployment boundaries.
+- [Architecture](architecture.md) — how config flows through the system
+- [Local Evaluator](local-evaluator.md) — where `.env` gets set
+- [Cloud Mapping](cloud-mapping.md) — cloud-specific wiring

--- a/docs/site/system/delivery-and-operator-workflow.md
+++ b/docs/site/system/delivery-and-operator-workflow.md
@@ -1,195 +1,104 @@
 # Delivery and Operator Workflow
 
-FoehnCast keeps contributor onboarding and shared-cloud delivery separate. Contributors use `./scripts/bootstrap-local.sh` to run the validated local evaluator. Maintainers use `./scripts/bootstrap-gcp.sh`, GitHub Actions, and Terraform to bootstrap and advance the shared hosted environment. The hosted architecture is Cloud Build plus Cloud Run. This page describes the workflow contract.
+Contributors run locally with Docker. Maintainers deploy to GCP through GitHub Actions + Terraform. This page explains both paths.
 
-!!! note "Scope"
-
-    This page describes the validated delivery and operator workflow.
-    It covers the Cloud Run and Cloud Build hosted architecture.
-    It is not the local evaluator setup guide.
-
-## Workflow In One View
+## Two Paths
 
 <div class="mermaid">
 flowchart TD
-    subgraph Local["fab:fa-docker Contributor lane"]
+    subgraph Contributor ["Contributor (everyone)"]
         direction LR
-        CLONE["Clone repo"]
-        LOCAL["bootstrap-local.sh"]
-        LVERIFY["Local stack + checks"]
-        CLONE --> LOCAL --> LVERIFY
+        CLONE["Clone repo"] --> LOCAL["bootstrap-local.sh"] --> DONE["Local stack running"]
     end
 
-    subgraph Maintainer["fab:fa-google Maintainer lane"]
+    subgraph Maintainer ["Maintainer (cloud deploy)"]
         direction LR
-        SHELL["Cloud Shell"]
-        BGCP["bootstrap-gcp.sh"]
-        HANDOFF["Remote TF + repo vars"]
-        PUSH["Push or dispatch"]
-        TFWF["fab:fa-github terraform.yml"]
-        RUN["Cloud Run API"]
-        SHELL --> BGCP --> HANDOFF --> TFWF
-        PUSH --> TFWF
-        TFWF --> RUN
+        SHELL["Cloud Shell"] --> BGCP["bootstrap-gcp.sh"] --> TF["Terraform + Actions"]
+        TF --> RUN["Cloud Run"]
     end
 </div>
 
-The local path is the supported onboarding path. The cloud path assumes GCP ownership, GitHub repository administration, and access to private operator surfaces.
+| Path | Who | Tools needed | Result |
+|------|-----|-------------|--------|
+| Local | Everyone | Docker only | Full local stack |
+| Cloud bootstrap | Maintainer (once) | `gcloud`, Cloud Shell | Remote TF backend + repo vars |
+| Day-2 delivery | Maintainer | GitHub Actions + Terraform | Updated cloud services |
 
-The remote workflow lands on Cloud Run for the public API lane. Cloud Build publishes runtime images. Orchestration runs on local Airflow via Docker Compose.
+## Contributor Path
 
-## Supported Paths
+```bash
+git clone ... && cd foehncast && ./scripts/bootstrap-local.sh
+```
 
-| Path | Audience | Main tools | Main result |
-|------|----------|------------|-------------|
-| Default contributor path | contributor or reviewer | local Docker plus `./scripts/bootstrap-local.sh` | validated one-machine evaluator stack |
-| One-time shared-cloud bootstrap | maintainer | Google Cloud Shell plus `./scripts/bootstrap-gcp.sh` | remote Terraform backend, repository-variable contract, and first hosted setup |
-| Reviewed day-2 delivery | maintainer | GitHub Actions plus Terraform plus OIDC | reviewed infrastructure and runtime updates |
-| Runtime recovery | maintainer | local Airflow plus the runtime release script | retries, backfills, and reviewed serving handoffs |
+No `gcloud`, no Terraform, no GitHub secrets needed.
 
-## Default Contributor Path
+## Cloud Bootstrap (One-Time)
 
-The default contributor path stays local and small:
+Run from Google Cloud Shell:
 
-1. Clone the repository.
-2. Install Docker.
-3. Run `./scripts/bootstrap-local.sh`.
+```bash
+./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions
+```
 
-This path does not require local `gcloud`, Terraform, or GitHub Actions repository variables. The bootstrap validates the full local evaluator contract, not just container startup, and prints alternate endpoints automatically when the preferred ports are already occupied. See [Local Evaluator](local-evaluator.md) for the full local runtime contract.
+This is interactive — it walks you through project/billing setup, creates the Terraform backend, and syncs repo variables to GitHub.
 
-## One-Time Shared Cloud Bootstrap
+## Day-2 Delivery
 
-The cloud bootstrap is a maintainer workflow, not a second onboarding path. The preferred environment is Google Cloud Shell so admin tools stay off the default evaluator machine.
+After bootstrap, everything goes through GitHub Actions:
 
-For the initial shared-cloud setup, run:
+| Workflow | What it does |
+|----------|-------------|
+| `terraform.yml` | Plan/apply/destroy infrastructure |
+| `publish-app-image.yml` | Build and push container images |
+| `promote-candidate.yml` | Promote model to champion |
+| `rollback-live-release.yml` | Roll back to previous model |
 
-`./scripts/bootstrap-gcp.sh --bootstrap-only --configure-github-actions`
-
-The script is interactive. It walks the operator through `gcloud` authentication, project and billing selection, hosted-target choices, and GitHub repository-variable sync.
-
-In `--bootstrap-only` mode the script prepares the remote Terraform backend, prints the handoff summary, and leaves the broader hosted apply to the remote workflow. It writes `.env` and `terraform/terraform.tfvars` so the local checkout reflects the selected project.
-
-In normal apply mode the script also verifies both hosted lanes: Cloud Run must answer `/health`, `/spots`, and `/metrics`, and the operator host must keep its app URL private.
-
-## Reviewed Day-2 Delivery
-
-After the one-time bootstrap establishes OIDC and the remote backend, GitHub Actions becomes the primary surface for Terraform-managed changes.
-
-| Surface | Purpose |
-|------|---------|
-| `.github/workflows/terraform.yml` | primary Terraform operator path for reviewed apply, plan, destroy, cleanup, and explicit overrides |
-| `scripts/configure-github-actions.sh` | sync Terraform outputs into GitHub repository variables |
-| `terraform/terraform.tfvars` | interactive bootstrap input, not the day-2 source of truth |
-| runtime image workflows | submit reviewed hosted image builds to Cloud Build and publish images to Artifact Registry |
-| `scripts/prepare-feast-cloud.sh` | hosted Feast follow-up after a remote apply and curated BigQuery rows exist |
-
-The remote workflow reads repository-backed values for project, state, storage, BigQuery, and hosted-target toggles. Cloud Run settings such as instance count, container port, CPU, and memory are also repo-variable-backed.
-
-Repository variables stay structural delivery inputs only. Runtime passwords, API tokens, and other secrets belong in the runtime environment or a managed secret path. Both hosted lanes read the same Terraform-managed storage, Feast, and MLflow contract. See [Configuration and Contracts](configuration-and-contracts.md) for the full inventory.
+Repository variables store project IDs, bucket names, and Cloud Run settings. No secrets in repo vars — those stay in runtime env or Secret Manager.
 
 ## Orchestration
 
-Local Airflow (via Docker Compose) owns orchestration: DAG scheduling, retries, backfills, and runtime release handoff.
+Airflow (local Docker Compose) handles:
 
-| Concern | Implementation |
-|------|------------------------|
-| Airflow surface | local Docker Compose |
-| Runtime release entry | `scripts/trigger-runtime-release.sh` against local Airflow API |
-| Scheduling, retries, and backfills | local Airflow |
-| Operator services | MLflow, monitoring, and private app checks |
+- DAG scheduling and retries
+- Asset-triggered pipeline runs
+- Runtime release handoff
 
-## GitHub Versus GCP Boundary
+Cloud Workflows + Scheduler handle cloud-side automation.
 
-The reviewed delivery plane and the runtime execution plane have different responsibilities.
+## Runtime Release
 
-| Plane | Active owner | What it owns | What it must not own |
-|------|---------------|--------------|----------------------|
-| Reviewed delivery | GitHub Actions plus Terraform | lint, test, build, image publish, Terraform plan/apply/destroy, and reviewed deploy workflows | runtime scheduling, retries, backfills, and long-lived operator state |
-| Runtime execution | GCP-hosted runtime surfaces | Cloud Run serving, operator telemetry | source control, CI review, and infrastructure policy review |
-| Shared handoff | repository variables, published images, Terraform outputs, and runtime release requests | reviewed contract from GitHub into GCP runtime surfaces | ad hoc operator-only divergence from the declared contract |
+Model promotion and rollback use a single script:
 
-GitHub Actions triggers reviewed delivery workflows, but runtime scheduling does not belong to GitHub. Runtime orchestration lives on local Airflow.
+```bash
+scripts/trigger-runtime-release.sh <action> <coordinates>
+```
 
-## Runtime Release Trigger Contract
+Actions: `deploy_candidate`, `promote_candidate`, `rollback_live`
 
-The runtime release handoff uses a single script against the Airflow API.
+The script calls the Airflow API, waits for the DAG to finish, and captures the result.
 
-<div class="mermaid">
-flowchart TD
-    SCRIPT["scripts/trigger-runtime-release.sh"] --> API["Airflow API"]
-    API --> DAG["runtime_release DAG"]
-    DAG --> REPORT["runtime-release-latest.json"]
-</div>
+## Retry Runbook
 
-- signal: `scripts/trigger-runtime-release.sh` sends one JSON request with a single action and the associated release coordinates
-- receiver: the local Airflow API
-- observable outcome: the script waits for the `runtime_release` DAG to succeed and captures the configured runtime release summary target
+| Problem | Where to fix | How |
+|---------|-------------|-----|
+| Terraform or image build fails | GitHub Actions | Fix input, rerun workflow |
+| Feature pipeline fails | Local Airflow | Retrigger with explicit logical date |
+| Training needs rerun | Local Airflow | Manual `training_pipeline` run |
+| Deploy/promote/rollback fails | Local terminal | Rerun the trigger script |
 
-Supported actions:
+## GitHub vs. GCP Boundary
 
-- `deploy_candidate`
-- `promote_candidate`
-- `rollback_live`
+| GitHub owns | GCP owns |
+|-------------|----------|
+| Source, lint, test, build | Runtime serving |
+| Image publishing | Metrics and telemetry |
+| Terraform plan/apply | Cloud Run responses |
+| Reviewed delivery | Runtime scheduling |
 
-This keeps the handoff explicit while deeper runtime automation still lives behind the Airflow side of the boundary.
+GitHub triggers delivery. GCP runs services. They don't mix responsibilities.
 
-## Retry And Backfill Runbooks
+## Related Pages
 
-Operators should retry work on the same plane that owns it instead of jumping between GitHub and runtime surfaces.
-
-| Situation | Where to act | Normal procedure | Minimum evidence |
-|------|---------------|------------------|------------------|
-| Terraform or image publication fails before any runtime request is sent | GitHub Actions | fix the reviewed delivery input, then rerun the failed GitHub workflow | GitHub workflow URL plus the updated workflow summary |
-| candidate deploy, promotion, or rollback handoff needs another attempt | local Airflow | rerun `scripts/trigger-runtime-release.sh` with the same release coordinates | runtime release summary target |
-| a feature slice failed or needs replay for one logical date | local Airflow | trigger `feature_pipeline` with an explicit logical date and wait for the DAG to succeed | logical date, feature DAG run id, and `airflow/reports/feature-pipeline-<dataset>-latest.json` |
-| a replayed feature slice should refresh training state too | local Airflow | let the feature replay publish the training-request asset and wait for the asset-triggered `training_pipeline` run | training DAG run id plus `airflow/reports/training-pipeline-<dataset>-latest.json` |
-| training must be rerun without replaying feature ingestion | local Airflow | use a manual `training_pipeline` run only when the curated feature slice already exists | training DAG run id, requested stage, model version, and training summary JSON |
-
-The operator services stay private by default. Recovery uses the local Airflow UI or API.
-
-After the trigger, keep the same wait contract:
-
-- `feature_pipeline` should reach `success` for the chosen logical date
-- the downstream `training_pipeline` should reach `success` as an `asset_triggered` run when the replay is meant to refresh production model state
-- operators should check the latest summary JSON files under `airflow/reports/` before treating the replay as complete
-
-Serving rollout problems should use the runtime trigger contract, not the backfill path. GitHub sends the reviewed deploy, promote, or rollback request, and the runtime side records one explicit acknowledgement.
-
-## Rollback
-
-Rollback uses the runtime trigger contract instead of direct GitHub runtime mutation.
-
-- `.github/workflows/publish-app-image.yml` publishes the reviewed app image only
-- `scripts/trigger-runtime-release.sh` is the single reviewed handoff for candidate deploy, promotion, and rollback requests
-- `.github/workflows/promote-candidate.yml` and `.github/workflows/rollback-live-release.yml` stay as blocked redirect workflows so the old entry points do not continue mutating runtime state directly
-- the configured runtime release summary target records the acknowledged handoff on the runtime side
-
-Practical recovery split:
-
-- use GitHub workflow reruns when reviewed delivery failed before runtime execution
-- use local Airflow retries and backfills when runtime data or orchestration work failed after delivery
-- use the runtime trigger script when the serving release handoff itself must be retried
-
-## Reviewable Boundaries
-
-These boundaries stay explicit across the scripts, Terraform reference, and workflow contract:
-
-- the local Docker evaluator remains the only default contributor path
-- the shared cloud environment stays operator-owned, even though the repository and images are public
-- `terraform/terraform.tfvars` belongs to bootstrap and local preview work, while day-2 remote runs read GitHub repository variables
-- runtime scheduling, retries, and backfills belong to local Airflow, not to GitHub Actions
-- runtime promotion, rollback, and live traffic control do not run inside GitHub workflows; GitHub only sends the reviewed runtime release request
-- Airflow, MLflow, and Prometheus remain operator surfaces rather than rider-facing product surfaces
-- public docs should explain those surfaces with rendered evidence and checked-in configuration, not live control-plane embeds
-
-The same split keeps cloud retirement reviewable. Destroy and cleanup stay separate workflow commands, and cleanup only runs the follow-up actions the operator selected.
-
-## Why This Workflow Works
-
-- contributors get one supported setup path instead of parallel onboarding stories
-- the one-time cloud bootstrap is explicit and interactive, which is safer for project, billing, and hosted-target choices
-- day-2 infrastructure changes run through GitHub Actions so operators do not need local Terraform
-- Terraform outputs, repository variables, and workflow behavior are tied together by regression tests
-- managed orchestration through local Airflow keeps scheduling local and reproducible
-
-See [Interfaces and Surfaces](interfaces-and-surfaces.md), [Hosted Full-Stack](hosted-full-stack.md), [Cloud Mapping](cloud-mapping.md), and [Monitoring](monitoring.md) for the surrounding runtime and exposure boundaries.
+- [Local Evaluator](local-evaluator.md) — the contributor setup
+- [Cloud Architecture](cloud-architecture.md) — what runs in GCP
+- [Configuration](configuration-and-contracts.md) — how config is split

--- a/docs/site/system/feature-pipeline.md
+++ b/docs/site/system/feature-pipeline.md
@@ -1,235 +1,88 @@
 # Feature Pipeline
 
-FoehnCast keeps the feature pipeline as a clear set of boundaries. The same curated feature contract drives the local evaluator and the hosted paths: forecast data is ingested, turned into curated features, checked against explicit bounds, stored through a backend abstraction, and then reshaped for Feast serving without changing the meaning of the feature set.
+The feature pipeline fetches weather forecasts, engineers useful features from them, validates the output, and stores curated rows. Those rows then feed training, Feast, and inference.
 
-This page describes the validated feature contract. It focuses on what each stage owns and what stays outside its scope.
-
-!!! note "Scope"
-
-    This page describes the validated feature-path contract.
-    It is not a roadmap.
-    Future changes belong here only after the contract changes.
-
-## Pipeline Shape
+## Steps
 
 <div class="mermaid">
 flowchart TD
-    subgraph Input ["Inputs"]
-        direction TB
-        CFG["Spot and storage config"]
-        ING["Ingest raw forecast rows"]
-        CFG --> ING
-    end
-
-    subgraph Curated ["Curated path"]
-        direction TB
-        ENG["Engineer curated features"]
-        VAL["Validate schema and ranges"]
-        STO["Store curated rows"]
-        ENG --> VAL --> STO
-    end
-
-    subgraph Handoff ["Handoff"]
-        direction TB
-        OFF["Build Feast offline frame"]
-        EXP["Export Feast-ready parquet"]
-        FEAST["Publish Feast-sync asset"]
-        REQ["Publish training-request asset"]
-        OFF --> EXP --> FEAST --> REQ
-    end
-
-    ING --> ENG
-    STO --> OFF
+    ING["Ingest forecasts"] --> ENG["Engineer features"]
+    ENG --> VAL["Validate"]
+    VAL --> STO["Store curated rows"]
+    STO --> FEAST["Prepare Feast data"]
+    FEAST --> REQ["Publish training-request asset"]
 </div>
 
-Each stage has one clear job:
+| Step | What it does |
+|------|-------------|
+| Ingest | Pulls forecast data from Open-Meteo, checks expected columns |
+| Engineer | Creates derived features (cyclical encoding, gust metrics, etc.) |
+| Validate | Rejects rows with missing columns, nulls, or out-of-range values |
+| Store | Writes curated parquet to MinIO (local) or BigQuery (cloud) |
+| Feast prep | Exports data for Feast online serving |
 
-- ingest proves the upstream weather contract
-- engineering creates the curated feature frame
-- validation rejects structurally broken outputs
-- storage preserves the curated contract without mutating it
-- Feast preparation consumes curated rows instead of reimplementing the feature pipeline
-- Airflow publishes the downstream asset hand-offs after persistence and Feast preparation succeed
+## Feature Engineering
 
-## Runtime Role
+Raw weather values pass through unchanged. On top of them, we add derived columns:
 
-| Runtime mode | What the feature path does |
-|------|-----------------------------|
-| Local evaluator | Airflow writes curated rows to the local storage baseline and prepares Feast downstream |
-| Active shared environment | the same DAG and curated contract write to BigQuery and keep Feast downstream through the hosted storage surfaces |
-| Hosted inference target | consumes the curated layer through the app and Feast; it does not run the feature DAG itself |
+| Feature | Input | Why |
+|---------|-------|-----|
+| `hour_of_day_sin/cos` | Timestamp | Cyclical time encoding (no break at midnight) |
+| `day_of_year_sin/cos` | Timestamp | Season encoding (no break at year-end) |
+| `wind_direction_10m_sin/cos` | Wind direction | Circular encoding (no break at 360°→0°) |
+| `gust_excess_10m` | Gusts − sustained wind | How much stronger gusts are than steady wind |
+| `gust_factor` | Gusts / sustained wind | Ratio for gustiness (used in labeling) |
+| `wind_steadiness` | Rolling wind speed CV | Low = steady, high = variable |
+| `shore_alignment` | Wind dir + shore orientation | How well wind hits the spot cross-shore |
+
+We use tree-based models, so circular encoding matters more than blanket scaling.
+
+## Validation
+
+Validation catches broken data, not bad forecasts. It's a structural gate:
+
+- All required columns must be present
+- Cyclical features must be in [-1, 1]
+- `gust_excess_10m` must be ≥ 0
+- Completeness checks catch nulls (ratio features go null when wind → 0)
+
+## Storage
+
+<div class="mermaid">
+flowchart LR
+    FRAME["Curated DataFrame"] --> WRITE["write_features()"]
+    WRITE --> BACKEND{"Backend?"}
+    BACKEND -->|Local| MINIO["MinIO (S3)"]
+    BACKEND -->|Cloud| BQ["BigQuery"]
+</div>
+
+The `STORAGE_BACKEND` env var picks `s3` or `bigquery`. Same interface, same output shape.
+
+| Data layer | Local | Cloud |
+|-----------|-------|-------|
+| Curated features | MinIO parquet | BigQuery table |
+| Feast offline source | Exported parquet | BigQuery view |
+| Feast online store | Datastore emulator | Firestore |
 
 ## DVC Mapping
 
-For reproducible local and CI runs, DVC collapses the offline feature path into one `curate` stage.
+DVC wraps the offline steps into one `curate` stage:
 
-| DVC stage | Covers | Stops at |
-|------|--------|----------|
-| `curate` | ingest, engineer, validate, and local curated-data materialization | `data/<dataset>/` parquet outputs |
-
-That means DVC proves the curated-data hand-off, not the full runtime orchestration. Airflow still owns the Feast-sync and training-request assets used in the running stack.
-
-## Notebook Review Surface
-
-The repo keeps one runtime-aware notebook review surface at `notebooks/feat_01_ingest_validation.ipynb`. The notebook runs the same feature-pipeline steps in either lane, writes a backend-tagged summary to `.state/notebook_reviews/feature_pipeline_summary_<backend>.json`, and can compare the stable output fields in place when the other backend artifact already exists.
-
-Outside the notebook, the same parity check is available as a normal repo command:
-
-```bash
-make notebook-review-compare NOTEBOOK_REVIEW_BACKEND=s3
+```yaml
+curate:
+  cmd: python -m foehncast.dvc_stages curate
+  outs: [data/<dataset>/]
 ```
 
-That command compares the stable review fields across the S3 and BigQuery summaries and leaves the expected runtime-specific differences, such as backend name and storage target, out of the pass or fail decision.
+DVC proves the data is reproducible. Airflow handles scheduling, retries, and the training-request trigger.
 
-## Stage Responsibilities
+## Wind Units
 
-| Stage | Main responsibility | Must not become |
-|------|----------------------|-----------------|
-| Ingest | fetch forecast rows and make source assumptions explicit | hidden enrichment or silent schema rewriting |
-| Engineering | turn raw rows into stable, curated features | a place where storage or training concerns leak in |
-| Validation | stop missing columns, null-heavy outputs, and impossible numeric ranges | a semantic quality model |
-| Storage | persist and restore curated rows faithfully | a second feature-engineering stage |
-| Feast preparation | project curated rows into offline and entity frames | a replacement for the base feature store |
-| Export | materialize a stable artifact for local Feast workflows | another place where feature semantics can drift |
+Wind values stay in km/h (as received from Open-Meteo). The `hourly_units` map is validated at ingest and logged in the pipeline summary. Domain thresholds (rideable wind limits) are configured in knots and converted at scoring time.
 
-## Ingest Boundary
+## Related Pages
 
-The ingest stage uses the live forecast helper rather than a notebook-only mock. The first contract to defend is upstream shape and timestamp behavior.
-
-The validated ingest assumptions are:
-
-- expected forecast columns are checked explicitly
-- missing and unexpected columns are surfaced rather than ignored
-- timestamp ordering and duplicate timestamps are inspected
-- timezone semantics are made explicit before later storage and Feast hand-offs
-- the upstream wind-unit contract is explicit: Open-Meteo is requested with `wind_speed_unit=kmh`, the returned `hourly_units` map is validated at ingest, and the persisted pipeline summary records those units for later review
-
-For this project, raw weather features stay in source weather units, which means km/h for wind speed and gusts. That is separate from domain-facing rideability thresholds, which remain configured in knots and are converted at scoring time instead of changing the stored feature contract.
-
-Ingest keeps the upstream payload boundary explicit instead of mixing raw capture with curated enrichment.
-
-## Curated Feature Boundary
-
-The engineering layer creates the project's curated feature frame. The feature set already reflects several design choices that should stay stable:
-
-- cyclical time variables are encoded with sine and cosine instead of plain integers
-- shoreline fit is represented with circular math through `shore_alignment`
-- gustiness is carried as both a stable absolute surplus (`gust_excess_10m`) for the model and a ratio (`gust_factor`) retained for label semantics
-- steadiness remains an operational wind-quality signal through `wind_steadiness`
-- raw columns remain available alongside engineered columns so downstream validation and storage operate on one complete curated frame
-- the datetime index and time basis are preserved so later storage and Feast preparation can add persistence and serving context without redefining the feature set
-
-The engineering step keeps the raw forecast measurements intact and adds a small, explicit set of derived columns on top of them:
-
-| Derived feature | Raw input | What the calculation captures |
-|------|-----------|-------------------------------|
-| `hour_of_day_sin`, `hour_of_day_cos` | forecast timestamp | cyclical time-of-day encoding without a hard break between 23:00 and 00:00 |
-| `day_of_year_sin`, `day_of_year_cos` | forecast timestamp | cyclical season-of-year position, with leap years handled explicitly |
-| `wind_direction_10m_sin`, `wind_direction_10m_cos` | `wind_direction_10m` | circular wind-direction encoding so angular wraparound stays model-friendly |
-| `gust_excess_10m` | `wind_gusts_10m`, `wind_speed_10m` | non-negative gust surplus above sustained 10 m wind in km/h |
-| `gust_factor` | `wind_gusts_10m`, `wind_speed_10m` | gust-to-sustained ratio, retained as a label-facing gustiness signal |
-| `wind_steadiness` | rolling `wind_speed_10m` history | 3-hour coefficient of variation, where lower values indicate steadier wind |
-| `shore_alignment` | `wind_direction_10m`, spot `shore_orientation_deg` | cosine similarity between wind direction and the spot's cross-shore orientation |
-
-Most weather fields, such as the raw wind-speed, gust, and temperature measurements, are carried through unchanged. The derived columns above are the only feature-engineering step before validation and storage.
-
-The supported training path is tree-based, so feature representation quality matters more than blanket scaling. Circular wind-direction encoding and the shift toward `gust_excess_10m` follow that same choice. The engineering stage stays narrow: create curated rows first, then let validation, storage, and Feast-specific projection happen downstream.
-
-## Validation Boundary
-
-Validation is structural, not semantic. It is there to stop broken feature frames before they reach storage, training, or Feast preparation.
-
-The validation contract is:
-
-- required columns cover the actual curated feature frame, not only raw ingest fields
-- configured range checks cover the engineered features that later storage and Feast preparation depend on
-- cyclical features and `shore_alignment` are bounded where the math makes the valid range explicit
-- `gust_excess_10m`, `gust_factor`, and `wind_steadiness` are lower-bounded rather than aggressively clipped
-- completeness checks remain important because ratio-based features can go null when sustained wind approaches zero
-- validation is the explicit gate before downstream persistence and Feast projection
-
-This layer does not decide whether a forecast is good for riding. That belongs to the downstream ranking and prediction logic.
-
-## Storage Boundary
-
-Storage works only if it behaves like persistence rather than transformation. A stored feature frame should come back with the same schema, index semantics, and numeric values that validation approved.
-
-<div class="mermaid">
-flowchart TD
-    FEAT["Curated feature frame"] --> WRITE["write_features"]
-    WRITE --> BACKEND["Local, S3-compatible, or BigQuery backend"]
-    BACKEND --> READ["read_features"]
-    READ --> ROUND["Round-trip checks"]
-</div>
-
-The storage contract is:
-
-- local, S3-compatible, and BigQuery backends may use different write-time metadata internally
-- rerunning one logical spot-and-dataset write must replace that slice instead of accumulating cloud-only duplicates
-- downstream reads must restore the same curated feature frame shape
-- backend-specific columns must not leak into consumers after read-back
-- round-trip checks should show matching row counts, matching columns, matching index behavior, and no numeric drift
-- the stored frame should preserve the time basis needed for later Feast projection after read-back
-- storage should operate on validation-approved curated rows, not compensate for upstream quality failures
-
-That is why raw landing, curated storage, and Feast should remain separate responsibilities rather than one blurred storage layer.
-
-## Storage Layering
-
-| Data role | Local baseline | Cloud direction |
-|----------|----------------|-----------------|
-| Raw landing | files if retained at all | GCS |
-| Curated features | MinIO-backed parquet objects | native BigQuery tables |
-| Feast offline source | exported parquet | BigQuery table or view over curated rows |
-| Feast registry and staging | local files | GCS |
-| Feast online store | Datastore-mode emulator | Datastore |
-
-The local operator path mirrors the cloud storage roles closely: MinIO-backed object storage for curated objects and MLflow artifacts, exported parquet for the local Feast offline source, and a Datastore-mode emulator for the local Feast online store. Curated persistence stays separate from Feast serving, and both stay separate from registry metadata.
-
-## Storage Control Surface
-
-The storage split is not only conceptual. The repository exposes it through explicit runtime and infrastructure surfaces so the local path and the cloud target stay aligned.
-
-| Surface | Role |
-|------|------|
-| Backend selection | `storage.backend` keeps curated persistence explicit with `s3` or `bigquery` |
-| Curated storage | `S3FeatureStoreBackend` is the local MinIO-backed path; `BigQueryFeatureStoreBackend` is the cloud path |
-| Feast offline source | local export writes `data/feast/<dataset>.parquet`; cloud Feast reads a BigQuery table or view |
-| Feast runtime state | local `.state/feast/*` files and cloud GCS paths keep Feast metadata separate from curated data |
-| Terraform baseline | Terraform provisions GCS, BigQuery, and Datastore surfaces without changing feature semantics |
-
-Terraform is part of the storage boundary because it provisions the cloud-side GCS and BigQuery surfaces that the feature pipeline expects. It should supply the bucket, dataset, and table baseline while leaving ingest, engineering, validation, storage, and Feast preparation responsible for their own stage contracts. The local baseline uses MinIO for blob-style surfaces, but the cloud target still keeps curated features in BigQuery and the Feast online store in Datastore rather than flattening everything behind one object API.
-
-## Feast Boundary
-
-Feast is downstream from the curated feature store. It should consume curated rows, not reach back into raw ingestion or recompute engineering logic.
-
-<div class="mermaid">
-flowchart TD
-    STORED["Stored curated rows"] --> OFF["build_offline_store_frame"]
-    STORED --> ENT["build_entity_rows"]
-    OFF --> HIST["Historical retrieval inputs"]
-    ENT --> HIST
-    HIST --> EXP["export_offline_store"]
-</div>
-
-That means:
-
-- `build_offline_store_frame(...)` and `build_entity_rows(...)` stay thin projections over stored curated data
-- `export_offline_store(...)` is a deterministic materialization step, not a second feature-engineering stage
-- `prepare_feature_store(...)` is the Airflow-owned orchestration step that exports curated rows, renders the runtime config, applies the Feast repo, and materializes the online store without redefining the feature contract
-- the local preparation script is an operator wrapper around those helpers, not the real source of truth for the feature contract
-- local and cloud Feast bindings stay downstream of curated persistence instead of redefining feature logic
-
-The Airflow-facing part of the contract matters here: the feature DAG emits explicit curated-feature and Feast-sync assets after `prepare_feature_store(...)` succeeds, then optionally publishes the training-request asset that schedules the training DAG. That makes the feature-to-training boundary visible in Airflow instead of hiding it behind a direct trigger.
-
-This keeps the same conceptual split available in both local and cloud directions: curated features first, Feast second.
-
-## Why This Structure Works
-
-- it keeps pipeline boundaries explicit enough for Airflow orchestration
-- it keeps local-first development simple without blocking a BigQuery-backed cloud path
-- it prevents Feast from becoming a surrogate landing layer or feature store owner
-- it gives README and site documentation stable sections that can be explained without embedding run-specific notebook output
-
-See [Architecture](architecture.md) for the broader system view and [Cloud Mapping](cloud-mapping.md) for the GCP direction.
+- [Training Pipeline](training-pipeline.md) — consumes these curated features
+- [Architecture](architecture.md) — where the feature pipeline fits
+- [Configuration](configuration-and-contracts.md) — what's in `config.yaml`
+- [Seasonality](seasonality.md) — the cyclical time features in detail

--- a/docs/site/system/hosted-full-stack.md
+++ b/docs/site/system/hosted-full-stack.md
@@ -1,140 +1,67 @@
-# Hosted Full-Stack
+# Hosted Cloud Environment
 
-FoehnCast no longer runs a separate hosted full-stack Airflow target. The shared environment now keeps a public Cloud Run lane plus a smaller set of private operator surfaces and managed cloud automation. Local Airflow remains the reviewed DAG runtime and runtime-release handoff path.
+The cloud environment runs on GCP with Cloud Run for serving and managed services for everything else. No VMs, no hosted Airflow — orchestration stays local.
 
-This page describes the hosted surfaces that remain after removing the old full-stack VM and managed-orchestration tracks.
-
-!!! note "Scope"
-
-    This page describes the remaining hosted cloud surfaces.
-    Cloud Run carries the public API lane.
-    Cloud Workflows, Cloud Scheduler, MLflow, and monitoring stay on the operator side.
-    It is not the local evaluator setup guide.
-
-## Target Shape
+## What Runs in GCP
 
 <div class="mermaid">
 flowchart TD
-    classDef infra fill:#f5f5f5,stroke:#333
-    classDef runner fill:#f4f1ea,stroke:#f05032
-    classDef platform fill:#fff,stroke:#4285F4
+    classDef platform fill:#e3f2fd,stroke:#1565c0
     classDef operator fill:#fff8e1,stroke:#f57f17
 
-    TF["Terraform baseline"]:::infra
-    GH["fab:fa-github GitHub Actions + OIDC"]:::runner
-
-    subgraph GCP ["fab:fa-google Hosted environment"]
-        direction LR
-        DATA["BigQuery + GCS + Datastore"]:::platform
-        RUN["Cloud Run services"]:::platform
-        WF["Cloud Workflows + Scheduler"]:::operator
-        MLF["MLflow"]:::operator
-        MON["Managed monitoring"]:::operator
-    end
-
-    TF --> DATA
-    DATA --> RUN
-    DATA --> MLF
-    DATA --> WF
-    GH --> RUN
+    TF["Terraform"] --> DATA["BigQuery + GCS + Firestore"]:::platform
+    DATA --> RUN["Cloud Run (public API)"]:::platform
+    DATA --> MLF["MLflow (protected)"]:::operator
+    DATA --> WF["Cloud Workflows + Scheduler"]:::operator
+    GH["GitHub Actions"] --> RUN
     GH --> MLF
-    GH --> WF
-    RUN --> MON
-    MLF --> MON
 </div>
 
-## Role In The Shared Environment
+| Service | Role | Access |
+|---------|------|--------|
+| Cloud Run (App + UI) | Public serving | Public |
+| MLflow | Model registry + tracking | Protected (service-account) |
+| Cloud Workflows | Pipeline scheduling | Protected |
+| BigQuery | Feature + monitoring storage | IAM-only |
+| GCS | Artifacts, Feast registry | IAM-only |
+| Firestore | Feast online store | IAM-only |
+| Cloud SQL | MLflow metadata | Private |
 
-| Lane | Concrete target | Main role |
-|------|----------------|-----------|
-| Shared API lane | Cloud Run hosted API and UI surfaces | serve the public FastAPI routes and rider-facing views |
-| Operator surfaces | protected MLflow, monitoring, and internal checks | provide private tracking and review surfaces |
-| Hosted automation | Cloud Workflows plus Cloud Scheduler | coordinate scheduled cloud-side refreshes |
+## Same Code, Different Infra
 
-The hosted cloud path stays a runtime target, not a contributor environment. It depends on shared GCP storage and identities instead of local emulators, and it stays private while Cloud Run owns public serving.
+| Shared with local | Different in cloud |
+|-------------------|--------------------|
+| FTI pipeline boundaries | BigQuery + GCS replace MinIO |
+| FastAPI routes and Feast | Cloud Run replaces localhost |
+| MLflow and monitoring roles | Cloud Workflows replaces Airflow |
+| Application code and containers | Service accounts replace dev credentials |
 
-## Shared Core And Hosted Differences
+## What Stays Out
 
-| Shared with the local evaluator | Different in the hosted cloud path |
-|------|--------------------------------------|
-| Same Feature-Training-Inference boundaries | BigQuery, GCS, and Datastore replace local object and emulator surfaces |
-| Same FastAPI app and Feast-backed feature path | Cloud Run carries the shared public API while operator surfaces stay private |
-| Same MLflow and monitoring roles | hosted automation moves to Cloud Workflows and Cloud Scheduler instead of a hosted Airflow stack |
-| Same repository and runtime contracts | service accounts and GitHub OIDC replace local developer credentials |
+These don't get deployed to the cloud:
 
-That keeps the hosted path smaller than the old full-stack design without changing the pipeline boundaries.
+- `development_env` container
+- Notebooks
+- Docs build tooling
+- Local MinIO and Datastore emulator
 
-## Surface Responsibilities
+## Identity Model
 
-| Surface | Main responsibility | Must not become |
-|------|----------------------|-----------------|
-| Shared GCP baseline | provide Artifact Registry, GCS, BigQuery, Datastore, and identity foundations | the application runtime itself |
-| Cloud Run | serve the public FastAPI product and service routes plus selected hosted services | a hidden deployment control plane |
-| Cloud Workflows + Scheduler | coordinate scheduled hosted automation | a contributor setup path or notebook host |
-| Cloud Build | publish reviewed runtime images to Artifact Registry | a substitute for GitHub-reviewed delivery |
-| MLflow and monitoring | operator tracking and monitoring | the rider-facing interface |
-| GitHub OIDC delivery | run remote Terraform and image-driven deploy updates | a substitute for the runtime orchestrator |
+- **GitHub Actions** → Workload Identity Federation (OIDC) → deployer service account
+- **Cloud Run services** → narrower runtime service accounts (least privilege)
+- **Cloud Workflows** → managed service identity
+- No long-lived credential files anywhere
 
-## Runtime Contract
+## Bootstrap and Day-2
 
-The hosted cloud path relies on these shared runtime dependencies:
+1. One-time: `./scripts/bootstrap-gcp.sh` from Cloud Shell
+2. Day-2: GitHub Actions runs Terraform and publishes images
+3. Rollback: `scripts/trigger-runtime-release.sh` against local Airflow
 
-- BigQuery for the curated cloud feature layer
-- GCS for MLflow artifacts, pipeline reports, and Feast registry-style storage
-- a named Datastore-mode database for Feast online serving
-- Cloud SQL for MLflow metadata
-- runtime service accounts with appropriate IAM roles instead of mounted key files
+See [Delivery Workflow](delivery-and-operator-workflow.md) for the full process.
 
-The identity split around this target is deliberate:
+## Related Pages
 
-- GitHub Actions uses the deployer identity for Terraform apply, image publish, and Cloud Run rollout work
-- Cloud Run services use narrower runtime identities for serving and service-to-service access
-- Cloud Workflows and Cloud Scheduler use managed service identities to call reviewed runtime entry points
-
-The goal is to keep each service's IAM scope as narrow as its actual duties require.
-
-## Bootstrap And Day-2 Delivery
-
-The hosted cloud path is not part of the default contributor setup. Its lifecycle splits into one-time maintainer bootstrap and GitHub-managed day-2 delivery after bootstrap. Terraform provisions shared services and optional hosted automation, GitHub Actions publishes images and updates hosted surfaces, and local Airflow remains the reviewed DAG runtime when maintainers need explicit runtime-release evidence.
-
-See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed bootstrap, remote Terraform, and runtime-release handoff steps.
-
-## Exposure And Verification
-
-The shared hosted target keeps exposure narrow by default.
-
-The exposure contract is:
-
-- Cloud Run API and UI surfaces are the only public-facing endpoints by default
-- MLflow, monitoring, and hosted automation surfaces stay private through IAM and network controls
-- `bootstrap-gcp` treats Cloud Run as the primary hosted API path and verifies `/health`, `/spots`, and `/metrics`
-
-This preserves the same public-surface rule used across the rest of the docs: the app is the product and service surface, while operator tools remain private by default.
-
-## What Stays Out Of This Target
-
-The hosted cloud path deploys runtime services only.
-
-These surfaces stay local or CI-only:
-
-- `development_env`
-- notebooks
-- docs build tooling
-- the local MinIO objectstore
-- the local Datastore emulator
-
-## Rollback
-
-Cloud Run remains the only supported public API path in the shared environment, so rollback still uses the reviewed runtime-release handoff. The request goes through `scripts/trigger-runtime-release.sh` against the configured Airflow API endpoint, typically from the local operator path.
-
-See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the detailed rollback and retry runbooks.
-
-## Why This Target Works
-
-- it keeps the full operator stack online in the shared environment using managed GCP services
-- it reuses the same repository and application boundaries as the local evaluator target
-- it keeps the hosted runtime tied to reviewable Terraform outputs, GitHub delivery, and metrics
-- it keeps public exposure narrow enough that the app remains the only default internet-facing surface
-- it uses managed orchestration instead of VM-owned scheduling
-
-See [Architecture](architecture.md), [Local Evaluator](local-evaluator.md), [Inference Pipeline](inference-pipeline.md), [Cloud Mapping](cloud-mapping.md), and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the surrounding runtime and deployment boundaries.
+- [Cloud Architecture](cloud-architecture.md) — service inventory and cost breakdown
+- [Cloud Mapping](cloud-mapping.md) — local ↔ cloud equivalents
+- [Local Evaluator](local-evaluator.md) — the contributor-facing alternative

--- a/docs/site/system/inference-pipeline.md
+++ b/docs/site/system/inference-pipeline.md
@@ -1,188 +1,94 @@
 # Inference Pipeline
 
-FoehnCast keeps inference inside the application layer. The same FastAPI serving contract runs locally and on Cloud Run. Internal checks and hosted automation reuse that contract without creating a separate rider-facing surface.
+The inference pipeline serves predictions through a FastAPI app. It loads a model from MLflow, fetches live forecasts, engineers features, predicts quality, and ranks spots.
 
-This page describes what the running app owns and what stays optional or operator-controlled.
-
-!!! note "Scope"
-
-    This page describes the validated inference-path contract.
-    It does not redefine orchestration or the hosted build.
-    The serving contract stays stable regardless of hosted control-plane changes.
-
-## Inference Shape
+## Request Flow
 
 <div class="mermaid">
 flowchart TD
-    subgraph RequestPath ["Request path"]
+    subgraph Request ["Request path"]
         direction TB
-        REQ["Requested spots"]
-        RES["Resolve configured spots"]
+        REQ["Spot IDs from client"]
         WX["Fetch Open-Meteo forecast"]
-        ENG["Engineer shared features"]
-        REQ --> RES --> WX --> ENG
+        ENG["Engineer features"]
+        REQ --> WX --> ENG
     end
 
-    subgraph ModelPath ["Model path"]
+    subgraph Model ["Model path"]
         direction TB
-        REG["MLflow serving alias"]
-        MOD["Load served model"]
+        REG["MLflow registry"]
+        MOD["Load champion model"]
         REG --> MOD
     end
 
-    subgraph OutputPath ["Outputs"]
+    subgraph Output ["Output"]
         direction TB
-        PRE["/predict response"]
-        RNK["Rank with rider profile and drive time"]
-        OUT["/rank response"]
-        MON["Prediction monitoring hand-off"]
-        PRE --> RNK --> OUT
+        PRE["/predict → quality scores"]
+        RNK["/rank → sorted spots"]
+        PRE --> RNK
     end
 
-    subgraph OptionalPath ["Demo surfaces"]
-        direction TB
-        ONL["/features/online lookup"]
-        DEMO["Online-features demo"]
-        DASH["Streamlit live demo"]
-        ONL --> DEMO
-    end
-
-    ENG --> MOD
-    MOD --> PRE
-    RES --> ONL
-    DASH --> PRE
-    DASH --> OUT
-    PRE --> MON
-    OUT --> MON
+    ENG --> MOD --> PRE
 </div>
 
-Inference stays request-focused:
+## API Endpoints
 
-- the app resolves configured spots and fetches fresh forecast data on demand
-- the serving model is loaded from the registry alias that represents the live contract
-- prediction and ranking reuse the same forecast payload instead of forking into separate pipelines
-- the Feast lookup path stays optional and does not gate the main prediction surface
-- monitoring is triggered from the request path but the operator metrics surface stays separate
+| Route | What it returns |
+|-------|----------------|
+| `/health` | App status + served model alias and version |
+| `/spots` | List of configured spots |
+| `/predict` | Per-spot forecast with `quality_index` values |
+| `/rank` | Spots scored and sorted for the rider profile |
+| `/features/online` | Feast-backed feature lookup (optional) |
+| `/metrics` | Prometheus metrics (for monitoring, not users) |
 
-## Endpoint Responsibilities
+## How Prediction Works
 
-| Surface | Main responsibility | Must not become |
-|------|----------------------|-----------------|
-| `/health` | expose app readiness plus the served alias and model version | a deployment control plane |
-| `/spots` | return the configured set of supported spots | a source of hidden business rules |
-| `/predict` | return per-spot forecast rows with continuous `quality_index` values | a training, labeling, or promotion path |
-| `/rank` | score the same prediction payload for one rider profile | a second prediction model or a dashboard layer |
-| `/features/online` | expose Feast-backed online feature rows for app-side integrations | a required dependency for normal prediction requests |
-| `/features/online/demo` | give a lightweight HTML page for manual lookup checks | the main rider product UI |
+1. Client sends spot IDs → app resolves them against `config.yaml`
+2. App fetches live forecast from Open-Meteo (capped at 14h horizon)
+3. Same `engineer_features()` function as the feature pipeline builds the feature vector
+4. Model predicts `quality_index` for each forecast row
+5. Response includes timestamps + continuous quality scores + model version
 
-The app also serves `/metrics`, but that route belongs to the monitoring hand-off described below rather than to the core rider-facing inference contract.
+## How Ranking Works
 
-## Model Resolution Boundary
+`/rank` is not a second model. It reuses `/predict` output and scores spots with:
 
-Inference serves one registry alias at a time. The serving contract is:
+| Weight | Factor | Default |
+|--------|--------|---------|
+| 0.6 | Peak quality score | Highest `quality_index` in the window |
+| 0.3 | Ride-vs-drive ratio | Session hours ÷ drive hours |
+| 0.1 | Session duration | Hours above rideable threshold |
 
-- the registered model name is `foehncast-quality`
-- the default live alias is `champion`
-- `FOEHNCAST_MLFLOW_SERVING_ALIAS` can override the served alias when an operator needs to pin another registry view
-- `/health` returns `status`, `model_alias`, and `model_version` so a runtime check can confirm what is actually being served
-- prediction responses also include `model_version` so downstream consumers can tie a response back to the active registry version
+Drive time comes from OSRM. Weights live in `config.yaml`.
 
-This keeps serving aligned with the training registry contract without giving the inference service promotion or rollback authority.
+## Model Loading
 
-## Prediction Boundary
+- Model name: `foehncast-quality`
+- Default alias: `champion`
+- Override: `FOEHNCAST_MLFLOW_SERVING_ALIAS` env var
+- `/health` shows which alias and version is active
 
-The prediction path is intentionally narrow:
+## Scheduled Inference (Airflow)
 
-- requested spot IDs are resolved against the configured spot list, and unknown spots return `404` instead of silently falling back
-- live weather comes from the Open-Meteo forecast pull for each requested spot
-- the request horizon is capped by `inference.max_horizon_hours`, which defaults to `14`
-- the same `engineer_features` step used by the feature path rebuilds the feature vector expected by the trained model
-- the served feature columns come from `model.features` in `config.yaml`
-- the app returns forecast rows as timestamps plus continuous `quality_index` values
+The `inference_pipeline` DAG also runs predictions in batch:
 
-That means the request path scores a trained model against fresh forecast features. It does not recompute the synthetic training labels, emit evaluation artifacts, or move registry aliases.
+- Triggered by the model-registry asset (new model → auto-run)
+- Predicts across all configured spots
+- Emits prediction log for monitoring and hindcast validation
 
-## Ranking Boundary
+This keeps prediction history populated even without live traffic.
 
-`/rank` is not a second model. It reuses the prediction payload from `/predict` and then scores the candidate spots for the configured rider profile.
+## Streamlit UI
 
-The ranking contract is:
+The Streamlit demo (`ui/app.py`) calls the same `/predict` and `/rank` endpoints and presents:
 
-- ranking weights come from `config.yaml`; the default weights are `0.6` for peak quality, `0.3` for ride-versus-drive ratio, and `0.1` for rideable duration
-- drive-time cost comes from the rider profile plus the OSRM routing lookup
-- session duration is derived from the forecast hours that clear the rideable threshold
-- the route returns ranked numeric rows such as `quality_index`, `drive_minutes`, `session_hours`, `ride_drive_ratio`, and `score`
+- Ranked spot cards with rider-friendly quality labels
+- Current model version and forecast window
+- Live metric charts from PromQL queries
 
-This keeps ranking personal without hiding another model behind the API. The Streamlit demo can add rider-facing labels and summary cards on top of the same ranked data.
+## Related Pages
 
-## Online Feature Boundary
-
-The online feature route is a separate integration surface layered on top of the same curated contract.
-
-The online-feature contract is:
-
-- the default Feast repo path is `feature_repo/`, with `FOEHNCAST_FEAST_REPO_PATH` as an override
-- a call without explicit feature names uses the `foehncast_model_v1` feature service
-- a call with explicit feature names resolves them against the `spot_forecast_features` view unless the caller already supplies a fully qualified feature reference
-- the route returns row-shaped feature data instead of leaking Feast's columnar response shape
-- the route returns `503` when the Feast runtime dependency or configured repo is missing and `400` when the requested feature list is invalid
-
-This path stays optional. Normal `/predict` and `/rank` requests do not depend on Feast being available.
-
-## Rider Demo Surfaces
-
-FoehnCast keeps the rider-facing demo separate from operator dashboards.
-
-The demo surfaces are:
-
-- the Streamlit live demo, which loads live predictions, applies the ranking helper, and presents rider-facing cards and tables
-- the online-features demo page, which issues manual `/features/online` calls against the running app
-
-The Streamlit helper rounds continuous quality scores into stable rider-facing labels from `Unsafe` through `Perfect Storm`, uses the configured forecast horizon to describe the live window, and exposes the served `model_version` in the returned payload. That makes it a public-safe evaluation surface, not an operator dashboard.
-
-## Monitoring Hand-Off
-
-Prediction routes emit monitoring signals, but the monitoring surface itself stays separate.
-
-The monitoring hand-off is:
-
-- `/predict` and `/rank` schedule background prediction-monitoring work after a successful response payload is built
-- the background path records scheduling and execution outcomes and emits prediction-drift metrics from retained prediction history
-- `/metrics` merges durable feature and training summaries, retained prediction-log metrics, hosted-sync metrics, hindcast validation results, and in-process prediction-monitoring counters
-- hindcast validation runs hourly in the background, comparing past predictions against observed weather to measure real forecast accuracy; results persist in `.state/monitoring/hindcast-validation.json`
-
-This keeps the inference service responsible for request-side facts while leaving dashboards, alert rules, and long-range operator review to the monitoring stack.
-
-## Scheduled Inference
-
-Inference also runs as a scheduled Airflow DAG alongside the request-driven app path.
-
-The `inference_pipeline` DAG is:
-
-- triggered by the `foehncast_mlflow_model_registry` asset, meaning it runs automatically after a new model version is registered
-- executes `run_inference_pipeline_step`, which predicts across all configured spots using the champion model
-- emits the `foehncast_inference_prediction_log` asset so downstream monitoring and hindcast validation can consume fresh predictions
-- can also be triggered manually from the Airflow UI when the operator wants a batch prediction refresh
-
-This keeps the prediction-event history populated even when no rider requests arrive, which is important for hindcast validation and drift detection over time.
-
-## Runtime Role
-
-| Runtime mode | Inference role |
-|------|---------------------|
-| Local evaluator | FastAPI app serves predictions from locally-registered MLflow model; the `inference_pipeline` DAG runs batch predictions after model registration |
-| Cloud Run | shared public API with the same serving contract |
-| Cloud Workflows + Scheduler | hosted automation can coordinate scheduled refreshes without changing the FastAPI serving contract |
-| Hosted operator surfaces | private checks and tracking stay separate from the rider-facing API |
-
-See [Architecture](architecture.md) for the lane summary and [Hosted Full-Stack](hosted-full-stack.md) for the hosted exposure and transition rules.
-
-## Why This Structure Works
-
-- live requests stay narrow enough to verify through simple route and dashboard tests
-- the shared feature contract is reused instead of inventing a serving-only schema
-- responses tie back to a concrete registry version without giving the app promotion authority
-- one FastAPI contract runs locally, on Cloud Run, and on the operator surface without contract changes
-- the Feast lookup path is useful for integration checks while prediction and ranking work from the core app alone
-
-See [Architecture](architecture.md), [Training Pipeline](training-pipeline.md), [Monitoring](monitoring.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding system boundaries.
+- [Training Pipeline](training-pipeline.md) — produces the model
+- [Monitoring](monitoring.md) — consumes prediction events
+- [Architecture](architecture.md) — how inference fits in the FTI split

--- a/docs/site/system/interfaces-and-surfaces.md
+++ b/docs/site/system/interfaces-and-surfaces.md
@@ -1,69 +1,48 @@
-# Interfaces and Surfaces
+# Interfaces
 
-FoehnCast exposes five surface classes: rider, service, operator, delivery, and public-safe docs. This page defines who each surface is for and what should stay private.
+FoehnCast exposes different things to different audiences. This page clarifies what's public, what's internal, and what's just for operators.
 
-!!! note "Scope"
-
-    This page defines exposure boundaries.
-    Use runtime pages for deployed targets.
-    Use workflow pages for maintainer procedures.
-
-## Surface Map
+## Who Sees What
 
 <div class="mermaid">
 flowchart TD
     classDef public fill:#f5f5f5,stroke:#333
     classDef service fill:#e1f5fe,stroke:#01579b
     classDef operator fill:#fff8e1,stroke:#f57f17
-    classDef evidence fill:#ececff,stroke:#9370db
 
-    RIDER["Rider demos<br/>Streamlit and /features/online/demo"]:::public
-    SERVICE["Service routes<br/>/health, /spots, /predict, /rank, /features/online"]:::service
-    OPERATOR["Private operator surfaces<br/>/metrics, Airflow, MLflow, Prometheus"]:::operator
-    DELIVERY["fab:fa-github Delivery<br/>GitHub Actions, Terraform, bootstrap"]:::public
-    EVIDENCE["Public-safe evidence<br/>Docs, summaries, screenshots"]:::evidence
+    RIDER["User-facing: Streamlit UI"]:::public
+    SERVICE["API routes: /health, /predict, /rank, /spots"]:::service
+    OPERATOR["Internal: /metrics, Airflow, MLflow, Prometheus"]:::operator
+    DOCS["Public docs: this website, screenshots"]:::public
 
     RIDER --> SERVICE
-    DELIVERY --> SERVICE
     SERVICE --> OPERATOR
-    OPERATOR -. "Rendered outputs only" .-> EVIDENCE
+    OPERATOR -. "screenshots only" .-> DOCS
 </div>
 
-The important split is simple: not every HTTP route is rider-facing, and not every visible screen is safe to treat as public documentation.
+## Surface Types
 
-## Surface Classes
+| Type | Examples | Who uses it | Access |
+|------|----------|-------------|--------|
+| User-facing | Streamlit UI, `/features/online/demo` | Users, reviewers | Public |
+| API endpoints | `/health`, `/predict`, `/rank`, `/spots` | Clients, tests | Public |
+| Operator tools | `/metrics`, Airflow, MLflow, Prometheus | Maintainers | Private |
+| CI/CD | GitHub Actions, Terraform | Maintainers | Review-gated |
+| Documentation | This site, screenshots | Everyone | Public |
 
-| Surface class | Examples | Main audience | Default exposure |
-|------|----------|---------------|------------------|
-| Rider-facing demo surfaces | Streamlit rider console and `/features/online/demo` | rider, reviewer, contributor | public-safe when shown as screenshots, rendered examples, or a deliberate local demo |
-| Service endpoints | `/health`, `/spots`, `/predict`, `/rank`, and `/features/online` | clients, smoke tests, and app-side integrations | service-only |
-| Operator surfaces | `/metrics`, Airflow, MLflow, and Prometheus | maintainer or deployment operator | private by default |
-| Delivery surfaces | GitHub Actions, Terraform, and bootstrap helpers | maintainer | review-controlled and not runtime-facing |
-| Public-safe docs and evidence | docs pages, rendered summaries, and screenshots | reviewer, fork reader, course audience | public-safe |
+## Key Rules
 
-## Exposure Rules
+- `/metrics` is **not** user-facing — it's an operator endpoint
+- Streamlit is a demo, not a deployment control panel
+- GitHub Actions handles delivery, not runtime scheduling
+- Public docs use screenshots or rendered data, never live embeds of Airflow/MLflow/Prometheus
 
-- `/metrics` is an operator surface even though it is an app route.
-- Streamlit and `/features/online/demo` are evaluation surfaces, not deployment control planes.
-- GitHub Actions and Terraform advance reviewed delivery, but they do not own runtime scheduling, retries, or backfills.
-- Public docs should use rendered evidence or screenshots instead of live Airflow, MLflow, or Prometheus views.
+## By Environment
 
-## Exposure By Runtime Mode
+| Environment | Public | Private |
+|-------------|--------|---------|
+| Local | FastAPI app, Streamlit | Airflow, MLflow, Prometheus |
+| Cloud | Cloud Run API, Streamlit UI | MLflow, monitoring |
+| Docs site | Rendered pages | Nothing live |
 
-| Runtime mode | Product or service surface | Operator-only surface |
-|------|-----------------------------|-----------------------|
-| Local evaluator | local app routes, local Streamlit demo, and the optional online-features demo | local Airflow, MLflow, and Prometheus |
-| Shared API lane | hosted inference API only | no hosted Airflow or MLflow container in that target |
-| Operator lane | no public app route by default | Airflow, MLflow, and Prometheus stay private unless deliberately exposed |
-| Public docs site | rendered docs and evidence only | no live control planes |
-
-The same split applies in local and cloud runtimes: app routes form the product and service surface, while operator tools stay private unless an operator intentionally publishes them.
-
-## Why This Boundary Works
-
-- it lets the rider-facing demo reuse the real serving path without turning the product into an admin console
-- it keeps service endpoints narrow enough for smoke tests and client integrations
-- it keeps orchestration, tracking, and monitoring on the operator side
-- it gives the public docs stable evidence sources that do not depend on exposing private hosted dashboards
-
-See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Inference Pipeline](inference-pipeline.md), [Monitoring](monitoring.md), [Local Evaluator](local-evaluator.md), and [Hosted Full-Stack](hosted-full-stack.md) for the surrounding runtime contracts.
+Same principle everywhere: the app is the product, operator tools stay behind the curtain.

--- a/docs/site/system/local-evaluator.md
+++ b/docs/site/system/local-evaluator.md
@@ -1,130 +1,103 @@
 # Local Evaluator
 
-FoehnCast uses the local evaluator lane as the default contributor runtime. `bootstrap-local` starts the validated service subset, resets disposable local state, runs one end-to-end feature and training hand-off, prepares Feast serving state, and verifies the app and operator contracts before it reports success.
+The local evaluator is the default way to run FoehnCast. It starts everything in Docker Compose and verifies the full pipeline works before declaring success.
 
-This page describes the default contributor runtime contract. It documents the supported baseline, not a migration plan.
+## What Bootstrap Does
 
-!!! note "Scope"
+```bash
+./scripts/bootstrap-local.sh
+```
 
-    This page describes the validated local evaluator target.
-    It is not a roadmap.
-    Future changes belong here only after the target changes.
+The script:
 
-## Target Shape
+1. Starts Docker services (Airflow, MLflow, MinIO, app, Prometheus)
+2. Waits for Airflow health
+3. Runs the feature pipeline → training pipeline (asset-triggered)
+4. Prepares Feast serving state
+5. Verifies app `/health` and `/metrics`
+6. Reports success with endpoint URLs
+
+If default ports are busy, it picks the next free ones and tells you.
+
+## Architecture
 
 <div class="mermaid">
 flowchart TD
     classDef pipeline fill:#e1f5fe,stroke:#01579b
-    classDef registry fill:#fff,stroke:#d32f2f
+    classDef storage fill:#ececff,stroke:#9370db
     classDef app fill:#222,stroke:#333,color:#fff
-    classDef storage fill:#fff,stroke:#9370db
-    classDef monitor fill:#fff,stroke:#f57f17
+    classDef monitor fill:#fff8e1,stroke:#f57f17
 
-    subgraph LocalStack ["fab:fa-docker Local stack"]
+    EXT["Weather APIs"]
+
+    subgraph Stack ["Docker Compose"]
         direction LR
         AIR["Airflow"]:::pipeline
         FEAT["Feature DAG"]:::pipeline
-        CUR["Curated feature data"]:::storage
-        REQ["Training-request asset"]:::pipeline
+        MIN["MinIO"]:::storage
         TRN["Training DAG"]:::pipeline
-        REG["MLflow registry"]:::registry
+        MLF["MLflow"]:::storage
         FEAST["Feast emulator"]:::storage
-        APP["FastAPI app"]:::app
-        MON["Prometheus + StatsD"]:::monitor
+        APP["FastAPI"]:::app
+        MON["Prometheus"]:::monitor
     end
 
+    EXT --> FEAT
     AIR --> FEAT
     AIR --> TRN
-    FEAT --> CUR
-    FEAT --> REQ
-    CUR --> FEAST
-    REQ --> TRN
-    TRN --> REG
-    REG --> APP
+    FEAT --> MIN
+    FEAT --> TRN
+    MIN --> TRN
+    TRN --> MLF
+    MIN --> FEAST
     FEAST --> APP
+    MLF --> APP
     APP --> MON
 </div>
 
-The local evaluator is a real runtime target, not a mock environment:
+## Three Entry Points
 
-- the same feature, training, inference, and monitoring modules run inside the local stack
-- the bootstrap waits for a real asset-triggered training run instead of stopping after container startup
-- Feast serving state is prepared after curated features exist instead of being treated as an optional afterthought
-- rider-facing and operator-facing surfaces stay separate even in local mode
+| Entry point | When to use | What it covers |
+|-------------|-------------|---------------|
+| `./scripts/bootstrap-local.sh` | Full local runtime | All services + pipeline run + verification |
+| `dvc repro` | Reproducible offline rerun | Curate + train, writes to `data/` and `reports/` |
+| `curl localhost:8000/rank` | Test serving | Just the running app |
 
-## Bootstrap Responsibilities
+## Services
 
-The default contributor entrypoint is still simple:
+| Service | Port | What |
+|---------|------|------|
+| FastAPI app | 8000 | Prediction and ranking API |
+| Airflow | 8080 | DAG scheduling and monitoring |
+| MLflow | 5001 | Experiment tracking and model registry |
+| Prometheus | 9090 | Metrics collection |
+| MinIO | 9000 | S3-compatible object storage |
+| Feast emulator | — | Datastore-mode online serving |
+| StatsD exporter | 9102 | Drift metrics |
 
-1. Install Docker.
-2. Clone the repository.
-3. Run `./scripts/bootstrap-local.sh`.
+## What Gets Verified
 
-You do not need local `gcloud`, Terraform, GitHub Actions variables, or a compiler toolchain for this path.
+The bootstrap doesn't just start containers — it proves the system works:
 
-The bootstrap path resets disposable state, starts the validated service subset without the optional `development_env` container, waits for Airflow health, runs the feature-to-training hand-off, prepares Feast local serving state, and verifies the live app plus `/metrics` before it reports success. The detailed proof path is listed below under [Verification Contract](#verification-contract).
+- Airflow webserver, scheduler, triggerer all healthy
+- Feature pipeline DAG runs successfully
+- Training pipeline triggers from the feature asset
+- App serves `/health` with a real model version
+- `/features/online` returns Feast data
+- `/metrics` exposes monitoring gauges
 
-If the preferred local ports are already occupied, the bootstrap moves the bindings to the next free ports and prints the resolved endpoints.
+## Local State
 
-## Bootstrap, DVC, And The App
+| Type | Location | Persists? |
+|------|----------|-----------|
+| Airflow metadata/logs | Docker volumes | Reset on bootstrap |
+| Curated features | MinIO | Reset on bootstrap |
+| MLflow artifacts | MinIO | Reset on bootstrap |
+| Prediction history | `.state/monitoring/` | Retained |
+| Pipeline summaries | `airflow/reports/` | Retained |
 
-The local evaluator keeps three useful entry points available, but each one has a different job.
+## Related Pages
 
-| Use this | When you want | What it covers |
-|------|---------------|----------------|
-| `./scripts/bootstrap-local.sh` | the full local runtime | Docker services, Airflow asset hand-off, MLflow, Feast, monitoring, and app validation |
-| `dvc repro` | a reproducible offline rerun | `curate` and `train` from `dvc.yaml`, writing tracked outputs under `data/` and `reports/` |
-| FastAPI or Streamlit | serving behavior | live prediction, ranking, and online-feature checks |
-
-DVC is optional in the local evaluator. It is useful when you want a clean, file-based rerun of the offline feature and training path without driving the scheduler by hand. The checked-in DVC remote points at the local MinIO objectstore for cache storage, but DVC itself is not the runtime control plane and it does not replace the app, Airflow, or monitoring stack.
-
-## Runtime Surfaces
-
-| Surface | Role in the local evaluator | Must not become |
-|------|--------------------------------------|-----------------|
-| FastAPI app | serve `/health`, `/spots`, `/predict`, `/rank`, `/features/online`, and `/metrics` | a hidden training or operator control plane |
-| Airflow plus Postgres metadata database | run feature and training orchestration with asset hand-offs | a notebook-only demo path |
-| MLflow | track runs, registry versions, and local model loading | the rider-facing interface |
-| MinIO objectstore | local object-access baseline for curated features and MLflow artifacts | a replacement for the online feature layer |
-| Feast Datastore emulator | required local online-serving layer above the curated contract | the primary storage contract |
-| Prometheus and StatsD exporter | operator monitoring validation | the product UI |
-| `development_env` | optional notebook and dev-shell helper surface | part of the default contributor path |
-
-This keeps the local lane close to the hosted architecture. The object-access layer follows the same shape as the hosted artifact path, while Feast continues to provide the online-serving boundary instead of turning storage into a serving shortcut.
-
-## Verification Contract
-
-The local evaluator reports success only after the runtime proves several real contracts.
-
-The verification path includes:
-
-- Airflow component health checks for the webserver, dag-processor, scheduler, triggerer, and metadata database
-- an Airflow API health payload check instead of treating `200 OK` alone as enough
-- a real `feature_pipeline` DAG test run through Airflow
-- a real asset-triggered `training_pipeline` success wait
-- a live `/features/online` request against the running app
-- app health and hosted-sync metric verification through `/metrics`
-
-That makes the local lane more than a container smoke test. It exercises the same hand-offs the rest of the system pages describe.
-
-## Disposable And Retained Local State
-
-The local evaluator resets disposable state aggressively, but it still keeps the important contracts explicit.
-
-The state split is:
-
-- disposable Airflow metadata and logs are cleared by the bootstrap path
-- curated features and MLflow artifacts use the MinIO-backed local objectstore baseline for the run
-- retained prediction monitoring history lives under `.state/monitoring/` instead of mixing into `data/`
-- pipeline summaries are rendered under `airflow/reports/`, with history copies under `airflow/reports/history/`
-
-This boundary matters because reproducibility depends on resetting transient runtime state without pretending that monitoring history or rendered evidence are themselves product data.
-
-## Why This Target Works
-
-- it gives contributors a clone-and-run baseline instead of a partial demo stack
-- it proves the feature-to-training hand-off through Airflow assets before declaring the stack ready
-- it keeps the online feature contract real by preparing Feast state and calling the live route
-- it keeps optional notebook tooling outside the default path so the supported baseline stays smaller and easier to reproduce
-
-See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Inference Pipeline](inference-pipeline.md), [Monitoring](monitoring.md), and [Cloud Mapping](cloud-mapping.md) for the surrounding runtime and deployment boundaries.
+- [Getting Started](../getting-started.md) — quick setup instructions
+- [Architecture](architecture.md) — how this fits the FTI split
+- [Delivery Workflow](delivery-and-operator-workflow.md) — cloud deployment (separate from local)

--- a/docs/site/system/monitoring.md
+++ b/docs/site/system/monitoring.md
@@ -1,48 +1,32 @@
 # Monitoring
 
-FoehnCast keeps monitoring as an operator surface, not a rider-facing one. The monitoring stack turns pipeline summaries, prediction events, drift signals, and serving health into scrapeable metrics and checked-in alert rules.
+FoehnCast uses Prometheus for metrics collection, Evidently for drift detection, and Streamlit for visualization. This page explains what gets measured and how.
 
-This page describes what is measured, where the evidence comes from, and how operators verify it.
-
-!!! note "Scope"
-
-    This page describes the validated monitoring contract.
-    It focuses on monitoring evidence and boundaries.
-    It does not redefine orchestration or the hosted build.
-
-## Signal Path
+## Signal Flow
 
 <div class="mermaid">
 flowchart TD
-    subgraph Sources ["Evidence sources"]
-        direction TB
-        AIR["Airflow pipeline summaries"]
+    subgraph Sources ["What generates signals"]
+        AIR["Pipeline summaries (JSON)"]
         PRED["Prediction requests"]
-        SYNC["Hosted sync status"]
         HIND["Hindcast validation"]
+        DRIFT["Drift detection (Evidently)"]
     end
 
-    subgraph Processing ["Metric composition"]
-        direction TB
-        APP["App /metrics endpoint"]
-        LOG["Prediction log + event history"]
-        DRIFT["Evidently drift detection"]
+    subgraph Collection ["How they're collected"]
+        APP["/metrics endpoint"]
         STATSD["StatsD exporter"]
     end
 
-    subgraph Operator ["Operator tooling"]
-        direction TB
+    subgraph Display ["Where you see them"]
         PROM["Prometheus"]
         ALERT["Alert rules"]
-        UI["Streamlit native charts"]
+        UI["Streamlit charts"]
     end
 
     AIR --> APP
-    PRED --> LOG
-    SYNC --> APP
+    PRED --> APP
     HIND --> APP
-    LOG --> APP
-    LOG --> DRIFT
     DRIFT --> STATSD
     APP --> PROM
     STATSD --> PROM
@@ -50,177 +34,88 @@ flowchart TD
     PROM --> ALERT
 </div>
 
-Monitoring consumes persisted or runtime state after the pipeline and serving paths run. It does not own feature engineering, model scoring, or orchestration.
-
-## Runtime Role
-
-| Runtime mode | Monitoring contract |
-|------|---------------------|
-| Local evaluator | app `/metrics`, StatsD drift export, persisted pipeline summaries, and native Altair charts in the Streamlit UI validate the full monitoring path on one machine |
-| Shared hosted environment | Cloud Run exposes `/metrics`; the operator lane keeps Prometheus and hosted sync evidence online |
-| Public docs | rendered metrics snippets, checked-in configs, and summary artifacts explain the contract without live control planes |
-
-The public-versus-private surface rule is documented in [Interfaces and Surfaces](interfaces-and-surfaces.md).
-
-## Evidence Sources
-
-| Source | Kind | What it shows |
-|------|------|---------------|
-| `airflow/reports/*.json` | durable | latest feature and training pipeline summaries plus history |
-| `.state/monitoring/prediction-events.jsonl` | durable | prediction-event history by model version (local S3-backed runtimes) |
-| `foehncast_monitoring.prediction_events` BigQuery table | durable | prediction-event history (Cloud Run and cloud-native readers) |
-| `.state/monitoring/prediction-log.jsonl` | bounded working set | recent prediction rows for local drift evaluation; not a history source |
-| `.state/monitoring/hindcast-validation.json` | durable | latest hindcast accuracy, MAE, and validated-pair counts |
-| `.state/hosted-sync/last-success.json` | durable | latest hosted sync success marker |
-| app `/metrics` | composed scrape | app-owned monitoring state and summary-derived metrics |
-| StatsD exporter `:9102` | scrape | Evidently-backed drift metrics |
-
-Durable files survive restarts and support audits. Runtime counters on `/metrics` describe process health and reset with the process.
-
 ## Metrics
 
-The serving application publishes one composed Prometheus payload on `/metrics`:
+The app serves one combined `/metrics` endpoint with everything Prometheus needs:
 
-<div class="mermaid">
-flowchart TD
-    subgraph App ["/metrics payload"]
-        direction TB
-        FPS["Feature pipeline summary gauges"]
-        TPS["Training pipeline summary gauges"]
-        PHS["Prediction history gauges"]
-        PMC["Prediction monitoring counters"]
-        HSS["Hosted sync status"]
-        REG["Registered model version"]
-    end
-
-    subgraph StatsD ["StatsD path"]
-        direction TB
-        EVD["Evidently drift report"]
-        SDE["StatsD exporter"]
-    end
-
-    FPS --> PROM["Prometheus"]
-    TPS --> PROM
-    PHS --> PROM
-    PMC --> PROM
-    HSS --> PROM
-    REG --> PROM
-    EVD --> SDE --> PROM
-</div>
-
-Key metric families:
-
-| Metric prefix | Source | Labels |
-|------|--------|--------|
-| `foehncast_feature_pipeline_*` | persisted `airflow/reports/` summaries | `dataset`, `storage_backend` |
-| `foehncast_training_pipeline_*` | persisted training summaries | `dataset` |
-| `foehncast_prediction_monitoring_*` | in-process counters (ephemeral) | `endpoint`, `result` |
-| `foehncast_drift_metric` | Evidently via StatsD | column-level drift scores |
-
-Feature and training summary metrics include per-stage state gauges (`succeeded`, `failed`, `not_run`), spot counts, row counts, duration gauges, and failure counts. Prediction monitoring counters track background task scheduling and execution attempts.
+| Metric prefix | What it tracks |
+|--------------|---------------|
+| `foehncast_feature_pipeline_*` | Feature pipeline stage status, row counts, durations |
+| `foehncast_training_pipeline_*` | Training results, model versions |
+| `foehncast_prediction_monitoring_*` | Background task scheduling and execution |
+| `foehncast_drift_metric` | Per-column drift scores (via StatsD) |
 
 ## Drift Detection
 
-Drift detection uses Evidently to compare reference and current datasets, then exports results through StatsD.
+Uses Evidently to compare feature distributions:
 
-| Drift kind | Reference | Current | Method |
+| Type | Reference | Current | Method |
 |------|-----------|---------|--------|
-| Feature drift | stored reference feature dataset | latest curated features | column-level statistical tests via Evidently |
-| Prediction drift | historical prediction events | recent prediction window | comparison across `prediction-events.jsonl` or the BigQuery warehouse contract |
+| Feature drift | Stored reference dataset | Latest curated features | Column-level statistical tests |
+| Prediction drift | Historical predictions | Recent prediction window | Distribution comparison |
 
-Emitted StatsD metrics are mapped into Prometheus as `foehncast_drift_metric`. The StatsD host defaults to `127.0.0.1:8125` and can be overridden through `monitoring.statsd_host` in `config.yaml`.
-
-## Scrape Configuration
-
-Prometheus scrapes four targets, all checked in at `prometheus_config/prometheus.yml`:
-
-| Job | Target | What it collects |
-|------|--------|------------------|
-| `foehncast_app` | `app:8000/metrics` | app-owned pipeline, prediction, and sync metrics |
-| `statsd_exporter` | `statsd:9102` | Evidently drift metrics |
-| `prometheus` | `prometheus:9090` | Prometheus self-monitoring |
-
-Scrape interval is 15 seconds. Alert rules are evaluated at the same interval.
-
-## Alert Rules
-
-The checked-in Prometheus rules at `prometheus_config/alerting_rules.yml` cover service health and domain health:
-
-| Alert | Group | Severity | Trigger | What it guards |
-|------|-------|----------|---------|----------------|
-| `AppDown` | service-health | critical | app target unreachable for 2 min | serving availability |
-| `HighRequestLatency` | service-health | warning | p95 latency above 2 s for 5 min | request performance |
-| `PredictionErrorRateHigh` | service-health | warning | error rate above 0.1/s for 5 min | prediction reliability |
-| `StatsdExporterDown` | service-health | warning | StatsD target unreachable for 5 min | drift pipeline availability |
-| `PredictionMonitoringScheduleFailure` | domain-health | warning | schedule failures in last 15 min | background monitoring scheduling |
-| `PredictionMonitoringExecutionFailure` | domain-health | warning | execution failures in last 15 min | background monitoring execution |
-| `FeaturePipelineStageFailure` | domain-health | warning | any feature stage failure count > 0 | feature pipeline reliability |
-| `TrainingPipelineStageFailure` | domain-health | warning | any training stage failure count > 0 | training pipeline reliability |
-| `HostedSyncStale` | domain-health | warning | no sync success for 15 min | hosted environment freshness |
-
-The alert rules are version-controlled so the alerting contract is reviewable without a live Prometheus instance.
-
-## Visualization
-
-Monitoring visualization uses native Altair charts in the Streamlit UI with direct PromQL queries against the app's `/api/v1/query` endpoint.
-
-The Streamlit sidebar renders:
-
-- system health indicators from Prometheus counters
-- pipeline status and timing from persisted summary metrics
-- drift scores from StatsD-exported Evidently results
-- hindcast accuracy from the cached validation result
-
-All chart data comes from the same Prometheus metrics that the alert rules consume, ensuring consistency between what operators see and what alerts fire on.
+Results go through StatsD → Prometheus as `foehncast_drift_metric`.
 
 ## Hindcast Validation
 
-Hindcast validation compares past predictions against observed weather data to measure real-world forecast accuracy.
+Compares past predictions against what actually happened:
 
-The validation path is:
+1. Background task runs hourly
+2. Waits 5 days (Open-Meteo archive API latency)
+3. Fetches observed weather for each past prediction
+4. Recomputes quality using the same labeling function
+5. Reports accuracy, MAE, and per-class counts
 
-- the app runs a background hindcast task hourly via `asyncio.to_thread` inside the FastAPI lifespan
-- eligible predictions are those older than a 120-hour buffer (accounting for Open-Meteo archive API latency of roughly five days)
-- for each eligible prediction, the archive API provides observed weather at the same spot and timestamp
-- ground-truth quality labels are recomputed from observed values using the same `compute_quality_index` function used in training
-- accuracy, MAE, and per-class counts are calculated and persisted to `.state/monitoring/hindcast-validation.json`
-- Prometheus scrapes the cached result; the app never calls the archive API on scrape
+Results persist in `.state/monitoring/hindcast-validation.json` and show up on `/metrics` and in the Streamlit model card.
 
-The Streamlit sidebar model card also embeds the hindcast accuracy gauge.
+## Alert Rules
 
-This closes the prediction-to-observation feedback loop without relying on manual evaluation notebooks.
+9 rules in `prometheus_config/alerting_rules.yml`:
 
-## Recovery Evidence
+| Alert | Fires when |
+|-------|-----------|
+| `AppDown` | App unreachable for 2 min |
+| `HighRequestLatency` | p95 > 2s for 5 min |
+| `PredictionErrorRateHigh` | Error rate > 0.1/s for 5 min |
+| `StatsdExporterDown` | StatsD target gone for 5 min |
+| `PredictionMonitoringScheduleFailure` | Background scheduling fails |
+| `PredictionMonitoringExecutionFailure` | Background execution fails |
+| `FeaturePipelineStageFailure` | Any feature stage fails |
+| `TrainingPipelineStageFailure` | Any training stage fails |
+| `HostedSyncStale` | No sync success for 15 min |
 
-Recovery work should leave durable evidence that operators can compare before and after the intervention.
+## Scrape Config
 
-| Recovery task | Evidence | Check |
-|------|----------|-------|
-| Feature retry or backfill | latest feature summary JSON | summary timestamp advances |
-| Training follow-up | latest training summary JSON | stage and model version are recorded |
-| Deploy, promote, or rollback | latest runtime-release summary | GitHub summary and runtime acknowledgement match |
-| Hosted sync refresh | latest sync status file | sync state updates on `/metrics` |
+Three targets in `prometheus_config/prometheus.yml` (15s interval):
 
-Capture the run reference with the summary artifacts: the GitHub workflow URL for reviewed delivery, or the logical date and DAG run id for hosted Airflow recovery. See [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for retry and backfill procedures.
+| Job | Target |
+|-----|--------|
+| `foehncast_app` | `app:8000/metrics` |
+| `statsd_exporter` | `statsd:9102` |
+| `prometheus` | `prometheus:9090` |
 
-## Public-Safe Evidence
+## Visualization
 
-Explain monitoring with rendered evidence, not live control-plane embeds:
+The Streamlit UI renders native Altair charts from PromQL queries:
 
-- rendered `/metrics` snippets or screenshots
-- checked-in Prometheus scrape and alert configs
-- native Altair charts in the Streamlit UI
-- pipeline summary JSON artifacts under `airflow/reports/`
-- prediction-event file structure under `.state/monitoring/`
+- System health indicators
+- Pipeline status and timing
+- Drift scores
+- Hindcast accuracy gauge
 
-This keeps public docs understandable in review while leaving live Prometheus and Airflow as operator tools.
+All charts read from the same metrics that alerts fire on — so what you see matches what triggers.
 
-## Why This Structure Works
+## Evidence Sources
 
-- operator monitoring stays separate from the rider-facing app
-- durable evidence survives restarts without turning runtime state into product data
-- alerting is reviewable because dashboards, rules, and scrape config live in git
-- the monitoring boundary stays stable even while hosted operator surfaces change
-- one `/metrics` surface describes the app-owned contract while StatsD handles drift export
+| Source | Type | Location |
+|--------|------|----------|
+| Pipeline summaries | JSON | `airflow/reports/*-latest.json` |
+| Prediction history | JSONL | `.state/monitoring/prediction-events.jsonl` (local) or BigQuery (cloud) |
+| Hindcast results | JSON | `.state/monitoring/hindcast-validation.json` |
+| Scrape + alert config | YAML | `prometheus_config/` (version-controlled) |
 
-See [Architecture](architecture.md), [Delivery and Operator Workflow](delivery-and-operator-workflow.md), [Feature Pipeline](feature-pipeline.md), and [Getting Started](../getting-started.md) for the surrounding system and local operator path.
+## Related Pages
+
+- [Architecture](architecture.md) — where monitoring fits
+- [Inference Pipeline](inference-pipeline.md) — generates prediction events
+- [Grading Checklist](grading-checklist.md) — monitoring evidence for grading

--- a/docs/site/system/seasonality.md
+++ b/docs/site/system/seasonality.md
@@ -1,50 +1,31 @@
 # Seasonality
 
-FoehnCast handles seasonality through cyclical time features derived from the forecast timestamp. The project does not split the model by season. It keeps repeating daily and yearly patterns in the shared feature layer so the same contract works in local and hosted runtimes.
+Swiss kite spots behave differently across seasons — summer thermals, winter pressure systems, daylight changes. We handle this with cyclical time features instead of separate seasonal models.
 
-## Why It Matters
+## Features
 
-Swiss kite spots do not behave the same way all year. Summer thermals, winter pressure systems, daylight, and temperature patterns all affect when a spot becomes rideable. If the model only sees raw weather values, it misses part of that repeating structure.
+The feature pipeline creates four time-derived columns:
 
-## Current Contract
+| Feature | Encodes |
+|---------|---------|
+| `hour_of_day_sin/cos` | Time of day (smooth wrap at midnight) |
+| `day_of_year_sin/cos` | Season (smooth wrap at year-end) |
 
-The feature pipeline engineers four timestamp-derived fields:
+Sin/cos encoding means the model understands that 23:00 is close to 00:00, and December 31 is close to January 1.
 
-- `hour_of_day_sin`
-- `hour_of_day_cos`
-- `day_of_year_sin`
-- `day_of_year_cos`
+## Where They're Used
 
-These features let the model learn that `14:00` is close to `15:00`, and that late June is close to early July, without introducing a discontinuity at midnight or year-end.
+| Pipeline | Role |
+|----------|------|
+| Feature | Creates the cyclical columns from forecast timestamps |
+| Training | Includes them in the model feature vector |
+| Inference | Rebuilds them from live timestamps (same function) |
 
-## Where It Fits In FTI
+## Why Keep It Simple
 
-| Stage | Seasonality role |
-|------|------------------|
-| Feature pipeline | creates the cyclical time fields from each forecast timestamp |
-| Training pipeline | consumes those fields as part of the model feature vector |
-| Inference pipeline | rebuilds the same fields from live forecast timestamps |
+- No separate summer/winter models
+- No wide month-dummy encoding
+- No special seasonal architecture
+- Just four extra features that give the tree-based model time context
 
-This keeps training and inference aligned around the same time encoding.
-
-## Why The Current Scope Stays Simple
-
-The current implementation favors the smallest feature set that still captures recurring patterns.
-
-- No separate seasonal model families.
-- No wide month-dummy design.
-- No extra architecture dedicated only to seasonal logic.
-
-That keeps the design simple while still giving the model useful time context.
-
-## How It Is Reviewed
-
-Seasonality changes are reviewed through the same training and MLflow workflow used for the rest of the model.
-
-- compare training runs with and without additional seasonal features
-- inspect error metrics and ranking quality across different parts of the year
-- keep only changes that improve the model enough to justify the added complexity
-
-## Summary
-
-FoehnCast already accounts for seasonality in a lightweight way. The current design keeps cyclical time features in the shared feature layer and treats extra seasonal complexity as something that must earn its place through model evidence.
+If we ever need more seasonal complexity, it has to prove itself through better model metrics first.

--- a/docs/site/system/training-pipeline.md
+++ b/docs/site/system/training-pipeline.md
@@ -1,174 +1,82 @@
 # Training Pipeline
 
-FoehnCast keeps training downstream from the curated feature store. The training path reads stored curated rows, rebuilds schema-derived features when needed, generates synthetic rideability labels, trains the configured regressor, writes evaluation evidence, and registers a versioned model in MLflow without pushing training concerns back into the feature pipeline.
+The training pipeline reads curated features, generates synthetic quality labels, trains a model, evaluates it, and registers the result in MLflow.
 
-This page describes what each stage owns and what remains an explicit operator control rather than an automatic side effect.
-
-!!! note "Scope"
-
-    This page describes the validated training-path contract.
-    It focuses on what the training path owns.
-    Hosted orchestration may move, but the training contract described here stays the same.
-
-## Pipeline Shape
+## Steps
 
 <div class="mermaid">
 flowchart TD
-    CUR["Curated feature store asset"] --> LAB["Label curated rows"]
-    REQ["Training-request asset"] --> LAB
+    CUR["Curated features"] --> LAB["Label quality"]
     LAB --> TRN["Train model"]
-    TRN --> EVA["Generate evaluation report"]
-    EVA --> REG["Register model version"]
-    REG --> ALS["Assign requested alias"]
-    OPS["Promote and rollback controls"] --> ALS
+    TRN --> EVA["Evaluate"]
+    EVA --> REG["Register in MLflow"]
+    REG --> ALS["Assign alias (candidate/champion)"]
 </div>
 
-The training path stays explicit:
+| Step | What it does |
+|------|-------------|
+| Label | Computes synthetic `quality_index` (0–5) from wind + shore features |
+| Train | Fits a tree-based model (random forest or gradient boosting) |
+| Evaluate | Logs MAE, RMSE, R², bucket accuracy to MLflow |
+| Register | Creates versioned model in MLflow registry |
+| Alias | Assigns `candidate` or `champion` alias |
 
-- curated features arrive from the feature pipeline instead of being rebuilt from raw ingest
-- labeling owns the synthetic target definition
-- training owns model fitting and metric logging
-- evaluation owns reviewable reporting
-- registration owns versioning and alias assignment in MLflow
-- promotion and rollback stay separate operator controls even though they reuse the same registry aliases
+## Labeling
 
-## Runtime Role
+Labels are synthetic — no human annotation. The rules use:
 
-| Runtime mode | Training role |
-|------|---------------------|
-| Local evaluator | local Airflow and MLflow run labeling, training, evaluation, and registration |
-| Active shared environment | the hosted full-stack operator lane runs the same Airflow and MLflow contract online |
-| Hosted inference target | serves a registered alias; it does not run training |
+- `wind_speed_10m`, `wind_gusts_10m` (rider weight → min rideable wind)
+- `wind_steadiness`, `gust_factor` (quality constraints)
+- `shore_alignment` (spot-specific wind direction fit)
+
+Dangerous conditions (extreme gusts) force quality to 0. The output is a continuous 0–5 score. All thresholds live in `config.yaml`.
+
+## Data Lineage
+
+Every MLflow run logs where its data came from:
+
+| Logged param | What it tells you |
+|-------------|------------------|
+| `dataset` | Which named dataset was used |
+| `data_hash` | SHA-256 of the training DataFrame |
+| `git_commit` | Which code version produced the run |
+
+This bridges DVC → MLflow: DVC versions the parquet, MLflow versions the model, both carry a content hash.
+
+## Model Registry
+
+- Model name: `foehncast-quality`
+- Pre-live alias: `candidate`
+- Live alias: `champion`
+- Promotion/rollback: separate operator controls, not automatic
 
 ## DVC Mapping
 
-For reproducible local and CI runs, DVC models the offline training path as one `train` stage.
+```yaml
+train:
+  cmd: python -m foehncast.dvc_stages train
+  metrics: [reports/train_metrics.json]
+  plots: [reports/feature_importance.png]
+```
 
-| DVC stage | Covers | Writes |
-|------|--------|--------|
-| `train` | label, train, and evaluate | `reports/train_metrics.json` and `reports/feature_importance.png` |
+DVC proves training is reproducible. Alias promotion stays outside DVC — that's an operator action.
 
-Model registration, alias movement, and rollback stay outside `dvc repro`. Those remain MLflow- and operator-controlled runtime steps.
+## Airflow Integration
 
-## Stage Responsibilities
+The training DAG starts from the feature pipeline's `training-request` asset (not a direct trigger):
 
-| Stage | Main responsibility | Must not become |
-|------|----------------------|-----------------|
-| Label | turn curated feature rows into a synthetic `quality_index` target | a replacement for feature engineering or a hidden scoring service |
-| Train | fit the configured model and log reproducible run metrics | a place where registry promotion or serving logic leaks in |
-| Evaluate | write reviewable metrics and report artifacts for one run | a second training stage or a silent model selector |
-| Register | create a versioned MLflow model and assign the requested alias | a broad deployment control plane |
-| Promote and rollback | move explicit aliases between validated model versions | retraining, relabeling, or feature regeneration |
+<div class="mermaid">
+flowchart LR
+    FEAT["Feature DAG"] -->|publishes| REQ["training-request asset"]
+    REQ -->|triggers| TRAIN["Training DAG"]
+    TRAIN -->|emits| REG["registry asset"]
+    REG -->|triggers| INF["Inference DAG"]
+</div>
 
-## Label Boundary
+This makes the dependency graph visible in Airflow's Assets view.
 
-### Data Lineage
+## Related Pages
 
-Every MLflow training run logs provenance params so the model can be traced back to its input data:
-
-| Param | Source | What it tells you |
-|-------|--------|-------------------|
-| `dataset` | config argument | which named dataset split was used |
-| `data_hash` | SHA-256 of the training DataFrame | whether the data content changed between runs |
-| `git_commit` | `git rev-parse --short HEAD` | which code version produced the run |
-
-The DVC path in `dvc_stages.py` writes `data_hash` and `git_commit` into the `reports/train_metrics.json` file for the same traceability outside MLflow.
-
-This bridges the DVC→MLflow lineage gap: DVC versions the curated parquet files, MLflow versions the model, and both carry a content hash so you can match them without inspecting local DVC state.
-
-## Label Boundary
-
-Labeling is synthetic and physics-driven, not human-curated. The label contract depends on curated wind and shoreline features that already exist in the stored dataset:
-
-- `wind_speed_10m`
-- `wind_gusts_10m`
-- `wind_steadiness`
-- `gust_factor`
-- `shore_alignment`
-
-The label rules combine rider profile settings with configured wind bands from `config.yaml`.
-
-The important design choices are:
-
-- dangerous wind and gust conditions are forced to the non-rideable bucket
-- the minimum rideable wind threshold depends on rider weight
-- high-quality windows depend on both wind range and quality constraints such as gust factor, shoreline fit, and steadiness
-- the output stays a stable `0` to `5` `quality_index` target that downstream training and evaluation can compare directly
-
-This means labeling is part of the training contract, not part of the inference service. The app serves predictions from a trained model; it does not recompute the synthetic label rules on demand.
-
-## Training Boundary
-
-Training reads stored curated feature rows by spot and dataset, then labels them directly. The curated storage contract is expected to already include the engineered columns required by labeling and the configured model feature list.
-
-The training contract is:
-
-- the input comes from stored curated features, not raw forecast payloads
-- stored curated rows must already satisfy the validated feature schema used by labeling and training
-- training does not rebuild missing derived columns from partial stored slices
-- the configured feature list and target column remain explicit in `config.yaml`
-- the supported model families are tree-based, with `random_forest` and `gradient_boosting` as the supported algorithms
-- one MLflow run records parameters, regression metrics, class-bucket accuracy metrics, row counts, feature counts, and a feature-importance plot when the estimator exposes importances
-
-Training should stay narrow. It fits a model and records one reproducible run. It should not decide traffic rollout or silently rewrite registry aliases beyond the requested registration stage.
-
-## Evaluation Boundary
-
-Evaluation resumes the same MLflow run after training and turns its metrics into a reviewable artifact.
-
-The evaluation contract is:
-
-- regression metrics include `mae`, `rmse`, and `r2`
-- rounded class-bucket accuracy is logged alongside the regression metrics
-- the markdown evaluation report is written under `airflow/reports/` as `evaluation-<run_id>.md`
-- the same report is logged back into MLflow as an artifact
-
-This keeps evaluation visible outside the notebook path. Reviewers and operators can inspect a persisted markdown report instead of depending on an ad hoc interactive session.
-
-## Registration Boundary
-
-Registration converts one logged MLflow run into a named registry version and assigns the requested alias.
-
-The registry contract is:
-
-- the registered model name is `foehncast-quality`
-- the validated pre-live alias is `candidate`
-- the live-serving alias is `champion`
-- training summaries persist run-level metrics, row counts, report paths, stage durations, and the registered version so the monitoring surface can expose the latest training state
-
-Manual training runs default to the `Candidate` stage. Asset-triggered runs from the feature pipeline can request `Production`, which lets the asset flow produce a live-ready registration path without changing the training code itself.
-
-## Airflow Hand-Off
-
-The training DAG is scheduled from the feature pipeline's published training-request asset instead of a direct DAG-to-DAG trigger.
-
-That keeps the orchestration boundary visible:
-
-- the feature DAG publishes curated-feature and training-request assets after persistence succeeds
-- the training DAG consumes the curated feature store and the training request
-- the training DAG emits MLflow training-run, evaluation-report, and model-registry assets
-- dataset and stage can still be overridden through DAG config when needed
-
-This makes the Airflow Assets view reflect the real dependency graph between curated feature persistence, training, evaluation, and registration. The local evaluator runs those steps directly in Airflow, while the hosted cloud path preserves the same training-stage ownership even when serving and scheduled automation move onto Cloud Run and Cloud Workflows.
-
-## Alias Controls Outside The DAG
-
-Promotion and rollback are explicit controls layered on top of the registry aliases, not hidden inside normal training.
-
-The operator controls are:
-
-- `foehncast.training_pipeline.promote` can move an explicit version or the `candidate` alias to the production stage
-- `foehncast.training_pipeline.rollback` can restore the `champion` alias to an explicit previous version
-- the same alias contract is reused by the shared cloud operator workflows and by the serving path that loads the live alias
-
-That separation is deliberate. Training can succeed without immediately changing the live serving version, and rollback can happen without retraining.
-
-## Why This Structure Works
-
-- it keeps training downstream from the curated feature contract instead of duplicating feature logic
-- it preserves reviewable evidence through MLflow runs and markdown evaluation reports
-- it keeps candidate and champion semantics explicit in the registry rather than buried in deployment scripts
-- it makes automatic retraining visible in Airflow through asset hand-offs instead of opaque trigger chains
-- it keeps the training contract stable even while the hosted orchestration surface is being simplified
-
-See [Architecture](architecture.md), [Feature Pipeline](feature-pipeline.md), [Monitoring](monitoring.md), and [Delivery and Operator Workflow](delivery-and-operator-workflow.md) for the surrounding system boundaries.
+- [Feature Pipeline](feature-pipeline.md) — produces the curated input
+- [Inference Pipeline](inference-pipeline.md) — serves the trained model
+- [Monitoring](monitoring.md) — tracks training metrics over time

--- a/docs/site/system/use-case.md
+++ b/docs/site/system/use-case.md
@@ -1,81 +1,75 @@
 # Use Case and Data
 
-FoehnCast is a trip-planning tool for one rider profile and a fixed set of Swiss kite spots. It answers one question: where is the best session worth driving to next?
+FoehnCast helps you pick the best Swiss kiteboarding spot for today. One rider, six spots, one question: where should I drive?
 
-The scope stays intentionally narrow. The project ranks a small known spot set for one rider baseline instead of trying to be a universal weather portal.
+We keep the scope small on purpose — it's a real decision for a real rider, not a generic weather app.
 
-## Decision Model
+## How the Ranking Works
 
 <div class="mermaid">
 flowchart TD
-        WX[Weather forecasts] --> QUAL[Per-spot quality]
-        SPOT[Spot metadata and shore orientation] --> QUAL
-        QUAL --> RANK[Rank session options]
+        WX[Weather forecasts] --> QUAL[Per-spot quality score]
+        SPOT[Spot metadata + shore orientation] --> QUAL
+        QUAL --> RANK[Rank spots]
         WINDOW[Rideable time window] --> RANK
         RIDER[Rider profile] --> RANK
-        DRIVE[OSRM drive time] --> RANK
+        DRIVE[Drive time from home] --> RANK
 </div>
 
-## What Shapes The Ranking
+## What Goes Into the Score
 
 <div class="grid cards" markdown>
 
 - **Wind quality**
 
-    The model predicts how good each spot looks for the configured rider profile.
+    The model predicts how good conditions look at each spot.
 
-- **Session window**
+- **Session length**
 
-    Longer rideable periods score better than short spikes.
+    Longer rideable windows beat short spikes.
 
 - **Drive time**
 
-    Distance matters because the system is choosing a trip, not only a forecast.
+    We're choosing a trip, not just reading a forecast.
 
 - **Spot fit**
 
-    Shore orientation and local spot rules shape whether the forecast is useful.
+    Shore orientation and local rules matter — not every wind direction works everywhere.
 
 </div>
 
-## Rider Baseline
+## Rider Profile
 
-| Field | Baseline value |
-|-------|----------------|
-| Home location | Schwyz |
+| Field | Value |
+|-------|-------|
+| Home | Schwyz |
 | Weight | 80 kg |
-| Quiver | 5 / 7 / 8 / 10 / 12 m2 |
+| Kite sizes | 5 / 7 / 8 / 10 / 12 m² |
 
-This baseline keeps the ranking problem consistent across the project. The model does not try to optimize for every possible rider at once.
+One fixed profile keeps the problem consistent. The model doesn't try to serve every rider.
 
-## Spots in Scope
+## Spots
 
-| Spot | Canton | Difficulty | Water | Ideal wind window |
-|------|--------|------------|-------|-------------------|
-| Silvaplana | GR | intermediate | lake | 180°-270° |
-| Urnersee | UR | intermediate | lake | 150°-210° |
-| Lac de Neuchatel | NE | beginner | lake | 200°-310° |
-| Bodensee | TG | beginner | lake | 180°-300° |
-| Walensee | SG | intermediate | lake | 220°-320° |
-| Thunersee | BE | advanced | lake | 220°-330° |
+| Spot | Canton | Level | Ideal wind |
+|------|--------|-------|-----------|
+| Silvaplana | GR | intermediate | 180°–270° |
+| Urnersee | UR | intermediate | 150°–210° |
+| Lac de Neuchatel | NE | beginner | 200°–310° |
+| Bodensee | TG | beginner | 180°–300° |
+| Walensee | SG | intermediate | 220°–320° |
+| Thunersee | BE | advanced | 220°–330° |
 
-These six spots define the ranking scope.
+## Data Sources
 
-## Main Inputs
+| Source | What it provides |
+|--------|-----------------|
+| Open-Meteo | Weather forecasts (wind, gusts, temperature, etc.) |
+| OSRM | Drive time from home to each spot |
+| Spot metadata | Shore orientation, difficulty, local rules |
 
-| Input | Role |
-|-------|------|
-| Open-Meteo | forecast weather inputs for feature generation and prediction |
-| OSRM | drive-time inputs for trip ranking |
-| Spot metadata | local wind context, shore orientation, and spot-level rules |
+## Why Fixed Scope
 
-Open-Meteo supplies the weather signal. OSRM supplies travel time. Spot metadata keeps the ranking grounded in the local riding context.
-
-## Why The Scope Stays Fixed
-
-- It keeps the labeling and ranking problem aligned with one real rider scenario.
-- It makes route-time personalization meaningful instead of theoretical.
-- It avoids turning the project into a generic weather portal with weak decision support.
-- It keeps implementation work focused on one concrete product question.
-
-See [Architecture](architecture.md) for the system structure and [Feature Pipeline](feature-pipeline.md) for how the data moves through the stack.
+- Keeps labeling aligned with one real rider scenario
+- Makes drive-time ranking meaningful (not theoretical)
+- Avoids becoming a generic weather portal
+- One clear product question = focused implementation


### PR DESCRIPTION
Continues the language simplification from PR #377 to all remaining system/ docs pages.

**Pages rewritten (13):**
feature-pipeline, training-pipeline, inference-pipeline, monitoring, use-case, local-evaluator, interfaces-and-surfaces, delivery-and-operator-workflow, cloud-architecture, cloud-mapping, configuration-and-contracts, hosted-full-stack, seasonality

**Changes:**
- Remove enterprise jargon (surfaces, lanes, contracts, hand-offs, operator controls)
- Short sentences, direct language, student-to-student tone
- Keep all mermaid diagrams
- Simplify tables: fewer columns, plain headers
- Cut system docs from 2137 → 1147 lines (−46%)

**Combined with PR #377:** total docs reduction is ~1240 lines removed across 20 pages.